### PR TITLE
[#169941581] cap donation message column width for processor flow

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -576,6 +576,9 @@ def mass_assign_action(self, request, queryset, field, value):
 
 
 class DonationAdmin(CustomModelAdmin):
+    class Media:
+        css = {'all': ('admin/donation.css',)}
+
     form = DonationForm
     list_display = (
         'id',

--- a/static/admin/donation.css
+++ b/static/admin/donation.css
@@ -1,0 +1,4 @@
+.model-donation .field-comment {
+  max-width: 20vw;
+  overflow-wrap: break-word;
+}

--- a/static/adminprocessing.css
+++ b/static/adminprocessing.css
@@ -1,5 +1,14 @@
 .disableClick {
   text-decoration: none;
-  color: #000 !important; 
+  color: #000 !important;
   pointer-events: none;
+}
+
+td {
+  padding: 5px;
+}
+
+.donationcell {
+  max-width: 60vw;
+  overflow-wrap: break-word;
 }

--- a/templates/admin/automail_prize_contributors.html
+++ b/templates/admin/automail_prize_contributors.html
@@ -7,7 +7,7 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_contributors_post.html
+++ b/templates/admin/automail_prize_contributors_post.html
@@ -9,7 +9,7 @@
 
 <link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
 <script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_winners.html
+++ b/templates/admin/automail_prize_winners.html
@@ -7,7 +7,7 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_winners_accept_notifications.html
+++ b/templates/admin/automail_prize_winners_accept_notifications.html
@@ -7,7 +7,7 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_winners_accept_notifications_post.html
+++ b/templates/admin/automail_prize_winners_accept_notifications_post.html
@@ -9,7 +9,7 @@
 
 <link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
 <script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_winners_post.html
+++ b/templates/admin/automail_prize_winners_post.html
@@ -9,7 +9,7 @@
 
 <link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
 <script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_winners_shipping_notifications.html
+++ b/templates/admin/automail_prize_winners_shipping_notifications.html
@@ -7,7 +7,7 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/automail_prize_winners_shipping_notifications_post.html
+++ b/templates/admin/automail_prize_winners_shipping_notifications_post.html
@@ -9,7 +9,7 @@
 
 <link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
 <script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 {% endblock %}

--- a/templates/admin/process_donations.html
+++ b/templates/admin/process_donations.html
@@ -7,13 +7,7 @@
 {% block nav %}{% endblock %}
 {% block head %}
 
-<style>
-td {
-  padding: 5px;
-}
-</style>
-
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 
@@ -67,7 +61,7 @@ function addRow(donation) {
 
   row.append($("<td>").append(makeAnchor(donation['fields']['donor__public'], trackerAPI.createAdminEditURL('donor', parseInt(donation['fields']['donor'])))));
   row.append($("<td>").append(makeAnchor(asMoney(donation['fields']['amount']), trackerAPI.createAdminEditURL('donation', id))));
-  row.append($("<td>").append(safeHtml(donation['fields']['comment'])));
+  row.append($("<td class='donationcell'>").append(safeHtml(donation['fields']['comment'])));
   row.append($("<td>")
     .append(makeEditButton(row, donation, "Approve Comment Only", "Comment Approved", { readstate: "IGNORED", commentstate: "APPROVED" }))
     .append(makeEditButton(row, donation, sendText, sentText, { readstate: readState, commentstate: "APPROVED" }))
@@ -84,7 +78,7 @@ function runSearch() {
 
   };
 
-  {% if user_can_approve and not current_event.use_one_step_screening %}
+  {% if user_can_approve and not currentEvent.use_one_step_screening %}
     if( $("#id_process_mode").val() === 'confirm' ) {
       searchParams['readstate'] = 'FLAGGED';
     } else {
@@ -157,7 +151,7 @@ function runSearch() {
   <option value="un">Unknown</option>
 </select>
 
-{% if not current_event.use_one_step_screening and user_can_approve %}
+{% if user_can_approve and not currentEvent.use_one_step_screening %}
 <label>Processing Mode</label>
 <select id="id_process_mode">
   <option value="confirm">Confirmation</option>

--- a/templates/admin/process_pending_bids.html
+++ b/templates/admin/process_pending_bids.html
@@ -12,7 +12,7 @@ td {
 }
 </style>
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 <script>

--- a/templates/admin/process_prize_submissions.html
+++ b/templates/admin/process_prize_submissions.html
@@ -12,7 +12,7 @@ td {
 }
 </style>
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 <script>

--- a/templates/admin/read_donations.html
+++ b/templates/admin/read_donations.html
@@ -7,13 +7,7 @@
 {% block nav %}{% endblock %}
 {% block head %}
 
-<style>
-td {
-  padding: 5px;
-}
-</style>
-
-<link href="{% static "adminprocessing.css" %}" type="text/css" media="ajax" rel="stylesheet" />
+<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
 <script src="{% static "adminprocessing.js" %}"></script>
 
 <script>
@@ -63,7 +57,7 @@ function addRow(donation) {
 
   row.append($("<td>").append(makeAnchor(donation['fields']['donor__public'], trackerAPI.createAdminEditURL('donor', parseInt(donation['fields']['donor'])))));
   row.append($("<td>").append(makeAnchor(asMoney(donation['fields']['amount']), trackerAPI.createAdminEditURL('donation', id))));
-  row.append($("<td>").append(safeHtml(donation['fields']['comment'])));
+  row.append($("<td class='donationcell'>").append(safeHtml(donation['fields']['comment'])));
 
   var buttons = $("<td>");
   buttons


### PR DESCRIPTION
# Contributing to the Donation Tracker

- ~~I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

It's a style change.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/169941581

### Description of the Change

Put a simple cap on the maximum width of the donation comment column in the processing flow. Just a visual change.

### Possible Drawbacks

If somebody forgets to run `collectstatic` they won't see the change since it's purely css.

### Verification Process

Opened the admin page, read donations, and process donations, with a massive donation comment, and it looked much better in all three places.