### PR TITLE
[#170165802] add some fields to prize api queries

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1399,6 +1399,7 @@ class PrizeAdmin(CustomModelAdmin):
                     'shortdescription',
                     'image',
                     'altimage',
+                    'imagefile',
                     'event',
                     'category',
                     'requiresshipping',

--- a/models/prize.py
+++ b/models/prize.py
@@ -65,7 +65,7 @@ class Prize(models.Model):
     minimumbid = models.DecimalField(
         decimal_places=2,
         max_digits=20,
-        default=Decimal('5.0'),
+        default=Decimal('5.00'),
         verbose_name='Minimum Bid',
         validators=[positive, nonzero],
     )
@@ -74,7 +74,7 @@ class Prize(models.Model):
         max_digits=20,
         null=True,
         blank=True,
-        default=Decimal('5.0'),
+        default=Decimal('5.00'),
         verbose_name='Maximum Bid',
         validators=[positive, nonzero],
     )

--- a/serializers.py
+++ b/serializers.py
@@ -1,0 +1,29 @@
+from django.db import models
+from django.core.serializers.json import Serializer as JSONSerializer
+
+from tracker.models import Prize
+
+_ExtraFields = {
+    Prize: ['start_draw_time', 'end_draw_time'],
+}
+
+
+class TrackerSerializer(JSONSerializer):
+    def __init__(self, Model, user):
+        self.Model = Model
+        self.user = user
+
+    def handle_field(self, obj, field):
+        if isinstance(field, models.FileField):
+            self._current[field.name] = field.value_from_object(obj).url
+        else:
+            super(TrackerSerializer, self).handle_field(obj, field)
+
+    def get_dump_object(self, obj):
+        data = super(TrackerSerializer, self).get_dump_object(obj)
+        for extra_field in _ExtraFields.get(self.Model, []):
+            prop = getattr(obj, extra_field)
+            if callable(prop):
+                prop = prop()
+            data['fields'][extra_field] = prop
+        return data

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,10 @@
+from django.core import serializers
+from django.core.serializers.json import DjangoJSONEncoder
+
 import tracker.models as models
 
 from django.test import TransactionTestCase, RequestFactory
