### PR TITLE
Add complete frontend CI processing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ pool:
 
 jobs:
   - job: tracker_backend_tests
+    dependsOn: []
     displayName: Tracker Backend
     strategy:
       matrix:
@@ -96,6 +97,7 @@ jobs:
         condition: succeededOrFailed()
 
   - job: tracker_frontend_tests
+    dependsOn: []
     displayName: Tracker Frontend
     continueOnError: true
     variables:
@@ -114,11 +116,14 @@ jobs:
       - displayName: 'build'
         script: yarn build
 
-      - displayName: 'prettier'
+      - displayName: 'Formatting (prettier)'
         script: yarn prettier
 
-      - displayName: 'typescript'
+      - displayName: 'Typechecking (typescript)'
         script: yarn tsc
 
-      - displayName: 'eslint'
+      - displayName: 'Linting (eslint)'
         script: yarn lint
+
+      - displayName: 'tests (Karma)'
+        script: yarn test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,20 +110,20 @@ jobs:
           path: $(YARN_CACHE_FOLDER)
         displayName: 'Cache yarn'
 
-      - displayName: 'yarn install'
-        script: yarn --frozen-lockfile
+      - script: yarn --frozen-lockfile
+        displayName: 'yarn install'
 
-      - displayName: 'build'
-        script: yarn build
+      - script: yarn build
+        displayName: 'build'
 
-      - displayName: 'Formatting (prettier)'
-        script: yarn prettier
+      - script: yarn prettier
+        displayName: 'Formatting (prettier)'
 
-      - displayName: 'Typechecking (typescript)'
-        script: yarn tsc
+      - script: yarn tsc
+        displayName: 'Typechecking (typescript)'
 
-      - displayName: 'Linting (eslint)'
-        script: yarn lint
+      - script: yarn lint
+        displayName: 'Linting (eslint)'
 
-      - displayName: 'tests (Karma)'
-        script: yarn test
+      - script: yarn test
+        displayName: 'tests (Karma)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,90 +3,122 @@ trigger:
 
 pool:
   vmImage: 'ubuntu-latest'
-strategy:
-  matrix:
-    Python36:
-      PYTHON_VERSION: '3.6'
-    Python37:
-      PYTHON_VERSION: '3.7'
 
-variables:
-  TOPLEVEL_REVISION: 947450932a0f68cb79222f5964aad319f99d9abf
+jobs:
+  - job: tracker_backend_tests
+    displayName: Tracker Backend
+    strategy:
+      matrix:
+        Python36:
+          PYTHON_VERSION: '3.6'
+        Python37:
+          PYTHON_VERSION: '3.7'
 
-steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(PYTHON_VERSION)'
-      architecture: 'x64'
+    variables:
+      TOPLEVEL_REVISION: 947450932a0f68cb79222f5964aad319f99d9abf
 
-  - script: |
-      mv -v $(Build.SourcesDirectory) $(Agent.BuildDirectory)/tracker
-      git clone git://github.com/GamesDoneQuick/donation-tracker-toplevel $(Build.SourcesDirectory)
-      cd $(Build.SourcesDirectory)
-      git reset --hard $(TOPLEVEL_REVISION)
-      mv -v $(Agent.BuildDirectory)/tracker $(Build.SourcesDirectory)
-      cp -v tracker/ci/local.py $(Build.SourcesDirectory)/local.py
-    displayName: 'Install toplevel around the tracker'
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '$(PYTHON_VERSION)'
+          architecture: 'x64'
 
-  - task: PythonScript@0
-    displayName: 'Export project path'
-    inputs:
-      scriptSource: 'inline'
-      script: |
-        """Search all subdirectories for `manage.py`."""
-        from glob import iglob
-        from os import path
-        manage_py = next(iglob(path.join('**', 'manage.py'), recursive=True), None)
-        if not manage_py:
-            raise SystemExit('Could not find a Django project')
-        project_location = path.dirname(path.abspath(manage_py))
-        print('Found Django project in', project_location)
-        print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
+      - script: |
+          mv -v $(Build.SourcesDirectory) $(Agent.BuildDirectory)/tracker
+          git clone git://github.com/GamesDoneQuick/donation-tracker-toplevel $(Build.SourcesDirectory)
+          cd $(Build.SourcesDirectory)
+          git reset --hard $(TOPLEVEL_REVISION)
+          mv -v $(Agent.BuildDirectory)/tracker $(Build.SourcesDirectory)
+          cp -v tracker/ci/local.py $(Build.SourcesDirectory)/local.py
+        displayName: 'Install toplevel around the tracker'
 
-  - task: CacheBeta@1
-    inputs:
-      key: pip | $(Agent.OS) | tracker/requirements.txt
-      path: $(Pipeline.Workspace)/../../.cache/pip
-    displayName: 'Cache pip'
+      - task: PythonScript@0
+        displayName: 'Export project path'
+        inputs:
+          scriptSource: 'inline'
+          script: |
+            """Search all subdirectories for `manage.py`."""
+            from glob import iglob
+            from os import path
+            manage_py = next(iglob(path.join('**', 'manage.py'), recursive=True), None)
+            if not manage_py:
+                raise SystemExit('Could not find a Django project')
+            project_location = path.dirname(path.abspath(manage_py))
+            print('Found Django project in', project_location)
+            print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
 
