### PR TITLE
Fix `fetchPrizes` filtering with simpler types and more accurate loading

### DIFF
--- a/bundles/tracker/prizes/PrizeActions.ts
+++ b/bundles/tracker/prizes/PrizeActions.ts
@@ -96,11 +96,11 @@ function prizeFromAPIPrize({ pk, fields }: { pk: number; fields: { [field: strin
   };
 }
 
-export function fetchPrizes(filters: PrizeSearchFilter = {}) {
+export function fetchPrizes(filter: PrizeSearchFilter = {}) {
   return (dispatch: SafeDispatch) => {
     dispatch({ type: ActionTypes.FETCH_PRIZES_STARTED });
 
-    return HTTPUtils.get(Endpoints.SEARCH, { ...filters, type: 'prize' })
+    return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'prize' })
       .then((data: Array<any>) => {
         const prizes = data.map(prizeFromAPIPrize);
 

--- a/bundles/tracker/prizes/PrizeTypes.ts
+++ b/bundles/tracker/prizes/PrizeTypes.ts
@@ -60,7 +60,7 @@ export type Prize = {
 export type PrizeSearchFilter = {
   id?: string;
   name?: string;
-  // maps to `prize.eventId` or `prize.event.short`
+  // maps to `prize.eventId`
   event?: string;
 };
 

--- a/bundles/tracker/prizes/PrizeTypes.ts
+++ b/bundles/tracker/prizes/PrizeTypes.ts
@@ -60,27 +60,8 @@ export type Prize = {
 export type PrizeSearchFilter = {
   id?: string;
   name?: string;
-  description?: string;
-  shortDescription?: string;
-  prizeWinnerId?: string;
-  provider?: string;
-  eventId?: string;
-  eventShortName?: string;
-  eventName?: string;
-  locked?: boolean;
-  categoryId?: string;
-  categoryName?: string;
-  startRunId?: string;
-  endRunId?: string;
-  startsBefore?: DateTime;
-  startsAfter?: DateTime;
-  endsBefore?: DateTime;
-  endsAfter?: DateTime;
-  sumDonations?: boolean;
-  randomDraw?: boolean;
-  state?: string;
-  handlerId?: string;
-  creatorId?: string;
+  // maps to `prize.eventId` or `prize.event.short`
+  event?: string;
 };
 
 export type PrizeAction =

--- a/bundles/tracker/prizes/components/Prizes.tsx
+++ b/bundles/tracker/prizes/components/Prizes.tsx
@@ -54,6 +54,8 @@ const Prizes = (props: PrizesProps) => {
 
   const now = TimeUtils.getNowLocal();
 
+  const [loadingPrizes, setLoadingPrizes] = React.useState(false);
+
   const { availableNow, closingPrizes, allPrizes, event } = useSelector((state: StoreState) => ({
     availableNow: PrizeStore.getPrizesOpeningSoon(state, { targetTime: now }).slice(0, FEATURED_SECTION_LIMIT),
     closingPrizes: PrizeStore.getPrizesClosingSoon(state, { targetTime: now }).slice(0, FEATURED_SECTION_LIMIT),
@@ -62,7 +64,8 @@ const Prizes = (props: PrizesProps) => {
   }));
 
   React.useEffect(() => {
-    dispatch(PrizeActions.fetchPrizes({ eventId }));
+    setLoadingPrizes(true);
+    dispatch(PrizeActions.fetchPrizes({ event: eventId })).finally(() => setLoadingPrizes(false));
   }, [eventId]);
 
   React.useEffect(() => {
@@ -70,7 +73,7 @@ const Prizes = (props: PrizesProps) => {
     dispatch(EventActions.fetchEvents({ id: eventId }));
   }, [event, eventId]);
 
-  if (event == null)
+  if (event == null) {
     return (
       <Container size={Container.Sizes.WIDE}>
         <div className={styles.loadingDots}>
@@ -78,25 +81,34 @@ const Prizes = (props: PrizesProps) => {
         </div>
       </Container>
     );
+  }
 
   return (
     <Container size={Container.Sizes.WIDE}>
       <Header size={Header.Sizes.H1} className={styles.pageHeader}>
         Prizes for <span className={styles.eventName}>{event.name}</span>
       </Header>
-      {closingPrizes.length > 0 && (
+      {!loadingPrizes ? (
         <React.Fragment>
-          <PrizeGrid prizes={closingPrizes} name="Closing Soon!" />
-          <hr className={styles.divider} />
+          {closingPrizes.length > 0 && (
+            <React.Fragment>
+              <PrizeGrid prizes={closingPrizes} name="Closing Soon!" />
+              <hr className={styles.divider} />
+            </React.Fragment>
+          )}
+          {availableNow.length > 0 && (
+            <React.Fragment>
+              <PrizeGrid prizes={availableNow} name="Available Now" />
+              <hr className={styles.divider} />
+            </React.Fragment>
+          )}
+          <PrizeGrid prizes={allPrizes} name="All Prizes" />
         </React.Fragment>
+      ) : (
+        <div className={styles.loadingDots}>
+          <LoadingDots width="100%" />
+        </div>
       )}
-      {availableNow.length > 0 && (
-        <React.Fragment>
-          <PrizeGrid prizes={availableNow} name="Available Now" />
-          <hr className={styles.divider} />
-        </React.Fragment>
-      )}
-      <PrizeGrid prizes={allPrizes} name="All Prizes" />
     </Container>
   );
 };


### PR DESCRIPTION
### Description of the Change

`PrizeSearchFilter` was using camelCase names to match the TS-style properties they map to on the front end, but the API expects mainly fastlowercase names for query fields. I also realized I honestly have no idea what is and isn't a valid filter for anything lol, so I just took out all of my guessing and left in the very basics the frontend needs to filter right now, and more can just be added as needed.

I also changed the loading behavior of the `Prizes` page to show loading dots under the "All Prizes" section while prizes are loading.

### Possible Drawbacks

You'll have to add filter types if you need them later idk /shrug

### Verification Process

Tested API directly and tested various event pages for Prizes themselves.