### PR TITLE
Prize deadline utils

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,13 +1,5 @@
 from django.contrib import admin
 from django.conf.urls import patterns, url
-import settings
-import tracker.viewutil as viewutil
-import tracker.views as views
-import tracker.forms as forms
-import tracker.models
-import tracker.prizemail as prizemail
-import tracker.filters as filters
-import tracker.logutil as logutil
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.utils.html import escape
@@ -25,6 +17,17 @@ import django.forms as djforms
 import django.contrib.auth.models
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import permission_required, REDIRECT_FIELD_NAME
+
+import settings
+
+import tracker.viewutil as viewutil
+import tracker.prizeutil as prizeutil
+import tracker.views as views
+import tracker.forms as forms
+import tracker.models
+import tracker.prizemail as prizemail
+import tracker.filters as filters
+import tracker.logutil as logutil
 
 def admin_auth(perm=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url='admin:login'):
   def impl_dec(viewFunc):
@@ -723,7 +726,7 @@ class PrizeAdmin(CustomModelAdmin):
       numToDraw = min(limit, prize.maxwinners - prize.current_win_count())
       drawingError = False
       while not drawingError and numDrawn < numToDraw:
-        drawn, msg = viewutil.draw_prize(prize)
+        drawn, msg = prizeutil.draw_prize(prize)
         time.sleep(1)
         if not drawn:
           self.message_user(request, msg, level=messages.ERROR)
@@ -966,7 +969,7 @@ def draw_prize_winners(request):
       for prize in form.cleaned_data['prizes']:
         status = True
         while status and not prize.maxed_winners():
-          status, data = viewutil.draw_prize(prize, seed=form.cleaned_data['seed'])
+          status, data = prizeutil.draw_prize(prize, seed=form.cleaned_data['seed'])
           prize.error = data['error'] if not status else ''
         logutil.change(request, prize, 'Prize Drawing')
       return render(request, 'admin/draw_prize_winners_post.html', { 'prizes': form.cleaned_data['prizes'] })

--- a/management/commands/draw_prizes.py
+++ b/management/commands/draw_prizes.py
@@ -8,6 +8,7 @@ import settings
 
 import tracker.models as models
 import tracker.viewutil as viewutil
+import tracker.prizeutil as prizeutil
 import tracker.prizemail as prizemail
 import tracker.commandutil as commandutil
 
@@ -27,7 +28,7 @@ class Command(commandutil.TrackerCommand):
         status = True
         self.message('Drawing prize #{0}...'.format(prize.pk))
         while status and not prize.maxed_winners():
-            status, data = viewutil.draw_prize(prize, seed=self.rand.getrandbits(256))
+            status, data = prizeutil.draw_prize(prize, seed=self.rand.getrandbits(256))
             if not status:
                 self.message('Error drawing prize #{0}: {1}'.format(prize.id, data['error']))
             else:

--- a/management/commands/past_due_prizewinners.py
+++ b/management/commands/past_due_prizewinners.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand, CommandError
+
+import settings
+
+import tracker.viewutil as viewutil
+import tracker.prizeutil as prizeutil
+import tracker.commandutil as commandutil
+
+class Command(commandutil.TrackerCommand):
+    help = "Manage prize winners which have passed their acceptance deadline"
+
+    def add_arguments(self, parser):
+        parser.add_argument('-e', '--event', help='Specify the event to target', type=viewutil.get_event, required=True)
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('-l', '--list', help='List all prize winners which have passed expiry', action='store_true')
+        group.add_argument('-c', '--close', help='Close all prize winners which have passed expiry (does not re-roll)', action='store_true')
+        parser.add_argument('-d', '--dry-run', help='Run the command, but do not commit anything to the database', action='store_true')
+
+    def handle(self, *args, **options):
+        super(Command,self).handle(*args, **options)
+        event = options['event']
+        dryRun = options['dry_run']
+        pastDueWinners = prizeutil.get_past_due_prize_winners(event)
+        
+        if not pastDueWinners.exists():
+            self.message("There are no past-due winners.", 2)
+        elif options['list']:
+            for prizeWinner in pastDueWinners:
+                self.message("Winner #{0} (due {1})".format(prizeWinner.id, prizeWinner.acceptdeadline))
+        elif options['clear']:
+            prizeutil.close_past_due_prize_winners(pastDueWinners, verbosity=self.verbosity, dry_run=dryRun)
+        else:
+            self.message("Invalid option.")