-from django.contrib.auth.models import User, Permission
+from django.contrib.auth.models import User, Permission, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.admin.models import (
     LogEntry,
@@ -30,6 +33,7 @@ def format_time(dt):
 
 class APITestCase(TransactionTestCase):
     model_name = None
+    encoder = DjangoJSONEncoder()
 
     def parseJSON(self, response, status_code=200):
         self.assertEqual(
@@ -108,6 +112,7 @@ class APITestCase(TransactionTestCase):
         self.event = models.Event.objects.create(
             datetime=today_noon, targetamount=5, short='event', name='Test Event'
         )
+        self.anonymous_user = AnonymousUser()
         self.user = User.objects.create(username='test')
         self.add_user = User.objects.create(username='add')
         self.locked_user = User.objects.create(username='locked')
@@ -124,6 +129,7 @@ class APITestCase(TransactionTestCase):
                 Permission.objects.get(name='Can change %s' % self.model_name),
             )
         self.super_user = User.objects.create(username='super', is_superuser=True)
+        self.maxDiff = None
 
 
 class TestGeneric(APITestCase):
@@ -693,6 +699,99 @@ class TestPrize(APITestCase):
     def setUp(self):
         super(TestPrize, self).setUp()
 
+    @classmethod
+    def format_prize(cls, prize):
+        def add_run_fields(fields, run, prefix):
+            dumped_run = json.loads(serializers.serialize('json', [run]))[0]
+            for key, value in dumped_run['fields'].items():
+                if key in ['event', 'giantbomb_id', 'runners']:
+                    continue
+                fields[prefix + '__' + key] = value
+            fields[prefix + '__public'] = str(run)
+
+        run_fields = {}
+        if prize.startrun:
+            add_run_fields(run_fields, prize.startrun, 'startrun')
+            add_run_fields(run_fields, prize.endrun, 'endrun')
+        draw_time_fields = {}
+        if prize.has_draw_time():
+            draw_time_fields['start_draw_time'] = cls.encoder.default(
+                prize.start_draw_time()
+            )
+            draw_time_fields['end_draw_time'] = cls.encoder.default(
+                prize.end_draw_time()
+            )
+
+        return dict(
+            fields=dict(
+                allowed_prize_countries=[
+                    c.id for c in prize.allowed_prize_countries.all()
+                ],
+                disallowed_prize_regions=[
+                    r.id for r in prize.disallowed_prize_regions.all()
+                ],
+                public=prize.name,
+                name=prize.name,
+                category=prize.category_id,
+                image=prize.image,
+                altimage=prize.image,
+                imagefile=prize.imagefile.url if prize.imagefile else '',
+                description=prize.description,
+                shortdescription=prize.shortdescription,
+                creator=prize.creator,
+                creatoremail=prize.creatoremail,
+                creatorwebsite=prize.creatorwebsite,
+                handler=prize.handler_id,
+                key_code=prize.key_code,
+                provider=prize.provider,
+                maxmultiwin=prize.maxmultiwin,
+                maxwinners=prize.maxwinners,
+                numwinners=str(len(prize.get_prize_winners())),
+                requiresshipping=prize.requiresshipping,
+                custom_country_filter=prize.custom_country_filter,
+                estimatedvalue=prize.estimatedvalue,
+                minimumbid=str(prize.minimumbid),
+                maximumbid=str(prize.maximumbid),
+                sumdonations=prize.sumdonations,
+                randomdraw=prize.randomdraw,
+                event=prize.event_id,
+                startrun=prize.startrun_id,
+                endrun=prize.endrun_id,
+                starttime=prize.starttime,
+                endtime=prize.endtime,
+                **run_fields,
+                **draw_time_fields,
+            ),
+            model='tracker.prize',
+            pk=prize.id,
+        )
+
+    def test_search(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        models.SpeedRun.objects.create(
+            event=self.event,
+            name='Test Run',
+            run_time='5:00',
+            setup_time='5:00',
+            order=1,
+        ).clean()
+        prize = models.Prize.objects.create(
+            event=self.event,
+            handler=self.add_user,
+            name='Prize With Image',
+            state='ACCEPTED',
+            startrun=self.event.speedrun_set.first(),
+            endrun=self.event.speedrun_set.first(),
+            imagefile=SimpleUploadedFile('test.jpg', b''),
+        )
+        prize.refresh_from_db()
+        request = self.factory.get('/api/v1/search', dict(type='prize',),)
+        request.user = self.user
+        data = self.parseJSON(tracker.views.api.search(request))
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0], self.format_prize(prize))
+
     def test_add_with_new_category(self):
         self.add_user.user_permissions.add(
             Permission.objects.get(name='Can add Prize Category')
@@ -709,10 +808,12 @@ class TestPrize(APITestCase):
         )
         request.user = self.add_user
         data = self.parseJSON(tracker.views.api.add(request))
+        prize = models.Prize.objects.get(pk=data[0]['pk'])
         self.assertEqual(len(data), 1)
+        # TODO: add and search don't format the same
+        # self.assertEqual(data[0], self.format_prize(prize))
         self.assertEqual(
-            models.Prize.objects.get(pk=data[0]['pk']).category,
-            models.PrizeCategory.objects.get(name='Grand'),
+            prize.category, models.PrizeCategory.objects.get(name='Grand'),
         )
 
     def test_add_with_new_category_without_category_add_permission(self):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170165802

### Description of the Change

The prize search in particular was missing a couple of useful fields (extra start/end to the draw times), and the `imagefile` field (which wasn't seeing much use yet) was only a partial url. Fixing these required starting to write a custom serializer, but it's fairly simple so far.

Might be worth moving the rest of the search API to that custom serializer.

### Possible Drawbacks

Some weird side effect to a different model? The changes are pretty tightly scoped so I'd be surprised.

### Verification Process

Uploaded a file with both the standard storage backend and the Amazon S3 storage backend, both returned valid urls for `imagefile` when queried via search.