### PR TITLE
Explicitly handle Prizes with no image

### DIFF
--- a/bundles/tracker/prizes/components/Prize.mod.css
+++ b/bundles/tracker/prizes/components/Prize.mod.css
@@ -25,9 +25,20 @@
   object-fit: contain;
 }
 
+.noImage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 80%;
+  min-height: 120px;
+  max-height: 240px;
+  background-color: var(--background-secondary);
+}
+
 .content {
   flex: 1 1 55%;
-  padding: 0 8px;
+  padding: 8px;
 }
 
 .prizeHeader {

--- a/bundles/tracker/prizes/components/Prize.tsx
+++ b/bundles/tracker/prizes/components/Prize.tsx
@@ -124,6 +124,7 @@ const Prize = (props: PrizeProps) => {
     );
 
   const prizeDetails = getPrizeDetails(prize);
+  const prizeImage = PrizeUtils.getPrimaryImage(prize);
 
   const handleBack = () => {
     RouterUtils.navigateTo(Routes.EVENT_PRIZES(prize.eventId));
@@ -133,7 +134,15 @@ const Prize = (props: PrizeProps) => {
     <Container size={Container.Sizes.WIDE}>
       <div className={styles.container}>
         <div className={styles.gallery}>
-          <img className={styles.image} src={PrizeUtils.getPrimaryImage(prize)} />
+          {prizeImage != null ? (
+            <img className={styles.image} src={prizeImage} />
+          ) : (
+            <div className={styles.noImage}>
+              <Header size={Header.Sizes.H4} color={Header.Colors.MUTED}>
+                No Image Provided
+              </Header>
+            </div>
+          )}
         </div>
         <div className={styles.content}>
           <div className={styles.summary}>

--- a/bundles/tracker/prizes/components/PrizeCard.mod.css
+++ b/bundles/tracker/prizes/components/PrizeCard.mod.css
@@ -53,7 +53,7 @@
   opacity: 0;
   transition: opacity 0.12s ease-in;
 
-  @nest .imageWrap:hover &, .imageWrap:focus & {
+  @nest .card:hover &, .card:focus & {
     opacity: 1;
   }
 }

--- a/bundles/tracker/prizes/components/PrizeCard.mod.css
+++ b/bundles/tracker/prizes/components/PrizeCard.mod.css
@@ -34,6 +34,18 @@
   object-fit: cover;
 }
 
+.noCoverImage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
 .viewDetailsButton {
   position: absolute;
   bottom: 8px;

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -37,10 +37,20 @@ const PrizeCard = (props: PrizeCardProps) => {
     return <div className={styles.card} />;
   }
 
+  const coverImage = PrizeUtils.getPrimaryImage(prize);
+
   return (
     <div className={classNames(styles.card, className)}>
       <Clickable className={styles.imageWrap} onClick={() => handleViewPrize(prize)}>
-        <img className={styles.coverImage} src={PrizeUtils.getPrimaryImage(prize)} />
+        {coverImage != null ? (
+          <img className={styles.coverImage} src={coverImage} />
+        ) : (
+          <div className={styles.noCoverImage}>
+            <Header size={Header.Sizes.H4} color={Header.Colors.MUTED}>
+              No Image Provided
+            </Header>
+          </div>
+        )}
         <Button className={styles.viewDetailsButton} tabIndex={-1}>
           View Details
         </Button>

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -40,8 +40,8 @@ const PrizeCard = (props: PrizeCardProps) => {
   const coverImage = PrizeUtils.getPrimaryImage(prize);
 
   return (
-    <div className={classNames(styles.card, className)}>
-      <Clickable className={styles.imageWrap} onClick={() => handleViewPrize(prize)}>
+    <Clickable className={classNames(styles.card, className)} onClick={() => handleViewPrize(prize)}>
+      <div className={styles.imageWrap}>
         {coverImage != null ? (
           <img className={styles.coverImage} src={coverImage} />
         ) : (
@@ -54,7 +54,7 @@ const PrizeCard = (props: PrizeCardProps) => {
         <Button className={styles.viewDetailsButton} tabIndex={-1}>
           View Details
         </Button>
-      </Clickable>
+      </div>
       <div className={styles.content}>
         <Header className={styles.prizeName} size={Header.Sizes.H5}>
           {prize.public}
@@ -75,7 +75,7 @@ const PrizeCard = (props: PrizeCardProps) => {
           {prize.sumDonations ? 'Total Donations' : 'Minimum Donation'}
         </Text>
       </div>
-    </div>
+    </Clickable>
   );
 };
 


### PR DESCRIPTION
It was somewhat assumed that prizes would always have at least one image, but that's not necessarily the case. Both `PrizeCard` and `Prize` now explicitly handle the case where a prize has no image and render a "No Image Provided" placeholder that fits the theme of the page.

It also makes the entirety of `PrizeCard` clickable to view prizes, since that is a more common interaction on mobile (instead of just having the image be clickable), and adds some padding to the Prize detail content to make it less jarring with the top of the prize image next to it.

![image](https://user-images.githubusercontent.com/783733/71056778-560add00-210f-11ea-815b-5409e530944d.png)
![image](https://user-images.githubusercontent.com/783733/71056785-5acf9100-210f-11ea-81c9-93205031b596.png)
![image](https://user-images.githubusercontent.com/783733/71056797-628f3580-210f-11ea-838c-bb9c53053991.png)
