### PR TITLE
Fix error with long emails in user reg

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,45 @@
+from django.test import TestCase, TransactionTestCase
+from django.contrib.auth import get_user_model
+
+AuthUser = get_user_model()
+
+import settings
+
+import tracker.forms
+
+class TestRegistrationForm(TransactionTestCase):
+
+    def run_registration(self, email):
+        regForm = tracker.forms.RegistrationForm(data={'email': email})
+        self.assertTrue(regForm.is_valid())
+        regForm.save(domain=settings.DOMAIN)
+        resultMail = regForm.save(domain=settings.DOMAIN)
+        self.assertIsNot(None, resultMail)
+        resultUserQuery = AuthUser.objects.filter(email=email)
+        self.assertEqual(1, resultUserQuery.count())
+        return resultUserQuery[0]
+
+    def testRegisterPerson(self):
+        regEmail = 'testemail@test.com'
+        userObj = self.run_registration(regEmail)
+        self.assertEqual(regEmail, userObj.username)
+        self.assertEqual(regEmail, userObj.email)
+        self.assertFalse(userObj.is_active)
+        self.assertFalse(userObj.is_staff)
+    
+    def testRegisterPersonLongEmail(self):
+        regEmail = 'test'*9 + '@anothertest.com'
+        userObj = self.run_registration(regEmail)
+        self.assertGreaterEqual(30, len(userObj.username))
+        self.assertEqual(regEmail, userObj.email)
+        self.assertFalse(userObj.is_active)
+        self.assertFalse(userObj.is_staff)
+    
+    def testClashingRegistrationEmails(self):
+        regEmailPrefix = 'prefix'*9
+        self.assertLess(30, len(regEmailPrefix))
+        regEmail1 = regEmailPrefix + '@test1.com'
+        regEmail2 = regEmailPrefix + '@test2.com'
+        userObj1 = self.run_registration(regEmail1)
+        userObj2 = self.run_registration(regEmail2)
+        self.assertNotEqual(userObj1, userObj2)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,47 @@
+import re
+
+from django.test import TestCase
+
+import tracker.util as util
+
+class TestRandomNumReplace(TestCase):
+    
+    def testMakeAuthCode(self):
+        authLen = 555
+        testCreate = util.make_auth_code(length=authLen)
+        self.assertEqual(authLen, len(testCreate))
+        self.assertTrue(re.match('[0-9A-Za-z]+', testCreate))
+    
+    def testReplaceNoLimit(self):
+        original = 'test'
+        replaceLen = 8
+        modified = util.random_num_replace(original, replaceLen)
+        self.assertEqual(len(original) + replaceLen, len(modified))
+        self.assertEqual(original, modified[0:len(original)])
+        self.assertTrue(re.match('[0-9A-Za-z]+', modified[len(original):]))
+    
+    def testReplaceWithLimit(self):
+        original = 'testingstuff'
+        replaceLen = 4
+        totalLen = len(original) + 2
+        unreplacedLen = totalLen - replaceLen
+        modified = util.random_num_replace(original, replaceLen, max_length=totalLen)
+        self.assertEqual(totalLen, len(modified))
+        self.assertEqual(original[:unreplacedLen], modified[:unreplacedLen])
+        self.assertTrue(re.match('[0-9A-Za-z]+', modified[unreplacedLen:]))
+    
+    def testReplaceStrictLimit(self):
+        original = 'testingstuffmore'
+        replaceLen = 6
+        unreplacedLen = len(original) - replaceLen
+        modified = util.random_num_replace(original, replaceLen, max_length=len(original))
+        self.assertEqual(len(original), len(modified))
+        self.assertEqual(original[:unreplacedLen], modified[:unreplacedLen])
+        self.assertTrue(re.match('[0-9A-Za-z]+', modified[unreplacedLen:]))
+     
+    def testInvalidReplaceLen(self):
+        original = 'short'
+        replaceLen = 8
+        maxLen = 7
+        with self.assertRaises(Exception):
+            s = util.random_num_replace(original, replaceLen, max_length=maxLen)

--- a/util.py
+++ b/util.py
@@ -49,10 +49,33 @@ def anywhere_on_earth_tz():
     to use the last possible timezone to define the end of a particular date"""
     return pytz.timezone('Etc/GMT+12')
 
-def make_auth_code(length=64):
-    rand = random.SystemRandom()
+def make_rand(rand_source=None, rand_seed=None):
+    if rand_source is None:
+        if rand_seed is None:
+            rand_source = random.SystemRandom()
+        else:
+            rand_source = random.Random(rand_seed)
+    return rand_source
+    
+def make_auth_code(length=64, rand_source=None, rand_seed=None):
+    rand_source = make_rand(rand_source, rand_seed)
     result = ''
     for i in range(0, length):
-        result += '{:x}'.format(rand.randrange(0,16))
+        result += '{:x}'.format(rand_source.randrange(0,16))
     return result
 
+def random_num_replace(s, replacements, rand_source=None, rand_seed=None, max_length=None):
+    """Attempts to 'uniquify' a string by adding/replacing characters with a hex string 
+    of the specified length"""
+    rand_source = make_rand(rand_source, rand_seed)
+    if max_length is None:
+        max_length = len(s) + replacements
+    if max_length < replacements:
+        raise Exception("Error, max_length ({0}) was less than the number of requested replacements ({1})".format(max_length, replacements))
+    originalLength = len(s)
+    endReplacements = min(max_length - len(s), replacements)
+    s += make_auth_code(endReplacements, rand_source=rand_source)
+    if endReplacements < replacements:
+        replacementsLeft = replacements-endReplacements
+        s = s[:originalLength-replacementsLeft] + make_auth_code(replacementsLeft, rand_source) + s[originalLength:]
+    return s


### PR DESCRIPTION
The page would error when an e-mail was of length > 30, as it uses e-mail
as the default username. This just truncates the e-mail to 30 characters,
and uses a simple collision resolution scheme to avoid clashes if two
e-mails have the same prefix.