--- a/management/commands/past_due_prizewinners.py
+++ b/management/commands/past_due_prizewinners.py
@@ -27,7 +27,7 @@ class Command(commandutil.TrackerCommand):
         elif options['list']:
             for prizeWinner in pastDueWinners:
                 self.message("Winner #{0} (due {1})".format(prizeWinner.id, prizeWinner.acceptdeadline))
-        elif options['clear']:
+        elif options['close']:
             prizeutil.close_past_due_prize_winners(pastDueWinners, verbosity=self.verbosity, dry_run=dryRun)
         else:
             self.message("Invalid option.")

--- a/prizeutil.py
+++ b/prizeutil.py
@@ -1,0 +1,42 @@
+import datetime
+import pytz
+import random
+
+from tracker.models import *
+import tracker.util as util
+
+def draw_prize(prize, seed=None):
+    eligible = prize.eligible_donors()
+    if prize.maxed_winners():
+        if prize.maxwinners == 1:
+            return False, {"error": "Prize: " + prize.name + " already has a winner."}
+        else:
+            return False, {"error": "Prize: " + prize.name + " already has the maximum number of winners allowed."}
+    if not eligible:
+        return False, {"error": "Prize: " + prize.name + " has no eligible donors."}
+    else:
+        rand = None
+        try:
+            rand = random.Random(seed)
+        except TypeError:  # not sure how this could happen but hey
+            return False, {'error': 'Seed parameter was unhashable'}
+        psum = reduce(lambda a, b: a + b['weight'], eligible, 0.0)
+        result = rand.random() * psum
+        ret = {'sum': psum, 'result': result}
+        for d in eligible:
+            if result < d['weight']:
+                try:
+                    donor = Donor.objects.get(pk=d['donor'])
+                    acceptDeadline = datetime.datetime.today().replace(tzinfo=util.anywhere_on_earth_tz(), hour=23,
+                                                                       minute=59, second=59) + datetime.timedelta(days=prize.event.prize_accept_deadline_delta)
+                    winRecord, created = PrizeWinner.objects.get_or_create(
+                        prize=prize, winner=donor, acceptdeadline=acceptDeadline)
+                    if not created:
+                        winRecord.pendingcount += 1
+                    ret['winner'] = winRecord.winner.id
+                    winRecord.save()
+                except Exception as e:
+                    return False, {"error": "Error drawing prize: " + prize.name + ", " + str(e)}
+                return True, ret
+            result -= d['weight']
+        return False, {"error": "Prize drawing algorithm failed."}

--- a/prizeutil.py
+++ b/prizeutil.py
@@ -40,3 +40,19 @@ def draw_prize(prize, seed=None):
                 return True, ret
             result -= d['weight']
         return False, {"error": "Prize drawing algorithm failed."}
+
+
+def get_past_due_prize_winners(event):
+    now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+    return PrizeWinner.objects.filter(acceptdeadline__lte=now, pendingcount__gte=1)
+
+
+def close_past_due_prize_winners(event, verbosity=0, dry_run=False):
+    for prizewinner in get_past_due_prize_winners(event):
+        if verbosity > 0:
+            print("Closing Prize Winner #{0} with {1} pending".format(
+                prizewinner.id, prizewinner.pendingcount))
+        if not dry_run:
+            prizewinner.declinecount += prizewinner.pendingcount
+            prizewinner.pendingcount = 0
+            prizewinner.save()

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -768,10 +768,15 @@ class TestPrizeDrawAcceptOffset(TransactionTestCase):
         winningDonation.save()
         self.assertEqual(1, len(targetPrize.eligible_donors()))
         self.assertEqual(winner.id, targetPrize.eligible_donors()[0]['donor'])
+        self.assertEqual(0, len(prizeutil.get_past_due_prize_winners(self.event)))
         currentDate = datetime.date.today()
         result, status = prizeutil.draw_prize(targetPrize)
