### PR TITLE
install django-paypal from gdq's fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ python-dateutil==2.4.2
 pytz==2015.6
 rsa==3.2
 six==1.9.0
+-e git+https://github.com/GamesDoneQuick/django-paypal.git@gdqchanges#egg=django-paypal


### PR DESCRIPTION
https://github.com/GamesDoneQuick/donation-tracker-toplevel 's README says:

`You also need to run pip install django-paypal. This isn't currently in requirements.txt for awful reasons that I'm hoping will change very soon.`

I'm not sure what the awful reasons are, but pip can install from a specific git repo and branch. If we merge this, we can delete some stuff from README. Bonus: paypal sandbox works right after install.
