### PR TITLE
passing too high of a `limit` param to search api is an error

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,6 @@ import json
 import random
 
 import pytz
-from django.conf import settings
 from django.contrib.admin.models import (
     LogEntry,
     ADDITION as LogEntryADDITION,
@@ -170,9 +169,8 @@ class TestGeneric(APITestCase):
 
         request = self.factory.get('/api/v1/search', dict(type='donation', limit=30),)
         request.user = self.anonymous_user
-        data = self.parseJSON(tracker.views.api.search(request))
-        # settings wins if too many are requested
-        self.assertEqual(len(data), settings.TRACKER_PAGINATION_LIMIT)
+        # bad request if limit is set above server config
+        self.parseJSON(tracker.views.api.search(request), status_code=400)
 
     def test_add_log(self):
         request = self.factory.post(


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170373232

### Description of the Change

After some discussion with Lange I decided it made more sense to return an error if the `limit` parameter was set above the server config, rather than silently truncating it. Makes it easier to decide if you need to actually paginate, given the lack of meta-info.

I also took the time to clean up the wrappers around the API a bit.

### Possible Drawbacks

The actual diff is hard to read because of the changed indentation.

### Verification Process

Hit the API with a `limit` parameter that was too high and observed the resulting error.