-  - script: |
-      python -m pip install --upgrade pip setuptools wheel
-      pip install -r requirements.txt
-      pip install unittest-xml-reporting tblib
-    displayName: 'Install python prerequisites'
+      - task: CacheBeta@1
+        inputs:
+          key: pip | $(Agent.OS) | tracker/requirements.txt
+          path: $(Pipeline.Workspace)/../../.cache/pip
+        displayName: 'Cache pip'
 
-  - task: CacheBeta@1
-    inputs:
-      key: yarn | $(Agent.OS) | tracker/yarn.lock
-      path: $(Build.SourcesDirectory)/tracker/node_modules
-    displayName: 'Cache yarn'
+      - script: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+          pip install unittest-xml-reporting tblib
+        displayName: 'Install python prerequisites'
 
-  - script: |
-      cd tracker
-      yarn install
-    displayName: 'Install node prerequisites'
+      - task: CacheBeta@1
+        inputs:
+          key: yarn | $(Agent.OS) | tracker/yarn.lock
+          path: $(Build.SourcesDirectory)/tracker/node_modules
+        displayName: 'Cache yarn'
 
-  - script: |
-      pushd '$(projectRoot)'
-      mkdir db
-      python manage.py migrate tracker
-      python manage.py makemigrations --check --dry-run tracker
-    displayName: 'Check for bad or missing migrations'
+      - script: |
+          cd tracker
+          yarn install --frozen-lockfile
+        displayName: 'Install node prerequisites'
 
-  - script: |
-      cd tracker
-      yarn build
-    displayName: 'Generate webpack manifest'
+      - script: |
+          pushd '$(projectRoot)'
+          mkdir db
+          python manage.py migrate tracker
+          python manage.py makemigrations --check --dry-run tracker
+        displayName: 'Check for bad or missing migrations'
 
-  - script: |
-      pushd '$(projectRoot)'
-      python manage.py test --parallel \
-        --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner \
-        --no-input
-    displayName: 'Run Django tests'
+      - script: |
+          cd tracker
+          yarn build
+        displayName: 'Generate webpack manifest'
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/TEST-*.xml'
-      testRunTitle: 'Python $(PYTHON_VERSION)'
-    condition: succeededOrFailed()
+      - script: |
+          pushd '$(projectRoot)'
+          python manage.py test --parallel \
+            --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner \
+            --no-input
+        displayName: 'Run Django tests'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: '**/TEST-*.xml'
+          testRunTitle: 'Python $(PYTHON_VERSION)'
+        condition: succeededOrFailed()
+
+  - job: tracker_frontend_tests
+    displayName: Tracker Frontend
+    continueOnError: true
+    variables:
+      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
+    steps:
+      - task: Cache@2
+        inputs:
+          key: yarn | $(Agent.OS) | yarn.lock
+          path: $(YARN_CACHE_FOLDER)
+        displayName: 'Cache yarn'
+
+      - displayName: 'yarn install'
+        script: yarn --frozen-lockfile
+
+      - displayName: 'build'
+        script: yarn build
+
+      - displayName: 'prettier'
+        script: yarn prettier
+
+      - displayName: 'typescript'
+        script: yarn tsc
+
+      - displayName: 'eslint'
+        script: yarn lint

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-- master
+  - master
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -14,79 +14,79 @@ variables:
   TOPLEVEL_REVISION: 947450932a0f68cb79222f5964aad319f99d9abf
 
 steps:
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '$(PYTHON_VERSION)'
-    architecture: 'x64'
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(PYTHON_VERSION)'
+      architecture: 'x64'
 
-- script: |
-    mv -v $(Build.SourcesDirectory) $(Agent.BuildDirectory)/tracker
-    git clone git://github.com/GamesDoneQuick/donation-tracker-toplevel $(Build.SourcesDirectory)
-    cd $(Build.SourcesDirectory)
-    git reset --hard $(TOPLEVEL_REVISION)
-    mv -v $(Agent.BuildDirectory)/tracker $(Build.SourcesDirectory)
-    cp -v tracker/ci/local.py $(Build.SourcesDirectory)/local.py
-  displayName: 'Install toplevel around the tracker'
+  - script: |
+      mv -v $(Build.SourcesDirectory) $(Agent.BuildDirectory)/tracker
+      git clone git://github.com/GamesDoneQuick/donation-tracker-toplevel $(Build.SourcesDirectory)
+      cd $(Build.SourcesDirectory)
+      git reset --hard $(TOPLEVEL_REVISION)
+      mv -v $(Agent.BuildDirectory)/tracker $(Build.SourcesDirectory)
+      cp -v tracker/ci/local.py $(Build.SourcesDirectory)/local.py
+    displayName: 'Install toplevel around the tracker'
 
