### PR TITLE
Add tsc check as a pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
       entry: ./node_modules/.bin/tsc
       language: script
       stages: [push]
+      files: (.*)\.(jsx?|tsx?)$
       pass_filenames: false
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_stages: [commit]
 exclude: (migrations/|static/(jquery.*|main.css))
 repos:
 - repo: https://github.com/psf/black
@@ -16,7 +17,7 @@ repos:
       entry: ./node_modules/.bin/prettier
       language: node
       stages: [commit]
-      files: (.*)\.(js|css)$
+      files: (.*)\.(js|jsx|ts|tsx|css)$
       args: ["--write"]
     - id: eslint
       name: eslint
@@ -25,6 +26,12 @@ repos:
       stages: [commit]
       files: (.*)\.(jsx?|tsx?)$
       args: ["--fix", "--quiet"]
+    - id: typescript
+      name: typescript
+      entry: ./node_modules/.bin/tsc
+      language: script
+      stages: [push]
+      pass_filenames: false
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.4.0
   hooks:

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ See setup instructions in the top level repository: https://github.com/GamesDone
 
 This project uses [`pre-commit`](https://pre-commit.com/) to run linters and other checks before every commit.
 
-`pre-commit` has been added as part of `requirements.txt`, so new installs should automatically get it, but if not, you can get it manually with pip:
+`pre-commit` has been added as part of `requirements.txt`, so new installs should automatically get it, but if not, you can get it manually with pip, and then install the hooks with the `pre-commit` binary.
 
 ```
 pip install pre-commit
+pre-commit install
+pre-commit install --hook-type pre-push
 ```
 
-Then, run `pre-commit install` in this repository to add the git hooks, and now every time you `git commit` the checks will run!
+And now every time you `git commit` or `git push`, the appropriate checks will run!
 
-_Note:_ You _can_ bypass these checks by adding `--no-verify` when you commit, though this is highly discouraged in most cases. In the future, CI tests may fail if any of these checks are not satisfied.
+_Note:_ You _can_ bypass these checks by adding `--no-verify` when you commit or push, though this is highly discouraged in most cases. In the future, CI tests may fail if any of these checks are not satisfied.
 
 If the pre-commit hooks fail on your first commit with them, make sure you are not inside of a submodule! This can affect where `pre-commit` tries to install hooks, and cloning the tools (specifically, `black`) can cause an error.
 


### PR DESCRIPTION
### Description of the Change

Since we're now going to have typescript code with static types, it's nice to have a hook that enforces the typechecking before pushing to a remote branch. For the most part, this is a shortcut against fast-failing CI pipelines, where you'll get immediate feedback instead of pushing and then later on told typechecking failed after the whole CI pipeline runs.

Using this also requires a few extra changes to pre-commit:

- Set `default_stages` to just `commit` so that things like `black` and `eslint` don't try to run at both stages.
- Run an additional `pre-commit install -t pre-push` on your machine to install the hook for pushes. This has also been added to the README.
- Also fixed the prettier file regex to check typescript files.

### Possible Drawbacks

`tsc` isn't exactly the fastest thing out there, so pushes can take a solid 20 seconds or so, which might not seem ergonomic.

However, assuming you've been running `yarn tsc` while developing, you can just let push run in the background until it's done. Otherwise, you can just use this hook as your run of `yarn tsc` and have it tell you directly if things are wrong, rather than waiting for CI (eventually) to error out the same way.

If even that is too slow, you can `git push --no-verify` to skip all push hooks as well.

### Verification Process

Made some commits, squashed some commits :)