### PR TITLE
[#169664387] fix api urls in admin processing pages

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 
 import django.forms as djforms
@@ -1762,21 +1763,41 @@ def process_donations(request):
     return render(
         request,
         'admin/process_donations.html',
-        {'user_can_approve': user_can_approve, 'current_event': current_event},
+        {
+            'user_can_approve': user_can_approve,
+            'currentEvent': current_event,
+            'apiUrls': mark_safe(json.dumps(api_urls())),
+        },
     )
+
+
+def api_urls():
+    return {
+        'adminBaseURL': reverse('admin:app_list', kwargs={'app_label': 'tracker'}),
+        'searchURL': reverse('tracker:api_v1:search'),
+        'editURL': reverse('tracker:api_v1:edit'),
+        'addURL': reverse('tracker:api_v1:add'),
+        'deleteURL': reverse('tracker:api_v1:delete'),
+    }
 
 
 @admin_auth(('tracker.change_donor', 'tracker.change_donation'))
 def read_donations(request):
     currentEvent = viewutil.get_selected_event(request)
-    return render(request, 'admin/read_donations.html', {'currentEvent': currentEvent})
+    return render(
+        request,
+        'admin/read_donations.html',
+        {'currentEvent': currentEvent, 'apiUrls': mark_safe(json.dumps(api_urls()))},
+    )
 
 
 @admin_auth('tracker.change_prize')
 def process_prize_submissions(request):
     currentEvent = viewutil.get_selected_event(request)
     return render(
-        request, 'admin/process_prize_submissions.html', {'currentEvent': currentEvent}
+        request,
+        'admin/process_prize_submissions.html',
+        {'currentEvent': currentEvent, 'apiUrls': mark_safe(json.dumps(api_urls()))},
     )
 
 
@@ -1784,7 +1805,9 @@ def process_prize_submissions(request):
 def process_pending_bids(request):
     currentEvent = viewutil.get_selected_event(request)
     return render(
-        request, 'admin/process_pending_bids.html', {'currentEvent': currentEvent}
+        request,
+        'admin/process_pending_bids.html',
+        {'currentEvent': currentEvent, 'apiUrls': mark_safe(json.dumps(api_urls()))},
     )
 
 
@@ -2060,10 +2083,6 @@ def get_urls():
             name='process_prize_submissions',
         ),
         url('process_pending_bids', process_pending_bids, name='process_pending_bids'),
-        url('search_objects', views.search, name='search_objects'),
-        url('edit_object', views.edit, name='edit_object'),
-        url('add_object', views.add, name='add_object'),
-        url('delete_object', views.delete, name='delete_object'),
         url(r'draw_prize/(?P<id>\d+)', views.draw_prize, name='draw_prize'),
     ] + urls
 

--- a/api_urls.py
+++ b/api_urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import url
+
+from .views import api
+
+urlpatterns = [
+    url(r'$', api.root, name='root'),
+    url(r'^search/$', api.search, name='search'),
+    url(r'^add/$', api.add, name='add'),
+    url(r'^edit/$', api.edit, name='edit'),
+    url(r'^delete/$', api.delete, name='delete'),
+    url(r'^command/$', api.command, name='command'),
+    url(r'^me/$', api.me, name='me'),
+]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "karma start --single-run",
     "test:watch": "karma start",
     "fix:prettier": "prettier --write \"bundles/**\"",
+    "yarn:install": "yarn install",
     "tsc": "tsc --version && tsc",
     "tsc:watch": "tsc --version && tsc --watch"
   },

