### PR TITLE
removed the inner span that hid the sorting triggers

### DIFF
--- a/templatetags/donation_tags.py
+++ b/templatetags/donation_tags.py
@@ -27,9 +27,7 @@ def sortlink(style, contents, **args):
   ret.append('"')
   if style: ret.append(' class="%s"' % style)
   ret.append('>')
-  if style: ret.append('<span style="display:none;">')
   ret.append(contents)
-  if style: ret.append('</span>')
   ret.append('</a>')
   return ''.join(map(unicode,ret))
 


### PR DESCRIPTION
Removed the inner span that was made to hide the sorting trigger
elements. It looks like queueindex.css has .asc and .dsc classes that
ought to be here, but for now, it's good enough to just show "AscDsc"
despite it not looking the best for the time being.

I saw no nearby comments explaining why this was done. It was clearly
done deliberately in a hasty attempt to amend something.