-        prizeWin = models.PrizeWinner.objects.filter(prize=targetPrize)[0]
+        prizeWin = models.PrizeWinner.objects.get(prize=targetPrize)
         self.assertEqual(prizeWin.accept_deadline_date(), currentDate + datetime.timedelta(days=self.event.prize_accept_deadline_delta))
-        prizeWin.acceptdeadline = datetime.datetime.utcnow().replacE(tzinfo=pytz.utc) - datetime.timedelta(days=2)
+        
+        prizeWin.acceptdeadline = datetime.datetime.utcnow().replace(tzinfo=pytz.utc) - datetime.timedelta(days=2)
         prizeWin.save()
         self.assertEqual(0, len(targetPrize.eligible_donors()))
+        pastDue = prizeutil.get_past_due_prize_winners(self.event)
+        self.assertEqual(1, len(prizeutil.get_past_due_prize_winners(self.event)))
+        self.assertEqual(prizeWin, pastDue[0])

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 import tracker.models as models
 import tracker.randgen as randgen
 import tracker.viewutil as viewutil
+import tracker.prizeutil as prizeutil
 
 
 class TestPrizeGameRange(TransactionTestCase):
@@ -97,7 +98,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                     prize.save()
                     eligibleDonors = prize.eligible_donors()
                     self.assertEqual(0, len(eligibleDonors))
-                    result, message = viewutil.draw_prize(prize)
+                    result, message = prizeutil.draw_prize(prize)
                     self.assertFalse(result)
                     self.assertEqual(0, prize.current_win_count())
         return
@@ -147,7 +148,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                                 expectedRatio, eligibleDonors[0]['weight'])
                         else:
                             self.assertEqual(1.0, eligibleDonors[0]['weight'])
-                    result, message = viewutil.draw_prize(prize)
+                    result, message = prizeutil.draw_prize(prize)
                     if donationSize != 'below' or not prize.randomdraw:
                         self.assertTrue(result)
                         self.assertEqual(donor, prize.get_winner())
@@ -194,14 +195,14 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
             self.assertTrue(found and "Could not find the donor in the list")
         winners = []
         for seed in [15634, 12512, 666]:
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertIn(prize.get_winner().id, donationDonors)
             winners.append(prize.get_winner())
             current = prize.get_winner()
             prize.prizewinner_set.all().delete()
             prize.save()
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertEqual(current, prize.get_winner())
             prize.prizewinner_set.all().delete()
@@ -261,14 +262,14 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         self.assertTrue(found and "Could not find the donor in the list")
         winners = []
         for seed in [51234, 235426, 62363245]:
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertIn(prize.get_winner().id, donationDonors)
             winners.append(prize.get_winner())
             current = prize.get_winner()
             prize.prizewinner_set.all().delete()
             prize.save()
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertEqual(current, prize.get_winner())
             prize.prizewinner_set.all().delete()
@@ -314,7 +315,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertEqual(largestDonor.id, prize.get_winner().id)
         newDonor = randgen.generate_donor(self.rand)
@@ -330,7 +331,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertEqual(newDonor.id, prize.get_winner().id)
 
@@ -370,7 +371,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertEqual(maxDonor['donor'].id, prize.get_winner().id)
         oldMaxDonor = maxDonor
@@ -391,7 +392,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
-            result, message = viewutil.draw_prize(prize, seed)
+            result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
             self.assertEqual(maxDonor['donor'].id, prize.get_winner().id)
 
@@ -450,19 +451,19 @@ class TestPrizeMultiWin(TransactionTestCase):
         prize.maxmultiwin = 3
         prize.save()
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
         self.assertEquals(1, prizeWinner.pendingcount)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
         self.assertEquals(2, prizeWinner.pendingcount)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
         self.assertEquals(3, prizeWinner.pendingcount)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
 
     def testWinMultiPrizeWithAccept(self):
@@ -476,11 +477,11 @@ class TestPrizeMultiWin(TransactionTestCase):
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
         prizeWinner = models.PrizeWinner.objects.create(
             winner=donor, prize=prize, pendingcount=1, acceptcount=1)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
         self.assertEquals(2, prizeWinner.pendingcount)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
 
     def testWinMultiPrizeWithDeny(self):