-- task: PythonScript@0
-  displayName: 'Export project path'
-  inputs:
-    scriptSource: 'inline'
-    script: |
-      """Search all subdirectories for `manage.py`."""
-      from glob import iglob
-      from os import path
-      manage_py = next(iglob(path.join('**', 'manage.py'), recursive=True), None)
-      if not manage_py:
-          raise SystemExit('Could not find a Django project')
-      project_location = path.dirname(path.abspath(manage_py))
-      print('Found Django project in', project_location)
-      print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
+  - task: PythonScript@0
+    displayName: 'Export project path'
+    inputs:
+      scriptSource: 'inline'
+      script: |
+        """Search all subdirectories for `manage.py`."""
+        from glob import iglob
+        from os import path
+        manage_py = next(iglob(path.join('**', 'manage.py'), recursive=True), None)
+        if not manage_py:
+            raise SystemExit('Could not find a Django project')
+        project_location = path.dirname(path.abspath(manage_py))
+        print('Found Django project in', project_location)
+        print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
 
-- task: CacheBeta@1
-  inputs:
-    key: pip | $(Agent.OS) | tracker/requirements.txt
-    path: $(Pipeline.Workspace)/../../.cache/pip
-  displayName: 'Cache pip'
+  - task: CacheBeta@1
+    inputs:
+      key: pip | $(Agent.OS) | tracker/requirements.txt
+      path: $(Pipeline.Workspace)/../../.cache/pip
+    displayName: 'Cache pip'
 
-- script: |
-    python -m pip install --upgrade pip setuptools wheel
-    pip install -r requirements.txt
-    pip install unittest-xml-reporting tblib
-  displayName: 'Install python prerequisites'
+  - script: |
+      python -m pip install --upgrade pip setuptools wheel
+      pip install -r requirements.txt
+      pip install unittest-xml-reporting tblib
+    displayName: 'Install python prerequisites'
 
-- task: CacheBeta@1
-  inputs:
-    key: yarn | $(Agent.OS) | tracker/yarn.lock
-    path: $(Build.SourcesDirectory)/tracker/node_modules
-  displayName: 'Cache yarn'
+  - task: CacheBeta@1
+    inputs:
+      key: yarn | $(Agent.OS) | tracker/yarn.lock
+      path: $(Build.SourcesDirectory)/tracker/node_modules
+    displayName: 'Cache yarn'
 
-- script: |
-    cd tracker
-    yarn install
-  displayName: 'Install node prerequisites'
+  - script: |
+      cd tracker
+      yarn install
+    displayName: 'Install node prerequisites'
 
-- script: |
-    pushd '$(projectRoot)'
-    mkdir db
-    python manage.py migrate tracker
-    python manage.py makemigrations --check --dry-run tracker
-  displayName: 'Check for bad or missing migrations'
+  - script: |
+      pushd '$(projectRoot)'
+      mkdir db
+      python manage.py migrate tracker
+      python manage.py makemigrations --check --dry-run tracker
+    displayName: 'Check for bad or missing migrations'
 
-- script: |
-    cd tracker
-    yarn build
-  displayName: 'Generate webpack manifest'
+  - script: |
+      cd tracker
+      yarn build
+    displayName: 'Generate webpack manifest'
 
-- script: |
-    pushd '$(projectRoot)'
-    python manage.py test --parallel \
-      --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner \
-      --no-input
-  displayName: 'Run Django tests'
+  - script: |
+      pushd '$(projectRoot)'
+      python manage.py test --parallel \
+        --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner \
+        --no-input
+    displayName: 'Run Django tests'
 
-- task: PublishTestResults@2
-  inputs:
-    testResultsFiles: "**/TEST-*.xml"
-    testRunTitle: 'Python $(PYTHON_VERSION)'
-  condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/TEST-*.xml'
+      testRunTitle: 'Python $(PYTHON_VERSION)'
+    condition: succeededOrFailed()

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "fix:lint": "yarn lint --fix",
     "fix:all": "yarn fix:prettier && yarn fix:lint",
     "lint": "eslint bundles spec --ext js --ext jsx --ext ts --ext tsx --quiet",
+    "prettier": "prettier --check \"bundles/**\"",
     "yarn:install": "yarn install",
     "tsc": "tsc --version && tsc",
     "tsc:watch": "tsc --version && tsc --watch"


### PR DESCRIPTION
### Description of the Change

Implementing https://github.com/GamesDoneQuick/donation-tracker/pull/144#issuecomment-562415143, CI now runs the frontend tests, typescript, eslint, and prettier 

The frontend tests are also moved into a new job that can run in parallel with the backend tests and doesn't get run twice unnecessarily as part of the python version matrix.

Most of the changes in this are formatting the YAML file via prettier. That's done in the first commit, so you can just read the later commits to see what's actually changed.