### PR TITLE
Remove unused `init` dir

### DIFF
--- a/bundles/init/index.js
+++ b/bundles/init/index.js
@@ -1,1 +1,0 @@
-import './int_keys';

--- a/bundles/init/int_keys.js
+++ b/bundles/init/int_keys.js
@@ -1,9 +1,0 @@
-function intKeys(obj) {
-  const result = Object.keys(obj);
-  return result.map(key => {
-    const ret = parseInt(key);
-    return ret || key;
-  });
-}
-
-Object.intKeys = intKeys;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,8 +25,8 @@ module.exports = {
   context: __dirname,
   mode: PROD ? 'production' : 'development',
   entry: {
-    admin: ['./bundles/init', './bundles/admin'],
-    donate: ['./bundles/init', './bundles/donate'],
+    admin: './bundles/admin',
+    donate: './bundles/donate',
   },
   output: {
     filename: PROD ? 'tracker-[name]-[hash].js' : 'tracker-[name].js',


### PR DESCRIPTION
- [-] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

`init` was a directory that didn't really do anything. It had a single `intKeys` function in it, which was unused (and can just be done with `lodash` anyway).

In the future, if we have shared utils, they should go in a utils folder and be required where used, rather than added to a global namespace.

### Possible Drawbacks

Some magical wizadry of webpack was using this in some distant place or something.


### Verification Process

Ran through `admin` and `donate` flows.