@@ -494,11 +495,11 @@ class TestPrizeMultiWin(TransactionTestCase):
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
         prizeWinner = models.PrizeWinner.objects.create(
             winner=donor, prize=prize, pendingcount=1, declinecount=1)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
         self.assertEquals(2, prizeWinner.pendingcount)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
 
     def testWinMultiPrizeLowerThanMaxWin(self):
@@ -512,19 +513,19 @@ class TestPrizeMultiWin(TransactionTestCase):
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
         prizeWinner = models.PrizeWinner.objects.create(
             winner=donor, prize=prize, pendingcount=1, declinecount=1)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
         donor2 = randgen.generate_donor(self.rand)
         donor2.save()
         models.DonorPrizeEntry.objects.create(donor=donor2, prize=prize)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         prizeWinner = models.PrizeWinner.objects.get(
             winner=donor2, prize=prize)
         self.assertEquals(1, prizeWinner.pendingcount)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
-        result, msg = viewutil.draw_prize(prize)
+        result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
 
 
@@ -552,7 +553,7 @@ class TestPersistentPrizeWinners(TransactionTestCase):
         donationA.save()
         self.assertEqual(1, len(targetPrize.eligible_donors()))
         self.assertEqual(donorA.id, targetPrize.eligible_donors()[0]['donor'])
