### PR TITLE
Fix Google Analytics ID

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -109,7 +109,7 @@ Running on Django with Python {% endblocktrans %}
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-36823056-2', 'gamesdonequick.com');
+  ga('create', 'UA-36823056-1', 'gamesdonequick.com');
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
As per CoolMatty: "the tracker is using a different google analytics code and they’ve changed how they do this, so it’s screwing up stats"