### PR TITLE
Add CI via Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,85 @@
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+strategy:
+  matrix:
+    Python36:
+      PYTHON_VERSION: '3.6'
+    Python37:
+      PYTHON_VERSION: '3.7'
+
+variables:
+  TOPLEVEL_REVISION: 947450932a0f68cb79222f5964aad319f99d9abf
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(PYTHON_VERSION)'
+    architecture: 'x64'
+
+- script: |
+    mv -v $(Build.SourcesDirectory) $(Agent.BuildDirectory)/tracker
+    git clone git://github.com/GamesDoneQuick/donation-tracker-toplevel $(Build.SourcesDirectory)
+    cd $(Build.SourcesDirectory)
+    git reset --hard $(TOPLEVEL_REVISION)
+    mv -v $(Agent.BuildDirectory)/tracker $(Build.SourcesDirectory)
+    cp -v tracker/ci/local.py $(Build.SourcesDirectory)/local.py
+  displayName: 'Install toplevel around the tracker'
+
+- task: PythonScript@0
+  displayName: 'Export project path'
+  inputs:
+    scriptSource: 'inline'
+    script: |
+      """Search all subdirectories for `manage.py`."""
+      from glob import iglob
+      from os import path
+      manage_py = next(iglob(path.join('**', 'manage.py'), recursive=True), None)
+      if not manage_py:
+          raise SystemExit('Could not find a Django project')
+      project_location = path.dirname(path.abspath(manage_py))
+      print('Found Django project in', project_location)
+      print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
+
+- task: CacheBeta@1
+  inputs:
+    key: pip | $(Agent.OS) | tracker/requirements.txt
+    path: $(Pipeline.Workspace)/../../.cache/pip
+  displayName: 'Cache pip'
+
+- script: |
+    python -m pip install --upgrade pip setuptools wheel
+    pip install -r requirements.txt
+    pip install unittest-xml-reporting
+  displayName: 'Install python prerequisites'
+
+- task: CacheBeta@1
+  inputs:
+    key: yarn | $(Agent.OS) | tracker/yarn.lock
+    path: $(Build.SourcesDirectory)/tracker/node_modules
+  displayName: 'Cache yarn'
+
+- script: |
+    cd tracker
+    yarn install
+  displayName: 'Install node prerequisites'
+
+- script: |
+    cd tracker
+    yarn build
+  displayName: 'Generate webpack manifest'
+
+- script: |
+    pushd '$(projectRoot)'
+    python manage.py test --parallel \
+      --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner \
+      --no-input
+  displayName: 'Run Django tests'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: "**/TEST-*.xml"
+    testRunTitle: 'Python $(PYTHON_VERSION)'
+  condition: succeededOrFailed()

--- a/ci/local.py
+++ b/ci/local.py
@@ -1,0 +1,56 @@
+import os
+
+ALLOWED_HOSTS = ['localhost', 'your.domain.name']
+
+# this is used as part of the auto-mailing services to identify where
+# to redirect registration and password resets to
+DOMAIN = 'your.domain.name'
+
+# Leave this as true during development, so that you get error pages describing what went wrong
+DEBUG = True
+
+# You can add your e-mail if you want to receive notifications of failures I think , but its probably not a good idea
+ADMINS = [
+    # ('Your Name', 'your_email@example.com'),
+]
+
+# You can also make local sqlite databases in your current directory
+# if you want to test changes to the data model
+DATABASES = {
+    'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'db/testdb',},
+}
+
+PAYPAL_TEST = True
+
+TIME_ZONE = 'America/New_York'
+
+SECRET_KEY = 'ChangeMeToARandomString'
+
+STATICFILES_DIRS = (os.path.abspath('tracker/static/'),)
+
+STATIC_URL = '/static/'
+STATIC_ROOT = '/var/www/static/'
+
+HAS_GDOC = False
+# GDOC_USERNAME = 'person@gmail.com'
+# GDOC_PASSWORD = '12345678'
+
+HAS_EMAIL = False
+# EMAIL_HOST = 'mail.somwhere.com'
+# EMAIL_PORT = 465
+# EMAIL_HOST_USER = 'dude@somewhere.com'
+# EMAIL_HOST_PASSWORD = '1234567878'
+# EMAIL_FROM_USER = 'someone_else@somewhere.com'
+
+HAS_GOOGLE_APP_ID = False
+# GOOGLE_CLIENT_ID = 'the.google.apps.url.thingy'
+# GOOGLE_CLIENT_SECRET = 'secretpasswordthing'
+
+HAS_GIANTBOMB_API_KEY = False
+# GIANTBOMB_API_KEY = 'Itsreallynicetohaveanditsfreetomakeanaccountbutnotneccessary'
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
+ADDITIONAL_APPS = [
+    # place additional apps here
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ httplib2==0.9.2
 jsonfield==1.0.3
 Markdown==2.6.5
 pre-commit==1.19.0
-# It is safe to remove --no-binary after upgrading to psycopg2>=2.8
-psycopg2==2.7.6.1 --no-binary=psycopg2
+psycopg2-binary==2.7.6.1
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 python-dateutil==2.4.2


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] ~I've added tests or modified existing tests for the change.~
- [ ] ~I've humanly end-to-end tested the change by running an instance of the tracker.~


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/112739405


### Description of the Change

This adds a basic pipeline for Azure Pipelines that runs the tracker's
tests using toplevel. AP's ubuntu image still doesn't have python 3.8 so
that's not included in the build matrix.

I've also changed our psycopg2 requirement to psycopg2-binary. This
simplifies installation for CI and new users, since static libraries
will not be required as we won't be building from source.


### Possible Drawbacks

~Before this PR can be merged, we should make sure all tests on `master` pass. (They do not, currently.)~
Added a `yarn build` step so the webpack manifest gets generated.


### Verification Process

I set up the pipeline on my personal account to test the pipeline configuration.