-        viewutil.draw_prize(targetPrize)
+        prizeutil.draw_prize(targetPrize)
         self.assertEqual(donorA, targetPrize.get_winner())
         self.assertEqual(0, len(targetPrize.eligible_donors()))
         donationB = randgen.generate_donation(
@@ -566,7 +567,7 @@ class TestPersistentPrizeWinners(TransactionTestCase):
         prizeWinnerEntry.save()
         self.assertEqual(1, len(targetPrize.eligible_donors()))
         self.assertEqual(donorB.id, targetPrize.eligible_donors()[0]['donor'])
-        viewutil.draw_prize(targetPrize)
+        prizeutil.draw_prize(targetPrize)
         self.assertEqual(donorB, targetPrize.get_winner())
         self.assertEqual(1, targetPrize.current_win_count())
         self.assertEqual(0, len(targetPrize.eligible_donors()))
@@ -768,7 +769,9 @@ class TestPrizeDrawAcceptOffset(TransactionTestCase):
         self.assertEqual(1, len(targetPrize.eligible_donors()))
         self.assertEqual(winner.id, targetPrize.eligible_donors()[0]['donor'])
         currentDate = datetime.date.today()
-        result, status = viewutil.draw_prize(targetPrize)
+        result, status = prizeutil.draw_prize(targetPrize)
         prizeWin = models.PrizeWinner.objects.filter(prize=targetPrize)[0]
         self.assertEqual(prizeWin.accept_deadline_date(), currentDate + datetime.timedelta(days=self.event.prize_accept_deadline_delta))
-        
+        prizeWin.acceptdeadline = datetime.datetime.utcnow().replacE(tzinfo=pytz.utc) - datetime.timedelta(days=2)
+        prizeWin.save()
+        self.assertEqual(0, len(targetPrize.eligible_donors()))

--- a/tests/test_prizetickets.py
+++ b/tests/test_prizetickets.py
@@ -1,14 +1,14 @@
-import tracker.models as models
-import tracker.viewutil as viewutil
-import tracker.randgen as randgen
+import random
+import pytz
+from decimal import Decimal
+from dateutil.parser import parse as parse_date
 
 from django.test import TestCase, TransactionTestCase
 
-from decimal import Decimal
-from dateutil.parser import parse as parse_date
-import random
-import pytz
-
+import tracker.models as models
+import tracker.viewutil as viewutil
+import tracker.prizeutil as prizeutil
+import tracker.randgen as randgen
 
 class TestTicketPrizeDraws(TransactionTestCase):
 
@@ -27,7 +27,7 @@ class TestTicketPrizeDraws(TransactionTestCase):
         prize.save()
         eligibleDonors = prize.eligible_donors()
         self.assertEqual(0, len(eligibleDonors))
-        result, message = viewutil.draw_prize(prize)
+        result, message = prizeutil.draw_prize(prize)
         self.assertFalse(result)
         self.assertEqual(None, prize.get_winner())
 
@@ -45,7 +45,7 @@ class TestTicketPrizeDraws(TransactionTestCase):
         eligibleDonors = prize.eligible_donors()
         self.assertEqual(1, len(eligibleDonors))
         self.assertEqual(eligibleDonors[0]['donor'], donor.id)
-        result, message = viewutil.draw_prize(prize)
+        result, message = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         self.assertEqual(donor, prize.get_winner())
 
@@ -69,7 +69,7 @@ class TestTicketPrizeDraws(TransactionTestCase):
         self.assertEqual(eligibleDonors[0]['donor'], donor.id)
         self.assertAlmostEqual(
             eligibleDonors[0]['weight'], donation.amount / prize.minimumbid)
-        result, message = viewutil.draw_prize(prize)
+        result, message = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         self.assertEqual(donor, prize.get_winner())
 

--- a/views/api.py
+++ b/views/api.py
@@ -7,6 +7,7 @@ from tracker.models import *
 import tracker.filters as filters
 from tracker.views.common import tracker_response
 import tracker.viewutil as viewutil
+import tracker.prizeutil as prizeutil
 import tracker.logutil as logutil
 from django.http import HttpResponse
 from django.core.exceptions import FieldError, ObjectDoesNotExist, ValidationError, PermissionDenied
@@ -390,7 +391,7 @@ def draw_prize(request):
         status = True
         results = []
         while status and currentCount < limit:
-            status, data = viewutil.draw_prize(prize, seed=requestParams.get('seed',None))
+            status, data = prizeutil.draw_prize(prize, seed=requestParams.get('seed',None))
             if status:
                 currentCount += 1
                 results.append(data)

--- a/viewutil.py
+++ b/viewutil.py
@@ -72,39 +72,6 @@ def request_params(request):
   else:
     raise Exception("No request parameters associated with this request method.")
 
-def draw_prize(prize, seed=None):
-  eligible = prize.eligible_donors()
-  if prize.maxed_winners():
-    if prize.maxwinners == 1:
-      return False, { "error" : "Prize: " + prize.name + " already has a winner." }
-    else:
-      return False, { "error" : "Prize: " + prize.name + " already has the maximum number of winners allowed." }
-  if not eligible:
-    return False, { "error" : "Prize: " + prize.name + " has no eligible donors." }
-  else:
-    rand = None
-    try:
-      rand = random.Random(seed)
-    except TypeError: # not sure how this could happen but hey
-      return False, {'error': 'Seed parameter was unhashable'}
-    psum = reduce(lambda a,b: a+b['weight'], eligible, 0.0)
-    result = rand.random() * psum
-    ret = {'sum': psum, 'result': result}
-    for d in eligible:
-      if result < d['weight']:
-        try:
-          donor = Donor.objects.get(pk=d['donor'])
-          acceptDeadline = datetime.datetime.today().replace(tzinfo=util.anywhere_on_earth_tz(), hour=23, minute=59, second=59) + datetime.timedelta(days=prize.event.prize_accept_deadline_delta)
-          winRecord,created = PrizeWinner.objects.get_or_create(prize=prize, winner=donor, acceptdeadline=acceptDeadline)
-          if not created:
-            winRecord.pendingcount += 1
-          ret['winner'] = winRecord.winner.id
-          winRecord.save()
-        except Exception as e:
-          return False, { "error" : "Error drawing prize: " + prize.name + ", " + str(e) }
-        return True, ret
-      result -= d['weight']
-    return False, {"error" : "Prize drawing algorithm failed." }
 
 _1ToManyBidsAggregateFilter = Q(bids__donation__transactionstate='COMPLETED')
 _1ToManyDonationAggregateFilter = Q(donation__transactionstate='COMPLETED')


### PR DESCRIPTION
Creates a management command for auto-closing prizes when their deadline has come up.

This allows us to automate prize deadlines by running it as a CRON command.
As a precursor step, I split off the `draw_prize` function into a `prizeutil` module, since 
the prize-based methods don't quite fit with what I would call `viewutil` (neither does the
gdoc related commands, but they're on their way out eventually, so I'm not as worried
about that right now).