### PR TITLE
Disambiguate choices in MergeObjectsForm with object IDs

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -323,8 +323,8 @@ class MergeObjectsForm(forms.Form):
         self.model = model
         self.choices = []
         for objId in objects:
-            self.choices.append(
-                (objId, unicode(self.model.objects.get(id=objId))))
+            choice_name = '#%d: ' % objId + unicode(self.model.objects.get(id=objId))
+            self.choices.append((objId, choice_name))
         self.fields['root'] = forms.ChoiceField(
             choices=self.choices, required=True)
         self.fields['objects'] = forms.CharField(initial=','.join(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,10 +1,22 @@
-import tracker.forms
 from django.conf import settings
 from django.test import TestCase, TransactionTestCase
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 
+import tracker.forms
+from tracker.models import Donor
+
 AuthUser = get_user_model()
+
+
+class TestMergeObjectsForm(TestCase):
+    def test_unambiguous_object_names(self):
+        d1 = Donor.objects.create(alias='Justin')
+
+        form = tracker.forms.MergeObjectsForm(
+            model=tracker.models.Donor,
+            objects=[d1.pk])
+        self.assertEqual(form.choices[0][1], '#%d: Justin' % d1.pk)
 
 
 @override_settings(EMAIL_FROM_USER='example@example.com')


### PR DESCRIPTION
When merging donors with the same display name, there's no way to know
which is which without looking at form source. This change makes it
easier for any user merging objects to see which user they are picking.