### PR TITLE
[#170302180] maximum bid is no longer editable

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1589,7 +1589,10 @@ class PrizeAdmin(CustomModelAdmin):
             params['event'] = event.id
         return filters.run_model_query('prize', params, user=request.user, mode='admin')
 
-    readonly_fields = ('handler_email',)
+    readonly_fields = (
+        'handler_email',
+        'maximumbid',
+    )
 
     def get_readonly_fields(self, request, obj=None):
         ret = list(self.readonly_fields)

--- a/models/prize.py
+++ b/models/prize.py
@@ -229,21 +229,14 @@ class Prize(models.Model):
             raise ValidationError(
                 {'starttime': 'Cannot have both Start/End Run and Start/End Time set'}
             )
-        if self.randomdraw:
-            if self.maximumbid is not None and self.maximumbid < self.minimumbid:
-                raise ValidationError(
-                    {'maximumbid': 'Maximum Bid cannot be lower than Minimum Bid'}
-                )
-            if not self.sumdonations and self.maximumbid != self.minimumbid:
-                raise ValidationError(
-                    {
-                        'maximumbid': 'Maximum Bid cannot differ from Minimum Bid if Sum Donations is not checked'
-                    }
-                )
         if self.image and self.imagefile:
             raise ValidationError(
                 {'image': 'Cannot have both an Image URL and an Image File'}
             )
+
+    def save(self, *args, **kwargs):
+        self.maximumbid = self.minimumbid
+        super(Prize, self).save(*args, **kwargs)
 
     def eligible_donors(self):
         donationSet = Donation.objects.filter(

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -1184,7 +1184,10 @@ class TestPrizeAdmin(TestCase):
         self.event = randgen.generate_event(self.rand)
         self.event.save()
         self.prize = randgen.generate_prize(self.rand, event=self.event)
+        self.prize.maximumbid = self.prize.minimumbid + 5
         self.prize.save()
+        # TODO: janky place to test this behavior, but it'll do for now
+        self.assertEqual(self.prize.minimumbid, self.prize.maximumbid)
         self.prize_with_keys = randgen.generate_prize(self.rand, event=self.event)
         self.prize_with_keys.key_code = True
         self.prize_with_keys.save()


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170302180

### Description of the Change

We haven't used prize donation ranges for years so I'm removing the ability to use it for new things. This is a minimal change to forcibly collapse the range on save, rather than removing the core behavior, as it's close to an event and I'd like to make the smallest change possible when it comes to code that has potential legal ramifications. Prize drawing is dangerous, yo.

### Possible Drawbacks

If you go back and edit an old prize, you'll lose the range information.

### Verification Process

Edited a prize multiple times with both the admin and the api and verified that `maximumbid` was always equal to `minimumbid` afterwards.