### PR TITLE
[#170173799] search api now returns canonical urls

### DIFF
--- a/models/bid.py
+++ b/models/bid.py
@@ -4,12 +4,12 @@ from gettext import gettext as _
 
 import mptt.models
 import pytz
-
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import signals, Sum, Q
 from django.dispatch import receiver
+from django.urls import reverse
 
 from tracker.models import Event, SpeedRun
 from tracker.validators import positive, nonzero
@@ -130,6 +130,9 @@ class Bid(mptt.models.MPTTModel):
 
     class MPTTMeta:
         order_insertion_by = ['name']
+
+    def get_absolute_url(self):
+        return reverse('tracker:bid', args=(self.id,))
 
     def natural_key(self):
         if self.parent:

--- a/models/donation.py
+++ b/models/donation.py
@@ -1,20 +1,19 @@
+import calendar
 from decimal import Decimal
+from functools import reduce
 
-from django.db import models
-from django.db.models import signals
-from django.db.models import Count, Sum, Max, Avg
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.db import models
+from django.db.models import Count, Sum, Max, Avg
+from django.db.models import signals
 from django.dispatch import receiver
-from django.contrib.auth.models import User
 from django.utils import timezone
 
 from .event import LatestEvent
 from .fields import OneToOneOrNoneField
 from ..validators import positive, nonzero
-from functools import reduce
-
-import calendar
 
 __all__ = [
     'Donation',
@@ -180,6 +179,9 @@ class Donation(models.Model):
         )
         get_latest_by = 'timereceived'
         ordering = ['-timereceived']
+
+    def get_absolute_url(self):
+        return reverse('tracker:donation', args=(self.id,))
 
     def bid_total(self):
         return reduce(

--- a/models/event.py
+++ b/models/event.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.db.models import signals
 from django.db.utils import OperationalError
 from django.dispatch import receiver
+from django.urls import reverse
 from timezone_field import TimeZoneField
 
 from ..validators import positive, nonzero
@@ -289,6 +290,9 @@ class Event(models.Model):
     def __str__(self):
         return self.name
 
+    def get_absolute_url(self):
+        return reverse('tracker:index', args=(self.id,))
+
     def natural_key(self):
         return (self.short,)
 
@@ -448,6 +452,9 @@ class SpeedRun(models.Model):
         unique_together = (('name', 'category', 'event'), ('event', 'order'))
         ordering = ['event__datetime', 'order']
         permissions = (('can_view_tech_notes', 'Can view tech notes'),)
+
+    def get_absolute_url(self):
+        return reverse('tracker:run', args=(self.id,))
 
     def natural_key(self):
         return (self.name, self.event.natural_key())

--- a/models/prize.py
+++ b/models/prize.py
@@ -187,6 +187,9 @@ class Prize(models.Model):
     def natural_key(self):
         return (self.name, self.event.natural_key())
 
+    def get_absolute_url(self):
+        return reverse('tracker:prize', args=(self.id,))
+
     def __str__(self):
         return str(self.name)
 

--- a/serializers.py
+++ b/serializers.py
@@ -1,5 +1,5 @@
-from django.db import models
 from django.core.serializers.json import Serializer as JSONSerializer
+from django.db import models
 
 from tracker.models import Prize
 
@@ -9,9 +9,9 @@ _ExtraFields = {
 
 
 class TrackerSerializer(JSONSerializer):
-    def __init__(self, Model, user):
+    def __init__(self, Model, request):
         self.Model = Model
-        self.user = user
+        self.request = request
 
     def handle_field(self, obj, field):
         if isinstance(field, models.FileField):
@@ -27,4 +27,9 @@ class TrackerSerializer(JSONSerializer):
             if callable(prop):
                 prop = prop()
             data['fields'][extra_field] = prop
+        absolute_url = getattr(obj, 'get_absolute_url', None)
+        if callable(absolute_url):
+            data['fields']['canonical_url'] = self.request.build_absolute_uri(
+                absolute_url()
+            )
         return data

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
+from django.urls import reverse
 
 import tracker.models as models
 
@@ -290,6 +291,9 @@ class TestSpeedRun(APITestCase):
     def format_run(cls, run):
         return dict(
             fields=dict(
+                canonical_url=(
+                    'http://testserver' + reverse('tracker:run', args=(run.id,))
+                ),
                 category=run.category,
                 commentators=run.commentators,
                 console=run.console,
@@ -732,6 +736,9 @@ class TestPrize(APITestCase):
                 ],
                 public=prize.name,
                 name=prize.name,
+                canonical_url=(
+                    'http://testserver' + reverse('tracker:prize', args=(prize.id,))
+                ),
                 category=prize.category_id,
                 image=prize.image,
                 altimage=prize.altimage,

--- a/views/api.py
+++ b/views/api.py
@@ -202,7 +202,7 @@ def search(request):
         if qs.count() > 1000:
             qs = qs[:1000]
         jsonData = json.loads(
-            TrackerSerializer(Model, request.user).serialize(qs, ensure_ascii=False)
+            TrackerSerializer(Model, request).serialize(qs, ensure_ascii=False)
         )
         objs = dict([(o.id, o) for o in qs])
         for o in jsonData:


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170173799

### Description of the Change

Any model that has a public url will return it in the search results as an absolute url. Useful in case something consuming the API wants to link directly to a resource without having to magic up the url layout.

### Possible Drawbacks

It's an additive change to the API, so exceptionally brittle code might have problems.

### Verification Process

Hit a few search requests, verified that the URLs actually worked.