### PR TITLE
Add an iCal feed for each event's runs

### DIFF
--- a/feeds/runs_calendar.py
+++ b/feeds/runs_calendar.py
@@ -1,0 +1,62 @@
+from django.core.urlresolvers import reverse
+from django.http import Http404
+
+from django_ical.views import ICalFeed
+
+from tracker.models.event import SpeedRun
+from tracker import viewutil
+
+
+# Reference the properties used by django-ical:
+# https://django-ical.readthedocs.io/en/latest/usage.html#property-reference-and-extensions
+class RunsCalendar(ICalFeed):
+    """A calendar feed for an event's runs. """
+
+    timezone = 'UTC'
+    file_name = 'event.ics'
+
+    def get_object(self, request, event):
+        event = viewutil.get_event(event)
+
+        if event.locked:
+            raise Http404
+
+        return event
+
+    def title(self, event):
+        return "{} Runs".format(event.name)
+
+    def description(self, event):
+        return "Calendar for runs during {} benefiting {}".format(
+            event.name, event.receivername)
+
+    # Exclude runs that haven't been slotted into the schedule yet (ones that
+    # have no order set)
+    def items(self, event):
+        return SpeedRun.objects.filter(
+            event=event,
+            order__isnull=False,
+        ).order_by('-starttime')
+
+    def item_title(self, run):
+        names = run.runners.values_list('name', flat=True)
+        runners = ', '.join(names)
+        return "{} ({})".format(run.name, runners)
+
+    def item_description(self, run):
+        return "{}\n\n{}".format(run.display_name, run.description)
+
+    def item_link(self, run):
+        return reverse('tracker:run', args=[run.id])
+
+    def item_class(self, run):
+        return 'PUBLIC'
+
+    def item_start_datetime(self, run):
+        return run.starttime
+
+    def item_end_datetime(self, run):
+        return run.endtime
+
+    def item_status(self, run):
+        return 'CONFIRMED'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ chromium-compact-language-detector==0.31415
 Django==1.11.20
 django-ajax-selects==1.7.1
 django-betterforms==1.1.4
+django-ical==1.5
 django-paypal==0.5.0
 django-mptt==0.8.6
 django-post-office==3.0.4

--- a/urls.py
+++ b/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import include, url
 
 from .views import public, api, donateviews, user, auth
+from .feeds.runs_calendar import RunsCalendar
 
 from .ui import urls as ui_urls
 
@@ -22,6 +23,7 @@ urlpatterns = [
     url(r'^prizes/(?P<event>\w+|)$', public.prizeindex, name='prizeindex'),
     url(r'^prize/(?P<id>-?\d+)$', public.prize, name='prize'),
     url(r'^events/$', public.eventlist, name='eventlist'),
+    url(r'^events/(?P<event>\w+)/calendar$', RunsCalendar(), name='calendar'),
     url(r'^index/(?P<event>\w+|)$', public.index, name='index'),
     # unfortunately, using the 'word' variant here clashes with the admin site (not to mention any unparameterized urls), so I guess its going to have to be this way for now.  I guess that ideally, one would only use the 'index' url, and redirect to it as neccessary).
     url(r'^(?P<event>\d+|)$', public.index),


### PR DESCRIPTION
Each event has its own calendar ics file and can be reached at
`/tracker/events/<short name>/calendar`. This URL can be directly
imported into calendar apps and online calendars.

ICS calendars are static files and so must be refreshed every so often
by a calendar app that is trying to keep the calendar in sync with the
server. Unfortunately, at least for Google Calendar, that sync interval
can be quite long [[1]]. Therefore, changes made to run information
(runners, name, description) or start/end times will not be reflected
everywhere immediately.

[1]: https://webapps.stackexchange.com/questions/6313/how-often-does-google-calendar-update-its-other-calendar-feeds

[#121361187]