### PR TITLE
Silence psycopg2 warning about psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ gdata==2.0.18
 httplib2==0.9.2
 jsonfield==1.0.3
 Markdown==2.6.5
-psycopg2==2.7.6.1
+# It is safe to remove --no-binary after upgrading to psycopg2>=2.8
+psycopg2==2.7.6.1 --no-binary=psycopg2
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 python-dateutil==2.4.2


### PR DESCRIPTION
- [x] ~I've added tests or modified existing tests for the change.~ Existing tests
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/169253044


### Description of the Change

In order to resolve a segfault encountered when using the psycopg2
binary bundled in the wheel at the same time as a different package
depending on libssl, maintainers will remove the binary from the
psycopg2 wheel beginning with version 2.8. Until then, a warning occurs
when using the psycopg2 wheel binary.

This warning is emitted every time we start up django, so it can be
annoying. Specifying `--no-binary` forces building from source and so
requires the build dependencies (libpq, etc.) to be present when
installing. Users that don't want this can install `psycopg2-binary` at
the same version instead.

Merging this commit doesn't fix existing installations of the tracker.
Users should run `pip install --force-reinstall psycopg2==2.7.6.1
--no-binary psycopg2` to silence the warning.

More reading: https://github.com/psycopg/psycopg2/issues/674


### Possible Drawbacks

Users installing the dependencies for the first time will need to have `psycopg2`'s build dependencies, like `libpq` present before installing.


### Verification Process

I also mucked around with records in the admin interface by creating and editing things.
