### PR TITLE
[#170173809] search api supports limit and offset parameters

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -82,7 +82,7 @@ _GeneralFields = {
     'prizeentry': ['prize', 'donor'],
     'run': ['name', 'description'],
     'log': ['category', 'message', 'event'],
-    'runner': ['name', 'stream', 'twitter', 'youtube','platform','pronouns'],
+    'runner': ['name', 'stream', 'twitter', 'youtube', 'platform', 'pronouns'],
 }
 
 _SpecificFields = {
@@ -689,8 +689,8 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
             callParams = {'donations': query}
             if 'delta' in params:
                 callParams['delta'] = timedelta(minutes=int(params['delta']))
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             if 'maxDonations' in params:
                 callParams['maxDonations'] = int(params['maxDonations'])
             if 'minDonations' in params:
@@ -726,8 +726,8 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
             if noslice:
                 callParams['maxRuns'] = None
                 callParams['minRuns'] = None
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             query = query.filter(state='OPENED').filter(
                 upcomming_bid_filter(**callParams)
             )
@@ -742,8 +742,8 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
                 callParams['minRuns'] = None
             if 'delta' in params:
                 callParams['delta'] = timedelta(minutes=int(params['delta']))
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             query = query.filter(future_bid_filter(**callParams))
         elif feedName == 'completed':
             query = get_completed_bids(query)
@@ -759,8 +759,8 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
             if noslice:
                 callParams['maxRuns'] = None
                 callParams['minRuns'] = None
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             query = get_upcomming_runs(**callParams)
         elif feedName == 'future':
             if 'maxRuns' in params:
@@ -772,14 +772,14 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
                 callParams['minRuns'] = None
             if 'delta' in params:
                 callParams['delta'] = timedelta(minutes=int(params['delta']))
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             query = get_future_runs(**callParams)
     elif model == 'prize':
         if feedName == 'current':
             callParams = {}
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             query = query.filter(current_prizes_filter(**callParams))
         elif feedName == 'future':
             callParams = {}
@@ -792,8 +792,8 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
                 callParams['minRuns'] = None
             if 'delta' in params:
                 callParams['delta'] = timedelta(minutes=int(params['delta']))
-            if 'offset' in params:
-                callParams['queryOffset'] = default_time(params['offset'])
+            if 'time' in params:
+                callParams['queryOffset'] = default_time(params['time'])
             x = upcomming_prizes_filter(**callParams)
             query = query.filter(x)
         elif feedName == 'won':
@@ -807,6 +807,6 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
             query = query.filter(bid__state='CLOSED')
     elif model == 'event':
         if feedName == 'future':
-            offsettime = default_time(params.get('offset', None))
+            offsettime = default_time(params.get('time', None))
             query = query.filter(datetime__gte=offsettime)
     return query

--- a/viewutil.py
+++ b/viewutil.py
@@ -220,7 +220,7 @@ def get_donation_prize_info(donation):
     prizeList = []
     for timeprize in filters.run_model_query(
         'prize',
-        params={'feed': 'current', 'offset': donation.timereceived, 'noslice': True,},
+        params={'feed': 'current', 'time': donation.timereceived, 'noslice': True,},
     ):
         contribAmount = get_donation_prize_contribution(timeprize, donation)
         if contribAmount is not None:


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170173809

### Description of the Change

The search API now supports `offset` and `limit` parameters for pagination reasons.

There was an old parameter for `current` feeds that allowed you to specify a time string and get a different "current" feed, so I renamed it to just `time`.

### Possible Drawbacks

If anybody was using the old `offset` parameter before, their requests won't work any more. It's a pretty obscure feature so I suspect nobody will notice.

### Verification Process

Made 10 objects, set `limit` and `offset` to various values, made sure I was getting the expected subset.