### PR TITLE
[#169196626] fix runner-by-event filter

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -665,7 +665,7 @@ def run_model_query(model, params={}, user=None, mode='user'):
     if 'feed' in params:
         filtered = apply_feed_filter(filtered, model, params['feed'], params, user=user)
 
-    return filtered
+    return filtered.distinct()
 
 
 def user_restriction_filter(model):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/169196626

### Description of the Change

This PR was intended to add support for searching the Runner api by `event`, (i.e. only people who have at least one run). Looks like I half-added that in another PR (#135) by accident (oops), but it was broken, because it would return duplicate results if a runner had more than one run.

### Possible Drawbacks

I added a `distinct` filter to all queries from the search api, and if somehow this breaks something I'm going to be very cross with the universe.

### Verification Process

Hit the API with requests and verified that only runners with a run in the event showed up.