### PR TITLE
[#169747249] reverse the order of events dropdown and cap height

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -58,12 +58,12 @@
                     <li><a href="{% url 'tracker:donationindex' event=event.short %}">{% trans "Donations" %}</a></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Events <span class="caret"></span></a>
-                        <ul class="dropdown-menu small">
-                            {% for ev in events %}
+                        <ul class="dropdown-menu small panel-max-height">
+                            <li><a href="{% url 'tracker:index_all' %}">{% trans "All Events" %}</a></li>
+                            <li role="separator" class="divider"></li>
+                            {% for ev in events reversed %}
                                 <li><a href="{% url 'tracker:index' event=ev.short %}">{{ ev.name }}</a></li>
                             {% endfor %}
-                            <li role="separator" class="divider"></li>
-                            <li><a href="{% url 'tracker:index_all' %}">{% trans "All Events" %}</a></li>
                         </ul>
                     </li>
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

- ~~I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

Just another style/layout change. 

"The view is a side effect."

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/169747249

### Description of the Change

The live GDQ dropdown is getting super tall and people have complained about it being harder to get what you want on smaller screens, especially since what you actually want was usually at the bottom.

### Possible Drawbacks

People will complain about anything and they might complain about a dropdown's order getting reversed.

### Verification Process

Opened the page and made sure it didn't light on fire.