### PR TITLE
[#170035139] fail CI if migrations are bad or missing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,13 @@ steps:
   displayName: 'Install node prerequisites'
 
 - script: |
+    pushd '$(projectRoot)'
+    mkdir db
+    python manage.py migrate tracker
+    python manage.py makemigrations --check --dry-run tracker
+  displayName: 'Check for bad or missing migrations'
+
+- script: |
     cd tracker
     yarn build
   displayName: 'Generate webpack manifest'


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

~~- [ ] I've added tests or modified existing tests for the change.~~
~~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~~

(Neither is relevant because this is a CI change.)

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170035139

### Description of the Change

I want CI to fail if it thinks there a migrations missing.

### Possible Drawbacks

It's possible that different machines may have different ideas about what needs a migration, but if that DOES happen we can start shaking them out.

### Verification Process

Put in a deliberately bad commit, see it fail, remove the bad part of the commit, see it pass.