--- a/templates/admin/process_donations.html
+++ b/templates/admin/process_donations.html
@@ -19,7 +19,7 @@ td {
 
 <script>
 
-var trackerAPI = new TrackerAPI("{% url 'tracker:api_v1' %}");
+var trackerAPI = new TrackerAPI({{ apiUrls }});
 
 var resultsTable;
 
@@ -94,8 +94,8 @@ function runSearch() {
     searchParams['feed'] = "toprocess";
   {% endif %}
 
-  {% if current_event %}
-  searchParams.event = {{ current_event.id }};
+  {% if currentEvent %}
+  searchParams.event = {{ currentEvent.id }};
   {% endif %}
 
   disableElements($("#id_result_set").get(0));

--- a/templates/admin/process_pending_bids.html
+++ b/templates/admin/process_pending_bids.html
@@ -12,14 +12,12 @@ td {
 }
 </style>
 
-<link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
-<script src="{% static "js/ajax_select.js" %}"></script>
 <link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 <script>
 
-var trackerAPI = new TrackerAPI("{% url 'tracker:api_v1' %}");
+var trackerAPI = new TrackerAPI({{ apiUrls }});
 
 var resultsTable;
 

--- a/templates/admin/process_prize_submissions.html
+++ b/templates/admin/process_prize_submissions.html
@@ -12,14 +12,12 @@ td {
 }
 </style>
 
-<link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
-<script src="{% static "js/ajax_select.js" %}"></script>
 <link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 <script>
 
-var trackerAPI = new TrackerAPI("{% url 'tracker:api_v1' %}");
+var trackerAPI = new TrackerAPI({{ apiUrls }});
 
 var resultsTable;
 

--- a/templates/admin/read_donations.html
+++ b/templates/admin/read_donations.html
@@ -21,7 +21,7 @@ td {
 var partitionLanguageElem = "#partition_language";
 var languageCookieName = 'donation_processing_language';
 
-var trackerAPI = new TrackerAPI("{% url 'tracker:api_v1' %}");
+var trackerAPI = new TrackerAPI({{ apiUrls }});
 
 var resultsTable;
 

--- a/templates/ui/index.html
+++ b/templates/ui/index.html
@@ -10,7 +10,7 @@
     {{ bundle.css|safe }}
     <script type="text/javascript">
       <!--
-      window.API_ROOT = '{% url 'tracker:api_v1' %}';
+      window.API_ROOT = '{% url 'tracker:api_v1:root' %}';
       window.ROOT_PATH = '{{ root_path }}';
       window.STATIC_URL = '{% static '' %}';
       window.APP_NAME = 'tracker';

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -61,6 +61,7 @@ class ProcessDonationsTest(TestCase):
         self.client.force_login(self.processor)
         response = self.client.get('/admin/process_donations')
         self.assertEqual(response.context['user_can_approve'], False)
+        self.assertEqual(response.status_code, 200)
 
     def test_no_event_selected_with_head(self):
         del self.session['admin-event']
@@ -68,11 +69,13 @@ class ProcessDonationsTest(TestCase):
         self.client.force_login(self.head_processor)
         response = self.client.get('/admin/process_donations')
         self.assertEqual(response.context['user_can_approve'], True)
+        self.assertEqual(response.status_code, 200)
 
     def test_one_step_screening(self):
         self.client.force_login(self.processor)
         response = self.client.get('/admin/process_donations')
         self.assertEqual(response.context['user_can_approve'], True)
+        self.assertEqual(response.status_code, 200)
 
     def test_two_step_screening_non_head(self):
         self.event.use_one_step_screening = False
@@ -80,6 +83,7 @@ class ProcessDonationsTest(TestCase):
         self.client.force_login(self.processor)
         response = self.client.get('/admin/process_donations')
         self.assertEqual(response.context['user_can_approve'], False)
+        self.assertEqual(response.status_code, 200)
 
     def test_two_step_screening_with_head(self):
         self.event.use_one_step_screening = False
@@ -87,3 +91,32 @@ class ProcessDonationsTest(TestCase):
         self.client.force_login(self.head_processor)
         response = self.client.get('/admin/process_donations')
         self.assertEqual(response.context['user_can_approve'], True)
+        self.assertEqual(response.status_code, 200)
+
+
+class TestAdminViews(TestCase):
+    # smoke tests for other views that don't have more detailed tests yet
+    def setUp(self):
+        self.rand = random.Random(None)
+        self.superuser = User.objects.create_superuser(
+            'superuser', 'super@example.com', 'password',
+        )
+        self.event = randgen.build_random_event(self.rand)
+        self.session = self.client.session
+        self.session['admin-event'] = self.event.id
+        self.session.save()
+
+    def test_read_donations(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get('/admin/read_donations')
+        self.assertEqual(response.status_code, 200)
+
+    def test_process_prize_submissions(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get('/admin/process_prize_submissions')
+        self.assertEqual(response.status_code, 200)
+
+    def test_process_pending_bids(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get('/admin/process_pending_bids')
+        self.assertEqual(response.status_code, 200)

--- a/urls.py
+++ b/urls.py
@@ -5,6 +5,8 @@ from .feeds.runs_calendar import RunsCalendar
 
 from .ui import urls as ui_urls
 
+from . import api_urls
+
 app_name = 'tracker'
 urlpatterns = [
     url(r'^ui/', include(ui_urls, namespace='ui')),
@@ -36,13 +38,7 @@ urlpatterns = [
     url(r'^delete/$', api.delete),
     url(r'^command/$', api.command),
     url(r'^me/$', api.me),
-    url(r'^api/v1/$', api.api_v1, name='api_v1'),
-    url(r'^api/v1/search/$', api.search),
-    url(r'^api/v1/add/$', api.add),
-    url(r'^api/v1/edit/$', api.edit),
-    url(r'^api/v1/delete/$', api.delete),
-    url(r'^api/v1/command/$', api.command),
-    url(r'^api/v1/me/$', api.me),
+    url(r'^api/v1/', include(api_urls, namespace='api_v1')),
     url(r'^api/v2/', include('tracker.api.urls')),
     url(r'^user/index/$', user.user_index, name='user_index'),
     url(r'^user/user_prize/(?P<prize>\d+)$', user.user_prize, name='user_prize'),

--- a/views/api.py
+++ b/views/api.py
@@ -48,7 +48,7 @@ __all__ = [
     'draw_prize',
     'parse_value',
     'me',
-    'api_v1',
+    'root',
 ]
 
 modelmap = {
@@ -355,7 +355,7 @@ def parse_value(Model, field, value, user=None):
                     return RelatedModel.objects.get_by_natural_key(*key)
 
 
-def api_v1(request):
+def root(request):
     # only here to give a root access point
     raise Http404
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/169664387

### Description of the Change

Removal of SITE_PREFIX wasn't complete, and broke the admin processing pages because they got the wrong URL structure. This not only fixes that problem, but slightly reworks the structure to be easier to work with in the first place.

### Possible Drawbacks

If I missed any hard-coded urls, they're still broken. Some URLs were outright removed, so if any external sources are referencing them, they'll stop working.

### Verification Process

Added a few new smoke unit tests to make sure the admin pages didn't explode, and I manually ran through the four pages in question (read donations, process donations, process pending bids, and process pending prizes) to verify they were reading data correctly.
