### PR TITLE
[semi-wip] Add pep8-naming for enforcing python naming conventions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,5 +4,6 @@ max-line-length = 120
 # W503 is superceded by W504 (multline operator positioning)
 # E203 conflicts with black (spaces between colons in slice notation)
 # E231 conflicts with black (spaces after commas in some situations)
-select = C,E,F,W,B,B950
+# N rules are from pep8-naming
+select = C,E,F,W,B,B950,N
 ignore = W503,E203,E501,E231

--- a/admin/bid.py
+++ b/admin/bid.py
@@ -72,17 +72,17 @@ class BidAdmin(CustomModelAdmin):
     inlines = [BidOptionInline, BidDependentsInline]
 
     def parent_(self, obj):
-        targetObject = None
+        target_object = None
         if obj.parent:
-            targetObject = obj.parent
+            target_object = obj.parent
         elif obj.speedrun:
-            targetObject = obj.speedrun
+            target_object = obj.speedrun
         elif obj.event:
-            targetObject = obj.event
-        if targetObject:
+            target_object = obj.event
+        if target_object:
             return mark_safe(
                 '<a href={0}>{1}</a>'.format(
-                    str(viewutil.admin_url(targetObject)), targetObject
+                    str(viewutil.admin_url(target_object)), target_object
                 )
             )
         else:
@@ -214,12 +214,12 @@ class BidAdmin(CustomModelAdmin):
     @staticmethod
     @permission_required('tracker.change_bid')
     def process_pending_bids(request):
-        currentEvent = viewutil.get_selected_event(request)
+        current_event = viewutil.get_selected_event(request)
         return render(
             request,
             'admin/process_pending_bids.html',
             {
-                'currentEvent': currentEvent,
+                'currentEvent': current_event,
                 'apiUrls': mark_safe(json.dumps(api_urls())),
             },
         )

--- a/admin/donation.py
+++ b/admin/donation.py
@@ -223,12 +223,12 @@ class DonationAdmin(CustomModelAdmin):
     @staticmethod
     @permission_required(('tracker.change_donor', 'tracker.change_donation'))
     def read_donations(request):
-        currentEvent = viewutil.get_selected_event(request)
+        current_event = viewutil.get_selected_event(request)
         return render(
             request,
             'admin/read_donations.html',
             {
-                'currentEvent': currentEvent,
+                'currentEvent': current_event,
                 'apiUrls': mark_safe(json.dumps(api_urls())),
             },
         )

--- a/admin/filters.py
+++ b/admin/filters.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import SimpleListFilter, models as admin_models
 
 from tracker import search_feeds
-from .util import ReadOffsetTokenPair
+from .util import read_offset_token_pair
 
 
 class PrizeListFilter(SimpleListFilter):
@@ -19,7 +19,7 @@ class PrizeListFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value() is not None:
-            feed, params = ReadOffsetTokenPair(self.value())
+            feed, params = read_offset_token_pair(self.value())
             params['noslice'] = True
             return search_feeds.apply_feed_filter(
                 queryset, 'prize', feed, params, request.user
@@ -65,7 +65,7 @@ class RunListFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value() is not None:
-            feed, params = ReadOffsetTokenPair(self.value())
+            feed, params = read_offset_token_pair(self.value())
             params['noslice'] = True
             return search_feeds.apply_feed_filter(
                 queryset, 'run', feed, params, request.user
@@ -91,7 +91,7 @@ class DonationListFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value() is not None:
-            feed, params = ReadOffsetTokenPair(self.value())
+            feed, params = read_offset_token_pair(self.value())
             params['noslice'] = True
             return search_feeds.apply_feed_filter(
                 queryset, 'donation', feed, params, request.user
@@ -114,7 +114,7 @@ class BidListFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value() is not None:
-            feed, params = ReadOffsetTokenPair(self.value())
+            feed, params = read_offset_token_pair(self.value())
             params['noslice'] = True
             return search_feeds.apply_feed_filter(
                 queryset, 'bid', feed, params, request.user

--- a/admin/prize.py
+++ b/admin/prize.py
@@ -467,9 +467,9 @@ class PrizeAdmin(CustomModelAdmin):
                 prizewinners=prizewinners, data=request.POST
             )
             if form.is_valid():
-                for prizeWinner in form.cleaned_data['prizewinners']:
-                    prizeWinner.acceptdeadline = form.cleaned_data['acceptdeadline']
-                    prizeWinner.save()
+                for prize_winner in form.cleaned_data['prizewinners']:
+                    prize_winner.acceptdeadline = form.cleaned_data['acceptdeadline']
+                    prize_winner.save()
                 prizemail.automail_prize_winners(
                     current_event,
                     form.cleaned_data['prizewinners'],

--- a/admin/util.py
+++ b/admin/util.py
@@ -19,7 +19,7 @@ class CustomModelAdmin(AjaxSelectAdmin):
     pass
 
 
-def ReadOffsetTokenPair(value):
+def read_offset_token_pair(value):
     toks = value.split('-')
     feed = toks[0]
     params = {}

--- a/auth.py
+++ b/auth.py
@@ -23,17 +23,17 @@ class EmailLoginAuthBackend:
     supports_inactive_user = False
 
     def authenticate(self, request=None, username=None, password=None, email=None):
-        AUTH_METHODS = [
+        auth_methods = [
             {'email': username},
             {'email': email},
         ]
 
         try:
-            userFilter = AuthUser.objects.none()
-            for method in AUTH_METHODS:
-                userFilter = AuthUser.objects.filter(**method)
-                if userFilter.count() == 1:
-                    user = userFilter[0]
+            user_filter = AuthUser.objects.none()
+            for method in auth_methods:
+                user_filter = AuthUser.objects.filter(**method)
+                if user_filter.count() == 1:
+                    user = user_filter[0]
                     if user.check_password(password):
                         return user
         except Exception:
@@ -142,13 +142,16 @@ def send_auth_token_mail(
 ):
     if not sender:
         sender = viewutil.get_default_email_from_user()
-    formatContext = {
+    format_context = {
         'domain': domain,
         'user': user,
         'reset_url': mark_safe(confirm_url),
     }
     if extra_context:
-        formatContext.update(extra_context)
+        format_context.update(extra_context)
     return post_office.mail.send(
-        recipients=[user.email], sender=sender, template=template, context=formatContext
+        recipients=[user.email],
+        sender=sender,
+        template=template,
+        context=format_context,
     )

--- a/forms.py
+++ b/forms.py
@@ -85,18 +85,18 @@ class DonationCredentialsForm(forms.Form):
 class DonationEntryForm(forms.Form):
     def __init__(self, event=None, *args, **kwargs):
         super(DonationEntryForm, self).__init__(*args, **kwargs)
-        minDonationAmount = (
+        min_donation_amount = (
             event.minimumdonation if event is not None else Decimal('1.00')
         )
         self.fields['amount'] = forms.DecimalField(
             decimal_places=2,
-            min_value=minDonationAmount,
+            min_value=min_donation_amount,
             max_value=Decimal('100000'),
-            label='Donation Amount (min ${0})'.format(minDonationAmount),
+            label='Donation Amount (min ${0})'.format(min_donation_amount),
             widget=tracker.widgets.NumberInput(
                 attrs={
                     'id': 'iDonationAmount',
-                    'min': str(minDonationAmount),
+                    'min': str(min_donation_amount),
                     'step': '0.01',
                 }
             ),
@@ -224,13 +224,13 @@ class DonationBidFormSetBase(forms.BaseFormSet):
                 + str(DonationBidFormSetBase.max_bids)
                 + ' bids.'
             )
-        sumAmount = Decimal('0.00')
+        sum_amount = Decimal('0.00')
         bids = set()
         for form in self.forms:
             if 'bid' in form.cleaned_data:
                 if form.cleaned_data.get('amount', None):
-                    sumAmount += form.cleaned_data['amount']
-                if sumAmount > self.amount:
+                    sum_amount += form.cleaned_data['amount']
+                if sum_amount > self.amount:
                     form.errors['__all__'] = form.error_class(
                         ['Error, total bid amount cannot exceed donation amount.']
                     )
@@ -317,9 +317,11 @@ class MergeObjectsForm(forms.Form):
         super(MergeObjectsForm, self).__init__(*args, **kwargs)
         self.model = model
         self.choices = []
-        for objId in objects:
-            choice_name = '#%d: ' % objId + str(self.model.objects.get(id=objId))
-            self.choices.append((objId, choice_name))
+        for object_id in objects:
+            choice_name = '#%d: ' % object_id + str(
+                self.model.objects.get(id=object_id)
+            )
+            self.choices.append((object_id, choice_name))
         self.fields['root'] = forms.ChoiceField(choices=self.choices, required=True)
         self.fields['objects'] = forms.CharField(
             initial=','.join([str(i) for i in objects]), widget=forms.HiddenInput()
@@ -328,12 +330,12 @@ class MergeObjectsForm(forms.Form):
     def clean(self):
         root = self.model.objects.get(id=self.cleaned_data['root'])
         objects = []
-        for objId in [
+        for object_id in [
             int(x)
             for x in [x for x in self.cleaned_data['objects'].split(',') if bool(x)]
         ]:
-            if objId != root.id:
-                objects.append(self.model.objects.get(id=objId))
+            if object_id != root.id:
+                objects.append(self.model.objects.get(id=object_id))
         self.cleaned_data['root'] = root
         self.cleaned_data['objects'] = objects
         return self.cleaned_data
@@ -803,7 +805,7 @@ class RegistrationForm(forms.Form):
             username = email
             if len(username) > 30:
                 username = email[:30]
-            AuthUser = get_user_model()
+            AuthUser = get_user_model()  # noqa N806
             tries = 0
             while user is None and tries < 5:
                 try:
@@ -828,17 +830,17 @@ class RegistrationForm(forms.Form):
         )
 
     def get_existing_user(self):
-        AuthUser = get_user_model()
+        AuthUser = get_user_model()  # noqa N806
         email = self.cleaned_data['email']
-        userSet = AuthUser.objects.filter(email__iexact=email)
-        if userSet.count() > 1:
+        user_set = AuthUser.objects.filter(email__iexact=email)
+        if user_set.count() > 1:
             raise forms.ValidationError(
                 'More than one user has the e-mail {0}. Ideally this would be a db constraint, but django is stupid. Contact SMK to get this sorted out.'.format(
                     email
                 )
             )
-        if userSet.exists():
-            return userSet[0]
+        if user_set.exists():
+            return user_set[0]
         else:
             return None
 
@@ -885,7 +887,7 @@ class RegistrationConfirmationForm(forms.Form):
             return False
 
     def clean_username(self):
-        AuthUser = get_user_model()
+        AuthUser = get_user_model()  # noqa N806
         cleaned = AuthUser.normalize_username(self.cleaned_data['username'])
         existing = AuthUser.objects.filter(username__iexact=cleaned).exclude(
             pk=self.user.pk

--- a/lookups.py
+++ b/lookups.py
@@ -85,8 +85,8 @@ class CountryRegionLookup(LookupChannel):
 
 
 class GenericLookup(LookupChannel):
-    useLock = False
-    useEvent = False
+    use_lock = False
+    use_event = False
     extra_params = {}
 
     def get_extra_params(self, request):
@@ -96,10 +96,12 @@ class GenericLookup(LookupChannel):
         params = {'q': q}
         params.update(self.get_extra_params(request))
         event = viewutil.get_selected_event(request)
-        if event and self.useEvent:
+        if event and self.use_event:
             params['event'] = event.id
-        model = getattr(self, 'modelName', self.model)
-        if self.useLock and not request.user.has_perm('tracker.can_edit_locked_events'):
+        model = getattr(self, 'model_name', self.model)
+        if self.use_lock and not request.user.has_perm(
+            'tracker.can_edit_locked_events'
+        ):
             params['locked'] = False
         return filters.run_model_query(model, params, request.user)
 
@@ -123,33 +125,33 @@ class GenericLookup(LookupChannel):
 
 
 class BidLookup(GenericLookup):
-    useEvent = True
-    useLock = True
+    use_event = True
+    use_lock = True
     model = Bid
-    modelName = 'bid'
+    model_name = 'bid'
     extra_params = {'feed': 'all'}
 
 
 class AllBidLookup(GenericLookup):
-    useEvent = True
-    useLock = True
+    use_event = True
+    use_lock = True
     model = Bid
-    modelName = 'allbids'
+    model_name = 'allbids'
     extra_params = {'feed': 'all'}
 
 
 class BidTargetLookup(GenericLookup):
     model = Bid
-    modelName = 'bidtarget'
-    useEvent = True
-    useLock = True
+    model_name = 'bidtarget'
+    use_event = True
+    use_lock = True
     extra_params = {'feed': 'all'}
 
 
 class DonationLookup(GenericLookup):
     model = Donation
-    useEvent = True
-    useLock = True
+    use_event = True
+    use_lock = True
 
 
 class DonorLookup(GenericLookup):
@@ -158,18 +160,18 @@ class DonorLookup(GenericLookup):
 
 class PrizeLookup(GenericLookup):
     model = Prize
-    useEvent = True
+    use_event = True
 
 
 class RunLookup(GenericLookup):
     model = SpeedRun
-    useEvent = True
-    useLock = True
+    use_event = True
+    use_lock = True
 
 
 class EventLookup(GenericLookup):
     model = Event
-    useLock = True
+    use_lock = True
 
 
 class RunnerLookup(GenericLookup):

--- a/mailutil.py
+++ b/mailutil.py
@@ -12,8 +12,8 @@ def get_email_template(name, default=None):
 def get_or_create_email_template(name, default):
     'Get an email template, or fall back to creating one, using the provided name onto the default template' ''
     # the extra bookkeeping here is to ensure that `default` is not modified as a side-effect
-    oldPk = default.pk
-    oldId = default.id
+    old_pk = default.pk
+    old_id = default.id
     try:
         return post_office.models.EmailTemplate.objects.get(name=name)
     except post_office.models.EmailTemplate.DoesNotExist:
@@ -23,5 +23,5 @@ def get_or_create_email_template(name, default):
         default.save()
         return get_email_template(name)
     finally:
-        default.pk = oldPk
-        default.id = oldId
+        default.pk = old_pk
+        default.id = old_id

--- a/management/commands/default_email_templates.py
+++ b/management/commands/default_email_templates.py
@@ -17,32 +17,32 @@ _defaultTemplates = {
 
 def email_template_name(arg):
     parts = arg.partition(':')
-    templateObj = _defaultTemplates[parts[0]]
-    customName = None
+    template = _defaultTemplates[parts[0]]
+    custom_name = None
     if parts[1] == ':':
         if parts[2]:
-            customName = parts[2]
+            custom_name = parts[2]
         else:
             raise Exception('Must specify custom name after colon')
-    return (templateObj, customName)
+    return (template, custom_name)
 
 
 class Command(commandutil.TrackerCommand):
     help = 'Generates all default mail templates that are not currently in the database'
 
     def add_arguments(self, parser):
-        commandGroup = parser.add_mutually_exclusive_group(required=True)
-        commandGroup.add_argument(
+        command_group = parser.add_mutually_exclusive_group(required=True)
+        command_group.add_argument(
             '-l', '--list', help='List all default email templates', action='store_true'
         )
-        commandGroup.add_argument(
+        command_group.add_argument(
             '-c',
             '--create',
             help='Create the specified template(s) (use the format <default>:<name> to specify a custom name in the database)',
             nargs='+',
             type=email_template_name,
         )
-        commandGroup.add_argument(
+        command_group.add_argument(
             '-a',
             '--create-all',
             help='Create all known templates(s)',
@@ -63,10 +63,10 @@ class Command(commandutil.TrackerCommand):
             default='',
         )
 
-    def check_validity(self, createList, force=False):
-        currentNames = set()
-        for create in createList:
-            if create[1] in currentNames:
+    def check_validity(self, craete_list, force=False):
+        current_names = set()
+        for create in craete_list:
+            if create[1] in current_names:
                 raise Exception('Name {0} was specified twice'.format(create[1]))
             if (
                 not force
@@ -75,7 +75,7 @@ class Command(commandutil.TrackerCommand):
                 ).exists()
             ):
                 raise Exception('Name {0} already exsits in database'.format(create[1]))
-            currentNames.add(create[1])
+            current_names.add(create[1])
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
@@ -104,20 +104,20 @@ class Command(commandutil.TrackerCommand):
         for create in self.templates:
             found = post_office.models.EmailTemplate.objects.filter(name=create[1])
             if found.exists():
-                targetTemplate = found[0]
+                target_template = found[0]
                 self.message(
                     'Overwriting email template {0} (id={1})'.format(
-                        create[1], targetTemplate.id
+                        create[1], target_template.id
                     ),
                     1,
                 )
-                for field in targetTemplate._meta.fields:
+                for field in target_template._meta.fields:
                     if field.name not in ['id', 'created', 'last_updated']:
                         setattr(
-                            targetTemplate, field.name, getattr(create[0], field.name)
+                            target_template, field.name, getattr(create[0], field.name)
                         )
-                targetTemplate.name = create[1]
-                targetTemplate.save()
+                target_template.name = create[1]
+                target_template.save()
             else:
                 self.message('Creating email template {0}'.format(create[1]), 1)
                 create[0].name = create[1]

--- a/management/commands/default_email_templates.py
+++ b/management/commands/default_email_templates.py
@@ -4,7 +4,7 @@ import tracker.prizemail as prizemail
 import tracker.auth as auth
 import tracker.commandutil as commandutil
 
-_defaultTemplates = {
+_DEFAULT_TEMPLATES = {
     auth.default_password_reset_template_name(): auth.default_password_reset_template(),
     auth.default_registration_template_name(): auth.default_registration_template(),
     prizemail.default_prize_winner_template_name(): prizemail.default_prize_winner_template(),
@@ -17,7 +17,7 @@ _defaultTemplates = {
 
 def email_template_name(arg):
     parts = arg.partition(':')
-    template = _defaultTemplates[parts[0]]
+    template = _DEFAULT_TEMPLATES[parts[0]]
     custom_name = None
     if parts[1] == ':':
         if parts[2]:
@@ -83,7 +83,7 @@ class Command(commandutil.TrackerCommand):
         self.prefix = options['prefix']
 
         if options['list']:
-            for option in list(_defaultTemplates.keys()):
+            for option in list(_DEFAULT_TEMPLATES.keys()):
                 self.message(option, 0)
             return
 
@@ -92,7 +92,7 @@ class Command(commandutil.TrackerCommand):
 
         if options['create_all']:
             self.templates = list(
-                map(email_template_name, list(_defaultTemplates.keys()))
+                map(email_template_name, list(_DEFAULT_TEMPLATES.keys()))
             )
 
         self.templates = list(

--- a/management/commands/draw_prizes.py
+++ b/management/commands/draw_prizes.py
@@ -14,14 +14,14 @@ class Command(commandutil.TrackerCommand):
     requires_system_checks = False
 
     def add_arguments(self, parser):
-        eventOrPrize = parser.add_mutually_exclusive_group(required=True)
-        eventOrPrize.add_argument(
+        event_or_prize = parser.add_mutually_exclusive_group(required=True)
+        event_or_prize.add_argument(
             '-e',
             '--event',
             help='specify an event for which event to draw przes',
             type=viewutil.get_event,
         )
-        eventOrPrize.add_argument(
+        event_or_prize.add_argument(
             '-p', '--prize', help='specify which prize to draw', type=int
         )
         parser.add_argument(
@@ -57,24 +57,24 @@ class Command(commandutil.TrackerCommand):
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
 
-        hasPrize = options['prize'] is not None
-        hasEvent = options['event'] is not None
-        dryRun = options['dry_run']
+        has_prize = options['prize'] is not None
+        has_event = options['event'] is not None
+        dry_run = options['dry_run']
 
-        prizeSet = None
+        prize_set = None
 
-        if hasPrize:
-            prizeId = int(options['prize'])
-            prizeSet = models.Prize.objects.filter(pk=prizeId)
-            if not prizeSet.exists():
-                self.message('No prize with id {0} found.'.format(prizeId))
+        if has_prize:
+            prize_id = int(options['prize'])
+            prize_set = models.Prize.objects.filter(pk=prize_id)
+            if not prize_set.exists():
+                self.message('No prize with id {0} found.'.format(prize_id))
                 sys.exit(1)
-            elif prizeSet[0].state != 'ACCEPTED':
-                self.message('Prize {0} is not in an accepted state'.format(prizeId))
+            elif prize_set[0].state != 'ACCEPTED':
+                self.message('Prize {0} is not in an accepted state'.format(prize_id))
                 sys.exit(1)
-        elif hasEvent:
+        elif has_event:
             event = viewutil.get_event(options['event'])
-            prizeSet = models.Prize.objects.filter(event=event, state='ACCEPTED')
+            prize_set = models.Prize.objects.filter(event=event, state='ACCEPTED')
 
         seed = options['seed']
 
@@ -83,14 +83,14 @@ class Command(commandutil.TrackerCommand):
 
         self.rand = random.Random(seed)
 
-        if not prizeSet.exists():
+        if not prize_set.exists():
             self.message('No prizes match the given query.')
         else:
             try:
                 with transaction.atomic():
-                    for prize in prizeSet:
+                    for prize in prize_set:
                         self.draw_prize(prize)
-                    if dryRun:
+                    if dry_run:
                         self.message('Rolling back operations...')
                         raise Exception('Cancelled due to dry run.')
             except Exception:

--- a/management/commands/list_email_templates.py
+++ b/management/commands/list_email_templates.py
@@ -11,13 +11,13 @@ class Command(commandutil.TrackerCommand):
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
 
-        templateList = post_office.models.EmailTemplate.objects.all()
+        template_list = post_office.models.EmailTemplate.objects.all()
 
         if 'filter' in options:
-            templateList = templateList.filter(name__icontains=options['filter'])
+            template_list = template_list.filter(name__icontains=options['filter'])
 
-        if templateList.exists():
-            for template in templateList:
+        if template_list.exists():
+            for template in template_list:
                 self.message('{0}'.format(template.name), 0)
         else:
             self.message('No templates found.')

--- a/management/commands/list_events.py
+++ b/management/commands/list_events.py
@@ -17,13 +17,13 @@ class Command(commandutil.TrackerCommand):
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
 
-        eventList = models.Event.objects.all()
+        event_list = models.Event.objects.all()
 
         if options['non_locked']:
-            eventList.filter(locked=False)
+            event_list.filter(locked=False)
 
-        if eventList.exists():
-            for event in eventList:
+        if event_list.exists():
+            for event in event_list:
                 self.message(
                     '{0} , id: {1}, short: {2}'.format(
                         event.name, event.id, event.short

--- a/management/commands/past_due_prizewinners.py
+++ b/management/commands/past_due_prizewinners.py
@@ -37,21 +37,21 @@ class Command(commandutil.TrackerCommand):
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
         event = options['event']
-        dryRun = options['dry_run']
-        pastDueWinners = prizeutil.get_past_due_prize_winners(event)
+        dry_run = options['dry_run']
+        past_due_winners = prizeutil.get_past_due_prize_winners(event)
 
-        if not pastDueWinners.exists():
+        if not past_due_winners.exists():
             self.message('There are no past-due winners.', 2)
         elif options['list']:
-            for prizeWinner in pastDueWinners:
+            for prize_winner in past_due_winners:
                 self.message(
                     'Winner #{0} (due {1})'.format(
-                        prizeWinner.id, prizeWinner.acceptdeadline
+                        prize_winner.id, prize_winner.acceptdeadline
                     )
                 )
         elif options['close']:
             prizeutil.close_past_due_prize_winners(
-                pastDueWinners, verbosity=self.verbosity, dry_run=dryRun
+                past_due_winners, verbosity=self.verbosity, dry_run=dry_run
             )
         else:
             self.message('Invalid option.')

--- a/management/commands/send_activate_prize_handlers_mail.py
+++ b/management/commands/send_activate_prize_handlers_mail.py
@@ -33,13 +33,17 @@ class Command(commandutil.TrackerCommand):
 
         event = options['event']
 
-        inactiveUsers = prizemail.get_event_inactive_prize_handlers(event)
-        dryRun = options['dry_run']
+        inactive_users = prizemail.get_event_inactive_prize_handlers(event)
+        dry_run = options['dry_run']
         template = options['template']
 
-        if inactiveUsers.exists():
+        if inactive_users.exists():
             prizemail.automail_inactive_prize_handlers(
-                event, inactiveUsers, template, verbosity=self.verbosity, dry_run=dryRun
+                event,
+                inactive_users,
+                template,
+                verbosity=self.verbosity,
+                dry_run=dry_run,
             )
         else:
             self.message('No inactive users found for the specified event.')

--- a/management/commands/send_prize_contributor_emails.py
+++ b/management/commands/send_prize_contributor_emails.py
@@ -27,10 +27,10 @@ class Command(commandutil.TrackerCommand):
 
         event = viewutil.get_event(options['event'])
         prizes = prizemail.prizes_with_submission_email_pending(event)
-        emailTemplate = options['template'] or event.prizecontributoremailtemplate
-        dryRun = options['dry_run']
+        email_template = options['template'] or event.prizecontributoremailtemplate
+        dry_run = options['dry_run']
 
-        if emailTemplate is None:
+        if email_template is None:
             self.message(
                 'No default prize accept/deny email template specified on event {0}, cannot send e-mails.'.format(
                     event.short
@@ -38,5 +38,5 @@ class Command(commandutil.TrackerCommand):
             )
         else:
             prizemail.automail_prize_contributors(
-                event, prizes, emailTemplate, verbosity=self.verbosity, dry_run=dryRun
+                event, prizes, email_template, verbosity=self.verbosity, dry_run=dry_run
             )

--- a/management/commands/send_prize_shipped_emails.py
+++ b/management/commands/send_prize_shipped_emails.py
@@ -28,11 +28,11 @@ class Command(commandutil.TrackerCommand):
         super(Command, self).handle(*args, **options)
 
         event = options['event']
-        prizeWinners = prizemail.prizes_with_shipping_email_pending(event)
-        emailTemplate = options['template'] or event.prizeshippedemailtemplate
-        dryRun = options['dry_run']
+        prize_winners = prizemail.prizes_with_shipping_email_pending(event)
+        email_template = options['template'] or event.prizeshippedemailtemplate
+        dry_run = options['dry_run']
 
-        if emailTemplate is None:
+        if email_template is None:
             self.message(
                 'No default prize shipped email template specified on event {0}, cannot send e-mails.'.format(
                     event.short
@@ -41,8 +41,8 @@ class Command(commandutil.TrackerCommand):
         else:
             prizemail.automail_shipping_email_notifications(
                 event,
-                prizeWinners,
-                emailTemplate,
+                prize_winners,
+                email_template,
                 verbosity=self.verbosity,
-                dry_run=dryRun,
+                dry_run=dry_run,
             )

--- a/management/commands/send_prize_winner_accept_emails.py
+++ b/management/commands/send_prize_winner_accept_emails.py
@@ -28,11 +28,11 @@ class Command(commandutil.TrackerCommand):
         super(Command, self).handle(*args, **options)
 
         event = viewutil.get_event(options['event'])
-        prizeWinners = prizemail.prizes_with_winner_accept_email_pending(event)
-        emailTemplate = options['template'] or event.prizewinneracceptemailtemplate
-        dryRun = options['dry_run']
+        prize_winners = prizemail.prizes_with_winner_accept_email_pending(event)
+        email_template = options['template'] or event.prizewinneracceptemailtemplate
+        dry_run = options['dry_run']
 
-        if emailTemplate is None:
+        if email_template is None:
             self.message(
                 'No default prize winner accepted email template specified on event {0}, cannot send e-mails.'.format(
                     event.short
@@ -41,8 +41,8 @@ class Command(commandutil.TrackerCommand):
         else:
             prizemail.automail_winner_accepted_prize(
                 event,
-                prizeWinners,
-                emailTemplate,
+                prize_winners,
+                email_template,
                 verbosity=self.verbosity,
-                dry_run=dryRun,
+                dry_run=dry_run,
             )

--- a/management/commands/send_prize_winner_emails.py
+++ b/management/commands/send_prize_winner_emails.py
@@ -31,11 +31,11 @@ class Command(commandutil.TrackerCommand):
         super(Command, self).handle(*args, **options)
 
         event = options['event']
-        prizeWinners = prizemail.prize_winners_with_email_pending(event)
-        emailTemplate = options['template'] or event.prizewinneremailtemplate
-        dryRun = options['dry_run']
+        prize_winners = prizemail.prize_winners_with_email_pending(event)
+        email_template = options['template'] or event.prizewinneremailtemplate
+        dry_run = options['dry_run']
 
-        if emailTemplate is None:
+        if email_template is None:
             self.message(
                 'No default prize winner email template specified on event {0}, cannot send e-mails.'.format(
                     event.short
@@ -44,8 +44,8 @@ class Command(commandutil.TrackerCommand):
         else:
             prizemail.automail_prize_winners(
                 event,
-                prizeWinners,
-                emailTemplate,
+                prize_winners,
+                email_template,
                 verbosity=self.verbosity,
-                dry_run=dryRun,
+                dry_run=dry_run,
             )

--- a/management/commands/send_volunteer_registration_emails.py
+++ b/management/commands/send_volunteer_registration_emails.py
@@ -43,13 +43,13 @@ class Command(commandutil.TrackerCommand):
         self.message(str(options), 3)
         self.verbosity = options['verbosity']
 
-        dryRun = options['dry_run']
+        dry_run = options['dry_run']
         template = options['template']
-        volunteersFile = options['volunteers_list']
+        volunteers_file = options['volunteers_list']
         sender = options['sender']
         event = options['event']
 
-        volunteers = volunteer.parse_volunteer_info_file(volunteersFile)
+        volunteers = volunteer.parse_volunteer_info_file(volunteers_file)
 
         volunteer.send_volunteer_mail(
             settings.DOMAIN,
@@ -58,5 +58,5 @@ class Command(commandutil.TrackerCommand):
             template,
             sender,
             verbosity=self.verbosity,
-            dry_run=dryRun,
+            dry_run=dry_run,
         )

--- a/migrations/0001_squashed_0039_upgrade_to_19.py
+++ b/migrations/0001_squashed_0039_upgrade_to_19.py
@@ -21,77 +21,83 @@ import tracker.validators
 
 
 def f0006_fill_in_order_column(apps, schema_editor):
-    SpeedRun = apps.get_model('tracker', 'SpeedRun')
+    SpeedRun = apps.get_model('tracker', 'SpeedRun')  # noqa N806
     for run in SpeedRun.objects.filter(order=None).order_by('starttime'):
-        prev = SpeedRun.objects.filter(event=run.event).exclude(order=None).order_by('starttime').last()
+        prev = (
+            SpeedRun.objects.filter(event=run.event)
+            .exclude(order=None)
+            .order_by('starttime')
+            .last()
+        )
         prev_order = (prev and prev.order) or 0
         run.order = prev_order + 1
         run.save()
 
 
 def f0006_clear_order_column(apps, schema_editor):
-    SpeedRun = apps.get_model('tracker', 'SpeedRun')
+    SpeedRun = apps.get_model('tracker', 'SpeedRun')  # noqa N806
     SpeedRun.objects.update(order=None)
 
 
-def f0013_collect_prize_contributor_names(Prize, AuthUser):
-    contributorNames = {}
+def f0013_collect_prize_contributor_names(Prize, AuthUser):  # noqa N806
+    contributor_names = {}
     for prize in Prize.objects.all():
         if prize.provideremail:
-            if prize.provideremail not in list(contributorNames.keys()):
-                contributorNames[prize.provideremail] = collections.Counter()
+            if prize.provideremail not in list(contributor_names.keys()):
+                contributor_names[prize.provideremail] = collections.Counter()
             if prize.provided:
-                contributorNames[prize.provideremail][prize.provided.strip()] += 1
-    return contributorNames
+                contributor_names[prize.provideremail][prize.provided.strip()] += 1
+    return contributor_names
 
 
-def f0013_guess_user_id(AuthUser, contributorEmail, contributorNameCounter):
+def f0013_guess_user_id(
+    AuthUser, contributor_email, contributor_name_counter  # noqa N806
+):
     # user email is a reasonable default in the presence of no other alternative
-    userId = contributorEmail
+    user_id = contributor_email
+    potential_tags = []
 
-    potentialTags = []
+    for name, count in list(contributor_name_counter.items()):
+        potential_tags.append((count, name))
 
-    for name, count in list(contributorNameCounter.items()):
-        potentialTags.append((count, name))
-
-    potentialTags.sort(reverse=True)
+    potential_tags.sort(reverse=True)
 
     # ensure that if we select a username, it is unique
-    for count, tag in potentialTags:
+    for count, tag in potential_tags:
         if not AuthUser.objects.filter(username=tag).exists():
-            userId = tag
+            user_id = tag
         break
 
-    return userId
+    return user_id
 
 
-def f0013_ensure_existing_users(Prize, AuthUser):
-    prizeContribCounts = f0013_collect_prize_contributor_names(Prize, AuthUser)
+def f0013_ensure_existing_users(Prize, AuthUser):  # noqa N806
+    prize_contrib_counts = f0013_collect_prize_contributor_names(Prize, AuthUser)
 
-    for contributorEmail, counterDict in list(prizeContribCounts.items()):
-        users = AuthUser.objects.filter(email=contributorEmail)
+    for contributor_email, counter_dict in list(prize_contrib_counts.items()):
+        users = AuthUser.objects.filter(email=contributor_email)
         if users.exists():
             user = users[0]
         else:
-            users = AuthUser.objects.filter(username=contributorEmail)
+            users = AuthUser.objects.filter(username=contributor_email)
             if users.exists():
                 user = users[0]
             else:
                 # Create a new, inactive user as a placeholder
                 user = AuthUser()
                 user.is_active = False
-        userId = f0013_guess_user_id(AuthUser, contributorEmail, counterDict)
+        user_id = f0013_guess_user_id(AuthUser, contributor_email, counter_dict)
         if not user.username:
-            user.username = userId
+            user.username = user_id
         if not user.email:
-            user.email = contributorEmail
+            user.email = contributor_email
 
         user.save()
 
 
 def f0013_populate_prize_contributors(apps, schema_editor):
-    Prize = apps.get_model('tracker', 'Prize')
-    AuthUser = Prize.handler.field.rel.to
+    Prize = apps.get_model('tracker', 'Prize')  # noqa N806
+    AuthUser = Prize.handler.field.rel.to  # noqa N806
 
     f0013_ensure_existing_users(Prize, AuthUser)
 
@@ -106,7 +112,7 @@ def f0013_populate_prize_contributors(apps, schema_editor):
 
 
 def f0013_read_back_prize_contributors(apps, schema_editor):
-    Prize = apps.get_model('tracker', 'Prize')
+    Prize = apps.get_model('tracker', 'Prize')  # noqa N806
 
     for prize in Prize.objects.all():
         if prize.handler:
@@ -117,14 +123,14 @@ def f0013_read_back_prize_contributors(apps, schema_editor):
 
 
 def f0023_copy_over_display_name(apps, schema_editor):
-    SpeedRun = apps.get_model('tracker', 'SpeedRun')
+    SpeedRun = apps.get_model('tracker', 'SpeedRun')  # noqa N806
     for run in SpeedRun.objects.all():
         run.display_name = run.name
         run.save()
 
 
 def f0024_write_existing_providers(apps, schema_editor):
-    Prize = apps.get_model('tracker', 'Prize')
+    Prize = apps.get_model('tracker', 'Prize')  # noqa N806
     for prize in Prize.objects.all():
         if prize.handler:
             if prize.handler.username != prize.handler.email:
@@ -137,37 +143,40 @@ def f0026_add_countries(apps, schema_editor):
 
 
 def f0026_migrate_to_country_code(apps, schema_editor):
-    Country = apps.get_model('tracker', 'Country')
-    Donor = apps.get_model('tracker', 'Donor')
-    PayPalIPN = apps.get_model('ipn', 'PayPalIPN')
+    Country = apps.get_model('tracker', 'Country')  # noqa N806
+    Donor = apps.get_model('tracker', 'Donor')  # noqa N806
+    PayPalIPN = apps.get_model('ipn', 'PayPalIPN')  # noqa N806
     for d in Donor.objects.all():
-        foundCountry = Country.objects.none()
+        found_country = Country.objects.none()
         if d.migrateaddresscountry:
-            foundCountry = Country.objects.filter(name=d.migrateaddresscountry)
-            if not foundCountry.exists():
-                foundCountry = Country.objects.filter(alpha2=d.migrateaddresscountry)
-            if not foundCountry.exists():
-                foundCountry = Country.objects.filter(alpha3=d.migrateaddresscountry)
-            if not foundCountry.exists():
+            found_country = Country.objects.filter(name=d.migrateaddresscountry)
+            if not found_country.exists():
+                found_country = Country.objects.filter(alpha2=d.migrateaddresscountry)
+            if not found_country.exists():
+                found_country = Country.objects.filter(alpha3=d.migrateaddresscountry)
+            if not found_country.exists():
                 if tracker.util.try_parse_int(d.migrateaddresscountry) is not None:
-                    foundCountry = Country.objects.filter(
-                        numeric=d.migrateaddresscountry)
+                    found_country = Country.objects.filter(
+                        numeric=d.migrateaddresscountry
+                    )
         # As a last resort, search through this user's most recent IPN for
         # country data
-        if not foundCountry.exists() and d.paypalemail:
-            foundIPNs = PayPalIPN.objects.filter(
-                payer_email=d.email).order_by('-payment_date')
-            if foundIPNs.exists():
-                foundIPN = foundIPNs[0]
-                foundCountry = Country.objects.filter(
-                    alpha2=foundIPN.address_country_code)
-        if foundCountry.exists():
-            d.addresscountry = foundCountry[0]
+        if not found_country.exists() and d.paypalemail:
+            found_ipns = PayPalIPN.objects.filter(payer_email=d.email).order_by(
+                '-payment_date'
+            )
+            if found_ipns.exists():
+                found_ipn = found_ipns[0]
+                found_country = Country.objects.filter(
+                    alpha2=found_ipn.address_country_code
+                )
+        if found_country.exists():
+            d.addresscountry = found_country[0]
             d.save()
 
 
 def f0026_migrate_from_country_code(apps, schema_editor):
-    Donor = apps.get_model('tracker', 'Donor')
+    Donor = apps.get_model('tracker', 'Donor')  # noqa N806
     for d in Donor.objects.all():
         if d.addresscountry:
             d.migrateaddresscountry = d.addresscountry.alpha2
@@ -188,74 +197,367 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bid',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64)),
-                ('state', models.CharField(choices=[('PENDING', 'Pending'), ('DENIED', 'Denied'), ('HIDDEN', 'Hidden'), ('OPENED', 'Opened'), ('CLOSED', 'Closed')], default='OPENED', max_length=32)),
+                (
+                    'state',
+                    models.CharField(
+                        choices=[
+                            ('PENDING', 'Pending'),
+                            ('DENIED', 'Denied'),
+                            ('HIDDEN', 'Hidden'),
+                            ('OPENED', 'Opened'),
+                            ('CLOSED', 'Closed'),
+                        ],
+                        default='OPENED',
+                        max_length=32,
+                    ),
+                ),
                 ('description', models.TextField(blank=True, max_length=1024)),
-                ('shortdescription', models.TextField(blank=True, help_text='Alternative description text to display in tight spaces', max_length=256, verbose_name='Short Description')),
-                ('goal', models.DecimalField(blank=True, decimal_places=2, default=None, max_digits=20, null=True)),
-                ('istarget', models.BooleanField(default=False, help_text=b"Set this if this bid is a 'target' for donations (bottom level choice or challenge)", verbose_name='Target')),
-                ('allowuseroptions', models.BooleanField(default=False, help_text='If set, this will allow donors to specify their own options on the donate page (pending moderator approval)', verbose_name='Allow User Options')),
-                ('revealedtime', models.DateTimeField(blank=True, null=True, verbose_name='Revealed Time')),
-                ('total', models.DecimalField(decimal_places=2, default=Decimal('0.00'), editable=False, max_digits=20)),
+                (
+                    'shortdescription',
+                    models.TextField(
+                        blank=True,
+                        help_text='Alternative description text to display in tight spaces',
+                        max_length=256,
+                        verbose_name='Short Description',
+                    ),
+                ),
+                (
+                    'goal',
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        default=None,
+                        max_digits=20,
+                        null=True,
+                    ),
+                ),
+                (
+                    'istarget',
+                    models.BooleanField(
+                        default=False,
+                        help_text=b"Set this if this bid is a 'target' for donations (bottom level choice or challenge)",
+                        verbose_name='Target',
+                    ),
+                ),
+                (
+                    'allowuseroptions',
+                    models.BooleanField(
+                        default=False,
+                        help_text='If set, this will allow donors to specify their own options on the donate page (pending moderator approval)',
+                        verbose_name='Allow User Options',
+                    ),
+                ),
+                (
+                    'revealedtime',
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name='Revealed Time'
+                    ),
+                ),
+                (
+                    'total',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal('0.00'),
+                        editable=False,
+                        max_digits=20,
+                    ),
+                ),
                 ('count', models.IntegerField(editable=False)),
                 ('lft', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('rght', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('tree_id', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('level', models.PositiveIntegerField(db_index=True, editable=False)),
-                ('biddependency', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='depedent_bids', to='tracker.Bid', verbose_name='Dependency')),
+                (
+                    'biddependency',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='depedent_bids',
+                        to='tracker.Bid',
+                        verbose_name='Dependency',
+                    ),
+                ),
             ],
             options={
-                'ordering': ['event__date', 'speedrun__starttime', 'parent__name', 'name'],
-                'permissions': (('top_level_bid', 'Can create new top level bids'), ('delete_all_bids', 'Can delete bids with donations attached'), ('view_hidden', 'Can view hidden bids')),
+                'ordering': [
+                    'event__date',
+                    'speedrun__starttime',
+                    'parent__name',
+                    'name',
+                ],
+                'permissions': (
+                    ('top_level_bid', 'Can create new top level bids'),
+                    ('delete_all_bids', 'Can delete bids with donations attached'),
+                    ('view_hidden', 'Can view hidden bids'),
+                ),
             },
         ),
         migrations.CreateModel(
             name='BidSuggestion',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64, verbose_name='Name')),
-                ('bid', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='suggestions', to='tracker.Bid')),
+                (
+                    'bid',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='suggestions',
+                        to='tracker.Bid',
+                    ),
+                ),
             ],
-            options={
-                'ordering': ['name'],
-            },
+            options={'ordering': ['name'],},
         ),
         migrations.CreateModel(
             name='Donation',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('domain', models.CharField(choices=[('LOCAL', 'Local'), ('CHIPIN', 'ChipIn'), ('PAYPAL', 'PayPal')], default='LOCAL', max_length=255)),
-                ('domainId', models.CharField(blank=True, editable=False, max_length=160, unique=True)),
-                ('transactionstate', models.CharField(choices=[('PENDING', 'Pending'), ('COMPLETED', 'Completed'), ('CANCELLED', 'Cancelled'), ('FLAGGED', 'Flagged')], default='PENDING', max_length=64, verbose_name='Transaction State')),
-                ('bidstate', models.CharField(choices=[('PENDING', 'Pending'), ('IGNORED', 'Ignored'), ('PROCESSED', 'Processed'), ('FLAGGED', 'Flagged')], default='PENDING', max_length=255, verbose_name='Bid State')),
-                ('readstate', models.CharField(choices=[('PENDING', 'Pending'), ('READY', 'Ready to Read'), ('IGNORED', 'Ignored'), ('READ', 'Read'), ('FLAGGED', 'Flagged')], default='PENDING', max_length=255, verbose_name='Read State')),
-                ('commentstate', models.CharField(choices=[('ABSENT', 'Absent'), ('PENDING', 'Pending'), ('DENIED', 'Denied'), ('APPROVED', 'Approved'), ('FLAGGED', 'Flagged')], default='ABSENT', max_length=255, verbose_name='Comment State')),
-                ('amount', models.DecimalField(decimal_places=2, default=Decimal('0.00'), max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Donation Amount')),
-                ('fee', models.DecimalField(decimal_places=2, default=Decimal('0.00'), max_digits=20, validators=[tracker.validators.positive], verbose_name='Donation Fee')),
-                ('currency', models.CharField(choices=[('USD', 'US Dollars'), ('CAD', 'Canadian Dollars')], max_length=8, verbose_name='Currency')),
-                ('timereceived', models.DateTimeField(default=django.utils.timezone.now, verbose_name='Time Received')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'domain',
+                    models.CharField(
+                        choices=[
+                            ('LOCAL', 'Local'),
+                            ('CHIPIN', 'ChipIn'),
+                            ('PAYPAL', 'PayPal'),
+                        ],
+                        default='LOCAL',
+                        max_length=255,
+                    ),
+                ),
+                (
+                    'domainId',
+                    models.CharField(
+                        blank=True, editable=False, max_length=160, unique=True
+                    ),
+                ),
+                (
+                    'transactionstate',
+                    models.CharField(
+                        choices=[
+                            ('PENDING', 'Pending'),
+                            ('COMPLETED', 'Completed'),
+                            ('CANCELLED', 'Cancelled'),
+                            ('FLAGGED', 'Flagged'),
+                        ],
+                        default='PENDING',
+                        max_length=64,
+                        verbose_name='Transaction State',
+                    ),
+                ),
+                (
+                    'bidstate',
+                    models.CharField(
+                        choices=[
+                            ('PENDING', 'Pending'),
+                            ('IGNORED', 'Ignored'),
+                            ('PROCESSED', 'Processed'),
+                            ('FLAGGED', 'Flagged'),
+                        ],
+                        default='PENDING',
+                        max_length=255,
+                        verbose_name='Bid State',
+                    ),
+                ),
+                (
+                    'readstate',
+                    models.CharField(
+                        choices=[
+                            ('PENDING', 'Pending'),
+                            ('READY', 'Ready to Read'),
+                            ('IGNORED', 'Ignored'),
+                            ('READ', 'Read'),
+                            ('FLAGGED', 'Flagged'),
+                        ],
+                        default='PENDING',
+                        max_length=255,
+                        verbose_name='Read State',
+                    ),
+                ),
+                (
+                    'commentstate',
+                    models.CharField(
+                        choices=[
+                            ('ABSENT', 'Absent'),
+                            ('PENDING', 'Pending'),
+                            ('DENIED', 'Denied'),
+                            ('APPROVED', 'Approved'),
+                            ('FLAGGED', 'Flagged'),
+                        ],
+                        default='ABSENT',
+                        max_length=255,
+                        verbose_name='Comment State',
+                    ),
+                ),
+                (
+                    'amount',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal('0.00'),
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Donation Amount',
+                    ),
+                ),
+                (
+                    'fee',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal('0.00'),
+                        max_digits=20,
+                        validators=[tracker.validators.positive],
+                        verbose_name='Donation Fee',
+                    ),
+                ),
+                (
+                    'currency',
+                    models.CharField(
+                        choices=[('USD', 'US Dollars'), ('CAD', 'Canadian Dollars')],
+                        max_length=8,
+                        verbose_name='Currency',
+                    ),
+                ),
+                (
+                    'timereceived',
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, verbose_name='Time Received'
+                    ),
+                ),
                 ('comment', models.TextField(blank=True, verbose_name='Comment')),
-                ('modcomment', models.TextField(blank=True, verbose_name='Moderator Comment')),
+                (
+                    'modcomment',
+                    models.TextField(blank=True, verbose_name='Moderator Comment'),
+                ),
                 ('testdonation', models.BooleanField(default=False)),
-                ('requestedvisibility', models.CharField(choices=[('CURR', 'Use Existing (Anonymous if not set)'), ('FULL', 'Fully Visible'), ('FIRST', 'First Name, Last Initial'), ('ALIAS', 'Alias Only'), ('ANON', 'Anonymous')], default='CURR', max_length=32, verbose_name='Requested Visibility')),
-                ('requestedalias', models.CharField(blank=True, max_length=32, null=True, verbose_name='Requested Alias')),
-                ('requestedemail', models.EmailField(blank=True, max_length=128, null=True, verbose_name='Requested Contact Email')),
-                ('commentlanguage', models.CharField(choices=[('un', 'Unknown'), ('en', 'English'), ('fr', 'French'), ('de', 'German')], default='un', max_length=32, verbose_name='Comment Language')),
+                (
+                    'requestedvisibility',
+                    models.CharField(
+                        choices=[
+                            ('CURR', 'Use Existing (Anonymous if not set)'),
+                            ('FULL', 'Fully Visible'),
+                            ('FIRST', 'First Name, Last Initial'),
+                            ('ALIAS', 'Alias Only'),
+                            ('ANON', 'Anonymous'),
+                        ],
+                        default='CURR',
+                        max_length=32,
+                        verbose_name='Requested Visibility',
+                    ),
+                ),
+                (
+                    'requestedalias',
+                    models.CharField(
+                        blank=True,
+                        max_length=32,
+                        null=True,
+                        verbose_name='Requested Alias',
+                    ),
+                ),
+                (
+                    'requestedemail',
+                    models.EmailField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        verbose_name='Requested Contact Email',
+                    ),
+                ),
+                (
+                    'commentlanguage',
+                    models.CharField(
+                        choices=[
+                            ('un', 'Unknown'),
+                            ('en', 'English'),
+                            ('fr', 'French'),
+                            ('de', 'German'),
+                        ],
+                        default='un',
+                        max_length=32,
+                        verbose_name='Comment Language',
+                    ),
+                ),
             ],
             options={
                 'ordering': ['-timereceived'],
                 'get_latest_by': 'timereceived',
-                'permissions': (('delete_all_donations', 'Can delete non-local donations'), ('view_full_list', 'Can view full donation list'), ('view_comments', 'Can view all comments'), ('view_pending', 'Can view pending donations'), ('view_test', 'Can view test donations'), ('send_to_reader', 'Can send donations to the reader')),
+                'permissions': (
+                    ('delete_all_donations', 'Can delete non-local donations'),
+                    ('view_full_list', 'Can view full donation list'),
+                    ('view_comments', 'Can view all comments'),
+                    ('view_pending', 'Can view pending donations'),
+                    ('view_test', 'Can view test donations'),
+                    ('send_to_reader', 'Can send donations to the reader'),
+                ),
             },
         ),
         migrations.CreateModel(
             name='DonationBid',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('amount', models.DecimalField(decimal_places=2, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero])),
-                ('bid', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='bids', to='tracker.Bid')),
-                ('donation', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='bids', to='tracker.Donation')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'amount',
+                    models.DecimalField(
+                        decimal_places=2,
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                    ),
+                ),
+                (
+                    'bid',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='bids',
+                        to='tracker.Bid',
+                    ),
+                ),
+                (
+                    'donation',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='bids',
+                        to='tracker.Donation',
+                    ),
+                ),
             ],
             options={
                 'ordering': ['-donation__timereceived'],
@@ -265,44 +567,196 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Donor',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('email', models.EmailField(max_length=128, verbose_name='Contact Email')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'email',
+                    models.EmailField(max_length=128, verbose_name='Contact Email'),
+                ),
                 ('alias', models.CharField(blank=True, max_length=32, null=True)),
-                ('firstname', models.CharField(blank=True, max_length=64, verbose_name='First Name')),
-                ('lastname', models.CharField(blank=True, max_length=64, verbose_name='Last Name')),
-                ('visibility', models.CharField(choices=[('FULL', 'Fully Visible'), ('FIRST', 'First Name, Last Initial'), ('ALIAS', 'Alias Only'), ('ANON', 'Anonymous')], default='FIRST', max_length=32)),
-                ('addresscity', models.CharField(blank=True, max_length=128, verbose_name='City')),
-                ('addressstreet', models.CharField(blank=True, max_length=128, verbose_name='Street/P.O. Box')),
-                ('addressstate', models.CharField(blank=True, max_length=128, verbose_name='State/Province')),
-                ('addresszip', models.CharField(blank=True, max_length=128, verbose_name='Zip/Postal Code')),
-                ('addresscountry', models.CharField(blank=True, max_length=128, verbose_name='Country')),
-                ('paypalemail', models.EmailField(blank=True, max_length=128, null=True, unique=True, verbose_name='Paypal Email')),
+                (
+                    'firstname',
+                    models.CharField(
+                        blank=True, max_length=64, verbose_name='First Name'
+                    ),
+                ),
+                (
+                    'lastname',
+                    models.CharField(
+                        blank=True, max_length=64, verbose_name='Last Name'
+                    ),
+                ),
+                (
+                    'visibility',
+                    models.CharField(
+                        choices=[
+                            ('FULL', 'Fully Visible'),
+                            ('FIRST', 'First Name, Last Initial'),
+                            ('ALIAS', 'Alias Only'),
+                            ('ANON', 'Anonymous'),
+                        ],
+                        default='FIRST',
+                        max_length=32,
+                    ),
+                ),
+                (
+                    'addresscity',
+                    models.CharField(blank=True, max_length=128, verbose_name='City'),
+                ),
+                (
+                    'addressstreet',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Street/P.O. Box'
+                    ),
+                ),
+                (
+                    'addressstate',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='State/Province'
+                    ),
+                ),
+                (
+                    'addresszip',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Zip/Postal Code'
+                    ),
+                ),
+                (
+                    'addresscountry',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Country'
+                    ),
+                ),
+                (
+                    'paypalemail',
+                    models.EmailField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        unique=True,
+                        verbose_name='Paypal Email',
+                    ),
+                ),
             ],
             options={
                 'ordering': ['lastname', 'firstname', 'email'],
-                'permissions': (('delete_all_donors', 'Can delete donors with cleared donations'), ('view_usernames', 'Can view full usernames'), ('view_emails', 'Can view email addresses')),
+                'permissions': (
+                    ('delete_all_donors', 'Can delete donors with cleared donations'),
+                    ('view_usernames', 'Can view full usernames'),
+                    ('view_emails', 'Can view email addresses'),
+                ),
             },
         ),
         migrations.CreateModel(
             name='DonorCache',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('donation_total', models.DecimalField(decimal_places=2, default=0, editable=False, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero])),
-                ('donation_count', models.IntegerField(default=0, editable=False, validators=[tracker.validators.positive, tracker.validators.nonzero])),
-                ('donation_avg', models.DecimalField(decimal_places=2, default=0, editable=False, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero])),
-                ('donation_max', models.DecimalField(decimal_places=2, default=0, editable=False, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero])),
-                ('donor', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tracker.Donor')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'donation_total',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=0,
+                        editable=False,
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                    ),
+                ),
+                (
+                    'donation_count',
+                    models.IntegerField(
+                        default=0,
+                        editable=False,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                    ),
+                ),
+                (
+                    'donation_avg',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=0,
+                        editable=False,
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                    ),
+                ),
+                (
+                    'donation_max',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=0,
+                        editable=False,
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                    ),
+                ),
+                (
+                    'donor',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='tracker.Donor'
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('donor',),
-            },
+            options={'ordering': ('donor',),},
         ),
         migrations.CreateModel(
             name='DonorPrizeEntry',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('weight', models.DecimalField(decimal_places=2, default=Decimal('1.0'), help_text='This is the weight to apply this entry in the drawing (if weight is applicable).', max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Entry Weight')),
-                ('donor', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='tracker.Donor')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'weight',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal('1.0'),
+                        help_text='This is the weight to apply this entry in the drawing (if weight is applicable).',
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Entry Weight',
+                    ),
+                ),
+                (
+                    'donor',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT, to='tracker.Donor'
+                    ),
+                ),
             ],
             options={
                 'verbose_name': 'Donor Prize Entry',
@@ -312,28 +766,628 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Event',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('short', models.CharField(max_length=64, unique=True)),
                 ('name', models.CharField(max_length=128)),
-                ('receivername', models.CharField(blank=True, max_length=128, verbose_name='Receiver Name')),
-                ('targetamount', models.DecimalField(decimal_places=2, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Target Amount')),
-                ('usepaypalsandbox', models.BooleanField(default=False, verbose_name='Use Paypal Sandbox')),
-                ('paypalemail', models.EmailField(max_length=128, verbose_name='Receiver Paypal')),
-                ('paypalcurrency', models.CharField(choices=[('USD', 'US Dollars'), ('CAD', 'Canadian Dollars')], default='USD', max_length=8, verbose_name='Currency')),
-                ('donationemailsender', models.EmailField(blank=True, max_length=128, null=True, verbose_name='Donation Email Sender')),
-                ('scheduleid', models.CharField(blank=True, max_length=128, null=True, unique=True, verbose_name='Schedule ID')),
-                ('scheduletimezone', models.CharField(blank=True, choices=[('Africa/Abidjan', 'Africa/Abidjan'), ('Africa/Accra', 'Africa/Accra'), ('Africa/Addis_Ababa', 'Africa/Addis_Ababa'), ('Africa/Algiers', 'Africa/Algiers'), ('Africa/Asmara', 'Africa/Asmara'), ('Africa/Bamako', 'Africa/Bamako'), ('Africa/Bangui', 'Africa/Bangui'), ('Africa/Banjul', 'Africa/Banjul'), ('Africa/Bissau', 'Africa/Bissau'), ('Africa/Blantyre', 'Africa/Blantyre'), ('Africa/Brazzaville', 'Africa/Brazzaville'), ('Africa/Bujumbura', 'Africa/Bujumbura'), ('Africa/Cairo', 'Africa/Cairo'), ('Africa/Casablanca', 'Africa/Casablanca'), ('Africa/Ceuta', 'Africa/Ceuta'), ('Africa/Conakry', 'Africa/Conakry'), ('Africa/Dakar', 'Africa/Dakar'), ('Africa/Dar_es_Salaam', 'Africa/Dar_es_Salaam'), ('Africa/Djibouti', 'Africa/Djibouti'), ('Africa/Douala', 'Africa/Douala'), ('Africa/El_Aaiun', 'Africa/El_Aaiun'), ('Africa/Freetown', 'Africa/Freetown'), ('Africa/Gaborone', 'Africa/Gaborone'), ('Africa/Harare', 'Africa/Harare'), ('Africa/Johannesburg', 'Africa/Johannesburg'), ('Africa/Juba', 'Africa/Juba'), ('Africa/Kampala', 'Africa/Kampala'), ('Africa/Khartoum', 'Africa/Khartoum'), ('Africa/Kigali', 'Africa/Kigali'), ('Africa/Kinshasa', 'Africa/Kinshasa'), ('Africa/Lagos', 'Africa/Lagos'), ('Africa/Libreville', 'Africa/Libreville'), ('Africa/Lome', 'Africa/Lome'), ('Africa/Luanda', 'Africa/Luanda'), ('Africa/Lubumbashi', 'Africa/Lubumbashi'), ('Africa/Lusaka', 'Africa/Lusaka'), ('Africa/Malabo', 'Africa/Malabo'), ('Africa/Maputo', 'Africa/Maputo'), ('Africa/Maseru', 'Africa/Maseru'), ('Africa/Mbabane', 'Africa/Mbabane'), ('Africa/Mogadishu', 'Africa/Mogadishu'), ('Africa/Monrovia', 'Africa/Monrovia'), ('Africa/Nairobi', 'Africa/Nairobi'), ('Africa/Ndjamena', 'Africa/Ndjamena'), ('Africa/Niamey', 'Africa/Niamey'), ('Africa/Nouakchott', 'Africa/Nouakchott'), ('Africa/Ouagadougou', 'Africa/Ouagadougou'), ('Africa/Porto-Novo', 'Africa/Porto-Novo'), ('Africa/Sao_Tome', 'Africa/Sao_Tome'), ('Africa/Tripoli', 'Africa/Tripoli'), ('Africa/Tunis', 'Africa/Tunis'), ('Africa/Windhoek', 'Africa/Windhoek'), ('America/Adak', 'America/Adak'), ('America/Anchorage', 'America/Anchorage'), ('America/Anguilla', 'America/Anguilla'), ('America/Antigua', 'America/Antigua'), ('America/Araguaina', 'America/Araguaina'), ('America/Argentina/Buenos_Aires', 'America/Argentina/Buenos_Aires'), ('America/Argentina/Catamarca', 'America/Argentina/Catamarca'), ('America/Argentina/Cordoba', 'America/Argentina/Cordoba'), ('America/Argentina/Jujuy', 'America/Argentina/Jujuy'), ('America/Argentina/La_Rioja', 'America/Argentina/La_Rioja'), ('America/Argentina/Mendoza', 'America/Argentina/Mendoza'), ('America/Argentina/Rio_Gallegos', 'America/Argentina/Rio_Gallegos'), ('America/Argentina/Salta', 'America/Argentina/Salta'), ('America/Argentina/San_Juan', 'America/Argentina/San_Juan'), ('America/Argentina/San_Luis', 'America/Argentina/San_Luis'), ('America/Argentina/Tucuman', 'America/Argentina/Tucuman'), ('America/Argentina/Ushuaia', 'America/Argentina/Ushuaia'), ('America/Aruba', 'America/Aruba'), ('America/Asuncion', 'America/Asuncion'), ('America/Atikokan', 'America/Atikokan'), ('America/Bahia', 'America/Bahia'), ('America/Bahia_Banderas', 'America/Bahia_Banderas'), ('America/Barbados', 'America/Barbados'), ('America/Belem', 'America/Belem'), ('America/Belize', 'America/Belize'), ('America/Blanc-Sablon', 'America/Blanc-Sablon'), ('America/Boa_Vista', 'America/Boa_Vista'), ('America/Bogota', 'America/Bogota'), ('America/Boise', 'America/Boise'), ('America/Cambridge_Bay', 'America/Cambridge_Bay'), ('America/Campo_Grande', 'America/Campo_Grande'), ('America/Cancun', 'America/Cancun'), ('America/Caracas', 'America/Caracas'), ('America/Cayenne', 'America/Cayenne'), ('America/Cayman', 'America/Cayman'), ('America/Chicago', 'America/Chicago'), ('America/Chihuahua', 'America/Chihuahua'), ('America/Costa_Rica', 'America/Costa_Rica'), ('America/Creston', 'America/Creston'), ('America/Cuiaba', 'America/Cuiaba'), ('America/Curacao', 'America/Curacao'), ('America/Danmarkshavn', 'America/Danmarkshavn'), ('America/Dawson', 'America/Dawson'), ('America/Dawson_Creek', 'America/Dawson_Creek'), ('America/Denver', 'America/Denver'), ('America/Detroit', 'America/Detroit'), ('America/Dominica', 'America/Dominica'), ('America/Edmonton', 'America/Edmonton'), ('America/Eirunepe', 'America/Eirunepe'), ('America/El_Salvador', 'America/El_Salvador'), ('America/Fortaleza', 'America/Fortaleza'), ('America/Glace_Bay', 'America/Glace_Bay'), ('America/Godthab', 'America/Godthab'), ('America/Goose_Bay', 'America/Goose_Bay'), ('America/Grand_Turk', 'America/Grand_Turk'), ('America/Grenada', 'America/Grenada'), ('America/Guadeloupe', 'America/Guadeloupe'), ('America/Guatemala', 'America/Guatemala'), ('America/Guayaquil', 'America/Guayaquil'), ('America/Guyana', 'America/Guyana'), ('America/Halifax', 'America/Halifax'), ('America/Havana', 'America/Havana'), ('America/Hermosillo', 'America/Hermosillo'), ('America/Indiana/Indianapolis', 'America/Indiana/Indianapolis'), ('America/Indiana/Knox', 'America/Indiana/Knox'), ('America/Indiana/Marengo', 'America/Indiana/Marengo'), ('America/Indiana/Petersburg', 'America/Indiana/Petersburg'), ('America/Indiana/Tell_City', 'America/Indiana/Tell_City'), ('America/Indiana/Vevay', 'America/Indiana/Vevay'), ('America/Indiana/Vincennes', 'America/Indiana/Vincennes'), ('America/Indiana/Winamac', 'America/Indiana/Winamac'), ('America/Inuvik', 'America/Inuvik'), ('America/Iqaluit', 'America/Iqaluit'), ('America/Jamaica', 'America/Jamaica'), ('America/Juneau', 'America/Juneau'), ('America/Kentucky/Louisville', 'America/Kentucky/Louisville'), ('America/Kentucky/Monticello', 'America/Kentucky/Monticello'), ('America/Kralendijk', 'America/Kralendijk'), ('America/La_Paz', 'America/La_Paz'), ('America/Lima', 'America/Lima'), ('America/Los_Angeles', 'America/Los_Angeles'), ('America/Lower_Princes', 'America/Lower_Princes'), ('America/Maceio', 'America/Maceio'), ('America/Managua', 'America/Managua'), ('America/Manaus', 'America/Manaus'), ('America/Marigot', 'America/Marigot'), ('America/Martinique', 'America/Martinique'), ('America/Matamoros', 'America/Matamoros'), ('America/Mazatlan', 'America/Mazatlan'), ('America/Menominee', 'America/Menominee'), ('America/Merida', 'America/Merida'), ('America/Metlakatla', 'America/Metlakatla'), ('America/Mexico_City', 'America/Mexico_City'), ('America/Miquelon', 'America/Miquelon'), ('America/Moncton', 'America/Moncton'), ('America/Monterrey', 'America/Monterrey'), ('America/Montevideo', 'America/Montevideo'), ('America/Montserrat', 'America/Montserrat'), ('America/Nassau', 'America/Nassau'), ('America/New_York', 'America/New_York'), ('America/Nipigon', 'America/Nipigon'), ('America/Nome', 'America/Nome'), ('America/Noronha', 'America/Noronha'), ('America/North_Dakota/Beulah', 'America/North_Dakota/Beulah'), ('America/North_Dakota/Center', 'America/North_Dakota/Center'), ('America/North_Dakota/New_Salem', 'America/North_Dakota/New_Salem'), ('America/Ojinaga', 'America/Ojinaga'), ('America/Panama', 'America/Panama'), ('America/Pangnirtung', 'America/Pangnirtung'), ('America/Paramaribo', 'America/Paramaribo'), ('America/Phoenix', 'America/Phoenix'), ('America/Port-au-Prince', 'America/Port-au-Prince'), ('America/Port_of_Spain', 'America/Port_of_Spain'), ('America/Porto_Velho', 'America/Porto_Velho'), ('America/Puerto_Rico', 'America/Puerto_Rico'), ('America/Rainy_River', 'America/Rainy_River'), ('America/Rankin_Inlet', 'America/Rankin_Inlet'), ('America/Recife', 'America/Recife'), ('America/Regina', 'America/Regina'), ('America/Resolute', 'America/Resolute'), ('America/Rio_Branco', 'America/Rio_Branco'), ('America/Santa_Isabel', 'America/Santa_Isabel'), ('America/Santarem', 'America/Santarem'), ('America/Santiago', 'America/Santiago'), ('America/Santo_Domingo', 'America/Santo_Domingo'), ('America/Sao_Paulo', 'America/Sao_Paulo'), ('America/Scoresbysund', 'America/Scoresbysund'), ('America/Sitka', 'America/Sitka'), ('America/St_Barthelemy', 'America/St_Barthelemy'), ('America/St_Johns', 'America/St_Johns'), ('America/St_Kitts', 'America/St_Kitts'), ('America/St_Lucia', 'America/St_Lucia'), ('America/St_Thomas', 'America/St_Thomas'), ('America/St_Vincent', 'America/St_Vincent'), ('America/Swift_Current', 'America/Swift_Current'), ('America/Tegucigalpa', 'America/Tegucigalpa'), ('America/Thule', 'America/Thule'), ('America/Thunder_Bay', 'America/Thunder_Bay'), ('America/Tijuana', 'America/Tijuana'), ('America/Toronto', 'America/Toronto'), ('America/Tortola', 'America/Tortola'), ('America/Vancouver', 'America/Vancouver'), ('America/Whitehorse', 'America/Whitehorse'), ('America/Winnipeg', 'America/Winnipeg'), ('America/Yakutat', 'America/Yakutat'), ('America/Yellowknife', 'America/Yellowknife'), ('Antarctica/Casey', 'Antarctica/Casey'), ('Antarctica/Davis', 'Antarctica/Davis'), ('Antarctica/DumontDUrville', 'Antarctica/DumontDUrville'), ('Antarctica/Macquarie', 'Antarctica/Macquarie'), ('Antarctica/Mawson', 'Antarctica/Mawson'), ('Antarctica/McMurdo', 'Antarctica/McMurdo'), ('Antarctica/Palmer', 'Antarctica/Palmer'), ('Antarctica/Rothera', 'Antarctica/Rothera'), ('Antarctica/Syowa', 'Antarctica/Syowa'), ('Antarctica/Troll', 'Antarctica/Troll'), ('Antarctica/Vostok', 'Antarctica/Vostok'), ('Arctic/Longyearbyen', 'Arctic/Longyearbyen'), ('Asia/Aden', 'Asia/Aden'), ('Asia/Almaty', 'Asia/Almaty'), ('Asia/Amman', 'Asia/Amman'), ('Asia/Anadyr', 'Asia/Anadyr'), ('Asia/Aqtau', 'Asia/Aqtau'), ('Asia/Aqtobe', 'Asia/Aqtobe'), ('Asia/Ashgabat', 'Asia/Ashgabat'), ('Asia/Baghdad', 'Asia/Baghdad'), ('Asia/Bahrain', 'Asia/Bahrain'), ('Asia/Baku', 'Asia/Baku'), ('Asia/Bangkok', 'Asia/Bangkok'), ('Asia/Beirut', 'Asia/Beirut'), ('Asia/Bishkek', 'Asia/Bishkek'), ('Asia/Brunei', 'Asia/Brunei'), ('Asia/Chita', 'Asia/Chita'), ('Asia/Choibalsan', 'Asia/Choibalsan'), ('Asia/Colombo', 'Asia/Colombo'), ('Asia/Damascus', 'Asia/Damascus'), ('Asia/Dhaka', 'Asia/Dhaka'), ('Asia/Dili', 'Asia/Dili'), ('Asia/Dubai', 'Asia/Dubai'), ('Asia/Dushanbe', 'Asia/Dushanbe'), ('Asia/Gaza', 'Asia/Gaza'), ('Asia/Hebron', 'Asia/Hebron'), ('Asia/Ho_Chi_Minh', 'Asia/Ho_Chi_Minh'), ('Asia/Hong_Kong', 'Asia/Hong_Kong'), ('Asia/Hovd', 'Asia/Hovd'), ('Asia/Irkutsk', 'Asia/Irkutsk'), ('Asia/Jakarta', 'Asia/Jakarta'), ('Asia/Jayapura', 'Asia/Jayapura'), ('Asia/Jerusalem', 'Asia/Jerusalem'), ('Asia/Kabul', 'Asia/Kabul'), ('Asia/Kamchatka', 'Asia/Kamchatka'), ('Asia/Karachi', 'Asia/Karachi'), ('Asia/Kathmandu', 'Asia/Kathmandu'), ('Asia/Khandyga', 'Asia/Khandyga'), ('Asia/Kolkata', 'Asia/Kolkata'), ('Asia/Krasnoyarsk', 'Asia/Krasnoyarsk'), ('Asia/Kuala_Lumpur', 'Asia/Kuala_Lumpur'), ('Asia/Kuching', 'Asia/Kuching'), ('Asia/Kuwait', 'Asia/Kuwait'), ('Asia/Macau', 'Asia/Macau'), ('Asia/Magadan', 'Asia/Magadan'), ('Asia/Makassar', 'Asia/Makassar'), ('Asia/Manila', 'Asia/Manila'), ('Asia/Muscat', 'Asia/Muscat'), ('Asia/Nicosia', 'Asia/Nicosia'), ('Asia/Novokuznetsk', 'Asia/Novokuznetsk'), ('Asia/Novosibirsk', 'Asia/Novosibirsk'), ('Asia/Omsk', 'Asia/Omsk'), ('Asia/Oral', 'Asia/Oral'), ('Asia/Phnom_Penh', 'Asia/Phnom_Penh'), ('Asia/Pontianak', 'Asia/Pontianak'), ('Asia/Pyongyang', 'Asia/Pyongyang'), ('Asia/Qatar', 'Asia/Qatar'), ('Asia/Qyzylorda', 'Asia/Qyzylorda'), ('Asia/Rangoon', 'Asia/Rangoon'), ('Asia/Riyadh', 'Asia/Riyadh'), ('Asia/Sakhalin', 'Asia/Sakhalin'), ('Asia/Samarkand', 'Asia/Samarkand'), ('Asia/Seoul', 'Asia/Seoul'), ('Asia/Shanghai', 'Asia/Shanghai'), ('Asia/Singapore', 'Asia/Singapore'), ('Asia/Srednekolymsk', 'Asia/Srednekolymsk'), ('Asia/Taipei', 'Asia/Taipei'), ('Asia/Tashkent', 'Asia/Tashkent'), ('Asia/Tbilisi', 'Asia/Tbilisi'), ('Asia/Tehran', 'Asia/Tehran'), ('Asia/Thimphu', 'Asia/Thimphu'), ('Asia/Tokyo', 'Asia/Tokyo'), ('Asia/Ulaanbaatar', 'Asia/Ulaanbaatar'), ('Asia/Urumqi', 'Asia/Urumqi'), ('Asia/Ust-Nera', 'Asia/Ust-Nera'), ('Asia/Vientiane', 'Asia/Vientiane'), ('Asia/Vladivostok', 'Asia/Vladivostok'), ('Asia/Yakutsk', 'Asia/Yakutsk'), ('Asia/Yekaterinburg', 'Asia/Yekaterinburg'), ('Asia/Yerevan', 'Asia/Yerevan'), ('Atlantic/Azores', 'Atlantic/Azores'), ('Atlantic/Bermuda', 'Atlantic/Bermuda'), ('Atlantic/Canary', 'Atlantic/Canary'), ('Atlantic/Cape_Verde', 'Atlantic/Cape_Verde'), ('Atlantic/Faroe', 'Atlantic/Faroe'), ('Atlantic/Madeira', 'Atlantic/Madeira'), ('Atlantic/Reykjavik', 'Atlantic/Reykjavik'), ('Atlantic/South_Georgia', 'Atlantic/South_Georgia'), ('Atlantic/St_Helena', 'Atlantic/St_Helena'), ('Atlantic/Stanley', 'Atlantic/Stanley'), ('Australia/Adelaide', 'Australia/Adelaide'), ('Australia/Brisbane', 'Australia/Brisbane'), ('Australia/Broken_Hill', 'Australia/Broken_Hill'), ('Australia/Currie', 'Australia/Currie'), ('Australia/Darwin', 'Australia/Darwin'), ('Australia/Eucla', 'Australia/Eucla'), ('Australia/Hobart', 'Australia/Hobart'), ('Australia/Lindeman', 'Australia/Lindeman'), ('Australia/Lord_Howe', 'Australia/Lord_Howe'), ('Australia/Melbourne', 'Australia/Melbourne'), ('Australia/Perth', 'Australia/Perth'), ('Australia/Sydney', 'Australia/Sydney'), ('Canada/Atlantic', 'Canada/Atlantic'), ('Canada/Central', 'Canada/Central'), ('Canada/Eastern', 'Canada/Eastern'), ('Canada/Mountain', 'Canada/Mountain'), ('Canada/Newfoundland', 'Canada/Newfoundland'), ('Canada/Pacific', 'Canada/Pacific'), ('Europe/Amsterdam', 'Europe/Amsterdam'), ('Europe/Andorra', 'Europe/Andorra'), ('Europe/Athens', 'Europe/Athens'), ('Europe/Belgrade', 'Europe/Belgrade'), ('Europe/Berlin', 'Europe/Berlin'), ('Europe/Bratislava', 'Europe/Bratislava'), ('Europe/Brussels', 'Europe/Brussels'), ('Europe/Bucharest', 'Europe/Bucharest'), ('Europe/Budapest', 'Europe/Budapest'), ('Europe/Busingen', 'Europe/Busingen'), ('Europe/Chisinau', 'Europe/Chisinau'), ('Europe/Copenhagen', 'Europe/Copenhagen'), ('Europe/Dublin', 'Europe/Dublin'), ('Europe/Gibraltar', 'Europe/Gibraltar'), ('Europe/Guernsey', 'Europe/Guernsey'), ('Europe/Helsinki', 'Europe/Helsinki'), ('Europe/Isle_of_Man', 'Europe/Isle_of_Man'), ('Europe/Istanbul', 'Europe/Istanbul'), ('Europe/Jersey', 'Europe/Jersey'), ('Europe/Kaliningrad', 'Europe/Kaliningrad'), ('Europe/Kiev', 'Europe/Kiev'), ('Europe/Lisbon', 'Europe/Lisbon'), ('Europe/Ljubljana', 'Europe/Ljubljana'), ('Europe/London', 'Europe/London'), ('Europe/Luxembourg', 'Europe/Luxembourg'), ('Europe/Madrid', 'Europe/Madrid'), ('Europe/Malta', 'Europe/Malta'), ('Europe/Mariehamn', 'Europe/Mariehamn'), ('Europe/Minsk', 'Europe/Minsk'), ('Europe/Monaco', 'Europe/Monaco'), ('Europe/Moscow', 'Europe/Moscow'), ('Europe/Oslo', 'Europe/Oslo'), ('Europe/Paris', 'Europe/Paris'), ('Europe/Podgorica', 'Europe/Podgorica'), ('Europe/Prague', 'Europe/Prague'), ('Europe/Riga', 'Europe/Riga'), ('Europe/Rome', 'Europe/Rome'), ('Europe/Samara', 'Europe/Samara'), ('Europe/San_Marino', 'Europe/San_Marino'), ('Europe/Sarajevo', 'Europe/Sarajevo'), ('Europe/Simferopol', 'Europe/Simferopol'), ('Europe/Skopje', 'Europe/Skopje'), ('Europe/Sofia', 'Europe/Sofia'), ('Europe/Stockholm', 'Europe/Stockholm'), ('Europe/Tallinn', 'Europe/Tallinn'), ('Europe/Tirane', 'Europe/Tirane'), ('Europe/Uzhgorod', 'Europe/Uzhgorod'), ('Europe/Vaduz', 'Europe/Vaduz'), ('Europe/Vatican', 'Europe/Vatican'), ('Europe/Vienna', 'Europe/Vienna'), ('Europe/Vilnius', 'Europe/Vilnius'), ('Europe/Volgograd', 'Europe/Volgograd'), ('Europe/Warsaw', 'Europe/Warsaw'), ('Europe/Zagreb', 'Europe/Zagreb'), ('Europe/Zaporozhye', 'Europe/Zaporozhye'), ('Europe/Zurich', 'Europe/Zurich'), ('GMT', 'GMT'), ('Indian/Antananarivo', 'Indian/Antananarivo'), ('Indian/Chagos', 'Indian/Chagos'), ('Indian/Christmas', 'Indian/Christmas'), ('Indian/Cocos', 'Indian/Cocos'), ('Indian/Comoro', 'Indian/Comoro'), ('Indian/Kerguelen', 'Indian/Kerguelen'), ('Indian/Mahe', 'Indian/Mahe'), ('Indian/Maldives', 'Indian/Maldives'), ('Indian/Mauritius', 'Indian/Mauritius'), ('Indian/Mayotte', 'Indian/Mayotte'), ('Indian/Reunion', 'Indian/Reunion'), ('Pacific/Apia', 'Pacific/Apia'), ('Pacific/Auckland', 'Pacific/Auckland'), ('Pacific/Bougainville', 'Pacific/Bougainville'), ('Pacific/Chatham', 'Pacific/Chatham'), ('Pacific/Chuuk', 'Pacific/Chuuk'), ('Pacific/Easter', 'Pacific/Easter'), ('Pacific/Efate', 'Pacific/Efate'), ('Pacific/Enderbury', 'Pacific/Enderbury'), ('Pacific/Fakaofo', 'Pacific/Fakaofo'), ('Pacific/Fiji', 'Pacific/Fiji'), ('Pacific/Funafuti', 'Pacific/Funafuti'), ('Pacific/Galapagos', 'Pacific/Galapagos'), ('Pacific/Gambier', 'Pacific/Gambier'), ('Pacific/Guadalcanal', 'Pacific/Guadalcanal'), ('Pacific/Guam', 'Pacific/Guam'), ('Pacific/Honolulu', 'Pacific/Honolulu'), ('Pacific/Johnston', 'Pacific/Johnston'), ('Pacific/Kiritimati', 'Pacific/Kiritimati'), ('Pacific/Kosrae', 'Pacific/Kosrae'), ('Pacific/Kwajalein', 'Pacific/Kwajalein'), ('Pacific/Majuro', 'Pacific/Majuro'), ('Pacific/Marquesas', 'Pacific/Marquesas'), ('Pacific/Midway', 'Pacific/Midway'), ('Pacific/Nauru', 'Pacific/Nauru'), ('Pacific/Niue', 'Pacific/Niue'), ('Pacific/Norfolk', 'Pacific/Norfolk'), ('Pacific/Noumea', 'Pacific/Noumea'), ('Pacific/Pago_Pago', 'Pacific/Pago_Pago'), ('Pacific/Palau', 'Pacific/Palau'), ('Pacific/Pitcairn', 'Pacific/Pitcairn'), ('Pacific/Pohnpei', 'Pacific/Pohnpei'), ('Pacific/Port_Moresby', 'Pacific/Port_Moresby'), ('Pacific/Rarotonga', 'Pacific/Rarotonga'), ('Pacific/Saipan', 'Pacific/Saipan'), ('Pacific/Tahiti', 'Pacific/Tahiti'), ('Pacific/Tarawa', 'Pacific/Tarawa'), ('Pacific/Tongatapu', 'Pacific/Tongatapu'), ('Pacific/Wake', 'Pacific/Wake'), ('Pacific/Wallis', 'Pacific/Wallis'), ('US/Alaska', 'US/Alaska'), ('US/Arizona', 'US/Arizona'), ('US/Central', 'US/Central'), ('US/Eastern', 'US/Eastern'), ('US/Hawaii', 'US/Hawaii'), ('US/Mountain', 'US/Mountain'), ('US/Pacific', 'US/Pacific'), ('UTC', 'UTC')], default='US/Eastern', max_length=64, verbose_name='Schedule Timezone')),
-                ('scheduledatetimefield', models.CharField(blank=True, max_length=128, verbose_name='Schedule Datetime')),
-                ('schedulegamefield', models.CharField(blank=True, max_length=128, verbose_name='Schdule Game')),
-                ('schedulerunnersfield', models.CharField(blank=True, max_length=128, verbose_name='Schedule Runners')),
-                ('scheduleestimatefield', models.CharField(blank=True, max_length=128, verbose_name='Schedule Estimate')),
-                ('schedulesetupfield', models.CharField(blank=True, max_length=128, verbose_name='Schedule Setup')),
-                ('schedulecommentatorsfield', models.CharField(blank=True, max_length=128, verbose_name='Schedule Commentators')),
-                ('schedulecommentsfield', models.CharField(blank=True, max_length=128, verbose_name='Schedule Comments')),
+                (
+                    'receivername',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Receiver Name'
+                    ),
+                ),
+                (
+                    'targetamount',
+                    models.DecimalField(
+                        decimal_places=2,
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Target Amount',
+                    ),
+                ),
+                (
+                    'usepaypalsandbox',
+                    models.BooleanField(
+                        default=False, verbose_name='Use Paypal Sandbox'
+                    ),
+                ),
+                (
+                    'paypalemail',
+                    models.EmailField(max_length=128, verbose_name='Receiver Paypal'),
+                ),
+                (
+                    'paypalcurrency',
+                    models.CharField(
+                        choices=[('USD', 'US Dollars'), ('CAD', 'Canadian Dollars')],
+                        default='USD',
+                        max_length=8,
+                        verbose_name='Currency',
+                    ),
+                ),
+                (
+                    'donationemailsender',
+                    models.EmailField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        verbose_name='Donation Email Sender',
+                    ),
+                ),
+                (
+                    'scheduleid',
+                    models.CharField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        unique=True,
+                        verbose_name='Schedule ID',
+                    ),
+                ),
+                (
+                    'scheduletimezone',
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ('Africa/Abidjan', 'Africa/Abidjan'),
+                            ('Africa/Accra', 'Africa/Accra'),
+                            ('Africa/Addis_Ababa', 'Africa/Addis_Ababa'),
+                            ('Africa/Algiers', 'Africa/Algiers'),
+                            ('Africa/Asmara', 'Africa/Asmara'),
+                            ('Africa/Bamako', 'Africa/Bamako'),
+                            ('Africa/Bangui', 'Africa/Bangui'),
+                            ('Africa/Banjul', 'Africa/Banjul'),
+                            ('Africa/Bissau', 'Africa/Bissau'),
+                            ('Africa/Blantyre', 'Africa/Blantyre'),
+                            ('Africa/Brazzaville', 'Africa/Brazzaville'),
+                            ('Africa/Bujumbura', 'Africa/Bujumbura'),
+                            ('Africa/Cairo', 'Africa/Cairo'),
+                            ('Africa/Casablanca', 'Africa/Casablanca'),
+                            ('Africa/Ceuta', 'Africa/Ceuta'),
+                            ('Africa/Conakry', 'Africa/Conakry'),
+                            ('Africa/Dakar', 'Africa/Dakar'),
+                            ('Africa/Dar_es_Salaam', 'Africa/Dar_es_Salaam'),
+                            ('Africa/Djibouti', 'Africa/Djibouti'),
+                            ('Africa/Douala', 'Africa/Douala'),
+                            ('Africa/El_Aaiun', 'Africa/El_Aaiun'),
+                            ('Africa/Freetown', 'Africa/Freetown'),
+                            ('Africa/Gaborone', 'Africa/Gaborone'),
+                            ('Africa/Harare', 'Africa/Harare'),
+                            ('Africa/Johannesburg', 'Africa/Johannesburg'),
+                            ('Africa/Juba', 'Africa/Juba'),
+                            ('Africa/Kampala', 'Africa/Kampala'),
+                            ('Africa/Khartoum', 'Africa/Khartoum'),
+                            ('Africa/Kigali', 'Africa/Kigali'),
+                            ('Africa/Kinshasa', 'Africa/Kinshasa'),
+                            ('Africa/Lagos', 'Africa/Lagos'),
+                            ('Africa/Libreville', 'Africa/Libreville'),
+                            ('Africa/Lome', 'Africa/Lome'),
+                            ('Africa/Luanda', 'Africa/Luanda'),
+                            ('Africa/Lubumbashi', 'Africa/Lubumbashi'),
+                            ('Africa/Lusaka', 'Africa/Lusaka'),
+                            ('Africa/Malabo', 'Africa/Malabo'),
+                            ('Africa/Maputo', 'Africa/Maputo'),
+                            ('Africa/Maseru', 'Africa/Maseru'),
+                            ('Africa/Mbabane', 'Africa/Mbabane'),
+                            ('Africa/Mogadishu', 'Africa/Mogadishu'),
+                            ('Africa/Monrovia', 'Africa/Monrovia'),
+                            ('Africa/Nairobi', 'Africa/Nairobi'),
+                            ('Africa/Ndjamena', 'Africa/Ndjamena'),
+                            ('Africa/Niamey', 'Africa/Niamey'),
+                            ('Africa/Nouakchott', 'Africa/Nouakchott'),
+                            ('Africa/Ouagadougou', 'Africa/Ouagadougou'),
+                            ('Africa/Porto-Novo', 'Africa/Porto-Novo'),
+                            ('Africa/Sao_Tome', 'Africa/Sao_Tome'),
+                            ('Africa/Tripoli', 'Africa/Tripoli'),
+                            ('Africa/Tunis', 'Africa/Tunis'),
+                            ('Africa/Windhoek', 'Africa/Windhoek'),
+                            ('America/Adak', 'America/Adak'),
+                            ('America/Anchorage', 'America/Anchorage'),
+                            ('America/Anguilla', 'America/Anguilla'),
+                            ('America/Antigua', 'America/Antigua'),
+                            ('America/Araguaina', 'America/Araguaina'),
+                            (
+                                'America/Argentina/Buenos_Aires',
+                                'America/Argentina/Buenos_Aires',
+                            ),
+                            (
+                                'America/Argentina/Catamarca',
+                                'America/Argentina/Catamarca',
+                            ),
+                            ('America/Argentina/Cordoba', 'America/Argentina/Cordoba'),
+                            ('America/Argentina/Jujuy', 'America/Argentina/Jujuy'),
+                            (
+                                'America/Argentina/La_Rioja',
+                                'America/Argentina/La_Rioja',
+                            ),
+                            ('America/Argentina/Mendoza', 'America/Argentina/Mendoza'),
+                            (
+                                'America/Argentina/Rio_Gallegos',
+                                'America/Argentina/Rio_Gallegos',
+                            ),
+                            ('America/Argentina/Salta', 'America/Argentina/Salta'),
+                            (
+                                'America/Argentina/San_Juan',
+                                'America/Argentina/San_Juan',
+                            ),
+                            (
+                                'America/Argentina/San_Luis',
+                                'America/Argentina/San_Luis',
+                            ),
+                            ('America/Argentina/Tucuman', 'America/Argentina/Tucuman'),
+                            ('America/Argentina/Ushuaia', 'America/Argentina/Ushuaia'),
+                            ('America/Aruba', 'America/Aruba'),
+                            ('America/Asuncion', 'America/Asuncion'),
+                            ('America/Atikokan', 'America/Atikokan'),
+                            ('America/Bahia', 'America/Bahia'),
+                            ('America/Bahia_Banderas', 'America/Bahia_Banderas'),
+                            ('America/Barbados', 'America/Barbados'),
+                            ('America/Belem', 'America/Belem'),
+                            ('America/Belize', 'America/Belize'),
+                            ('America/Blanc-Sablon', 'America/Blanc-Sablon'),
+                            ('America/Boa_Vista', 'America/Boa_Vista'),
+                            ('America/Bogota', 'America/Bogota'),
+                            ('America/Boise', 'America/Boise'),
+                            ('America/Cambridge_Bay', 'America/Cambridge_Bay'),
+                            ('America/Campo_Grande', 'America/Campo_Grande'),
+                            ('America/Cancun', 'America/Cancun'),
+                            ('America/Caracas', 'America/Caracas'),
+                            ('America/Cayenne', 'America/Cayenne'),
+                            ('America/Cayman', 'America/Cayman'),
+                            ('America/Chicago', 'America/Chicago'),
+                            ('America/Chihuahua', 'America/Chihuahua'),
+                            ('America/Costa_Rica', 'America/Costa_Rica'),
+                            ('America/Creston', 'America/Creston'),
+                            ('America/Cuiaba', 'America/Cuiaba'),
+                            ('America/Curacao', 'America/Curacao'),
+                            ('America/Danmarkshavn', 'America/Danmarkshavn'),
+                            ('America/Dawson', 'America/Dawson'),
+                            ('America/Dawson_Creek', 'America/Dawson_Creek'),
+                            ('America/Denver', 'America/Denver'),
+                            ('America/Detroit', 'America/Detroit'),
+                            ('America/Dominica', 'America/Dominica'),
+                            ('America/Edmonton', 'America/Edmonton'),
+                            ('America/Eirunepe', 'America/Eirunepe'),
+                            ('America/El_Salvador', 'America/El_Salvador'),
+                            ('America/Fortaleza', 'America/Fortaleza'),
+                            ('America/Glace_Bay', 'America/Glace_Bay'),
+                            ('America/Godthab', 'America/Godthab'),
+                            ('America/Goose_Bay', 'America/Goose_Bay'),
+                            ('America/Grand_Turk', 'America/Grand_Turk'),
+                            ('America/Grenada', 'America/Grenada'),
+                            ('America/Guadeloupe', 'America/Guadeloupe'),
+                            ('America/Guatemala', 'America/Guatemala'),
+                            ('America/Guayaquil', 'America/Guayaquil'),
+                            ('America/Guyana', 'America/Guyana'),
+                            ('America/Halifax', 'America/Halifax'),
+                            ('America/Havana', 'America/Havana'),
+                            ('America/Hermosillo', 'America/Hermosillo'),
+                            (
+                                'America/Indiana/Indianapolis',
+                                'America/Indiana/Indianapolis',
+                            ),
+                            ('America/Indiana/Knox', 'America/Indiana/Knox'),
+                            ('America/Indiana/Marengo', 'America/Indiana/Marengo'),
+                            (
+                                'America/Indiana/Petersburg',
+                                'America/Indiana/Petersburg',
+                            ),
+                            ('America/Indiana/Tell_City', 'America/Indiana/Tell_City'),
+                            ('America/Indiana/Vevay', 'America/Indiana/Vevay'),
+                            ('America/Indiana/Vincennes', 'America/Indiana/Vincennes'),
+                            ('America/Indiana/Winamac', 'America/Indiana/Winamac'),
+                            ('America/Inuvik', 'America/Inuvik'),
+                            ('America/Iqaluit', 'America/Iqaluit'),
+                            ('America/Jamaica', 'America/Jamaica'),
+                            ('America/Juneau', 'America/Juneau'),
+                            (
+                                'America/Kentucky/Louisville',
+                                'America/Kentucky/Louisville',
+                            ),
+                            (
+                                'America/Kentucky/Monticello',
+                                'America/Kentucky/Monticello',
+                            ),
+                            ('America/Kralendijk', 'America/Kralendijk'),
+                            ('America/La_Paz', 'America/La_Paz'),
+                            ('America/Lima', 'America/Lima'),
+                            ('America/Los_Angeles', 'America/Los_Angeles'),
+                            ('America/Lower_Princes', 'America/Lower_Princes'),
+                            ('America/Maceio', 'America/Maceio'),
+                            ('America/Managua', 'America/Managua'),
+                            ('America/Manaus', 'America/Manaus'),
+                            ('America/Marigot', 'America/Marigot'),
+                            ('America/Martinique', 'America/Martinique'),
+                            ('America/Matamoros', 'America/Matamoros'),
+                            ('America/Mazatlan', 'America/Mazatlan'),
+                            ('America/Menominee', 'America/Menominee'),
+                            ('America/Merida', 'America/Merida'),
+                            ('America/Metlakatla', 'America/Metlakatla'),
+                            ('America/Mexico_City', 'America/Mexico_City'),
+                            ('America/Miquelon', 'America/Miquelon'),
+                            ('America/Moncton', 'America/Moncton'),
+                            ('America/Monterrey', 'America/Monterrey'),
+                            ('America/Montevideo', 'America/Montevideo'),
+                            ('America/Montserrat', 'America/Montserrat'),
+                            ('America/Nassau', 'America/Nassau'),
+                            ('America/New_York', 'America/New_York'),
+                            ('America/Nipigon', 'America/Nipigon'),
+                            ('America/Nome', 'America/Nome'),
+                            ('America/Noronha', 'America/Noronha'),
+                            (
+                                'America/North_Dakota/Beulah',
+                                'America/North_Dakota/Beulah',
+                            ),
+                            (
+                                'America/North_Dakota/Center',
+                                'America/North_Dakota/Center',
+                            ),
+                            (
+                                'America/North_Dakota/New_Salem',
+                                'America/North_Dakota/New_Salem',
+                            ),
+                            ('America/Ojinaga', 'America/Ojinaga'),
+                            ('America/Panama', 'America/Panama'),
+                            ('America/Pangnirtung', 'America/Pangnirtung'),
+                            ('America/Paramaribo', 'America/Paramaribo'),
+                            ('America/Phoenix', 'America/Phoenix'),
+                            ('America/Port-au-Prince', 'America/Port-au-Prince'),
+                            ('America/Port_of_Spain', 'America/Port_of_Spain'),
+                            ('America/Porto_Velho', 'America/Porto_Velho'),
+                            ('America/Puerto_Rico', 'America/Puerto_Rico'),
+                            ('America/Rainy_River', 'America/Rainy_River'),
+                            ('America/Rankin_Inlet', 'America/Rankin_Inlet'),
+                            ('America/Recife', 'America/Recife'),
+                            ('America/Regina', 'America/Regina'),
+                            ('America/Resolute', 'America/Resolute'),
+                            ('America/Rio_Branco', 'America/Rio_Branco'),
+                            ('America/Santa_Isabel', 'America/Santa_Isabel'),
+                            ('America/Santarem', 'America/Santarem'),
+                            ('America/Santiago', 'America/Santiago'),
+                            ('America/Santo_Domingo', 'America/Santo_Domingo'),
+                            ('America/Sao_Paulo', 'America/Sao_Paulo'),
+                            ('America/Scoresbysund', 'America/Scoresbysund'),
+                            ('America/Sitka', 'America/Sitka'),
+                            ('America/St_Barthelemy', 'America/St_Barthelemy'),
+                            ('America/St_Johns', 'America/St_Johns'),
+                            ('America/St_Kitts', 'America/St_Kitts'),
+                            ('America/St_Lucia', 'America/St_Lucia'),
+                            ('America/St_Thomas', 'America/St_Thomas'),
+                            ('America/St_Vincent', 'America/St_Vincent'),
+                            ('America/Swift_Current', 'America/Swift_Current'),
+                            ('America/Tegucigalpa', 'America/Tegucigalpa'),
+                            ('America/Thule', 'America/Thule'),
+                            ('America/Thunder_Bay', 'America/Thunder_Bay'),
+                            ('America/Tijuana', 'America/Tijuana'),
+                            ('America/Toronto', 'America/Toronto'),
+                            ('America/Tortola', 'America/Tortola'),
+                            ('America/Vancouver', 'America/Vancouver'),
+                            ('America/Whitehorse', 'America/Whitehorse'),
+                            ('America/Winnipeg', 'America/Winnipeg'),
+                            ('America/Yakutat', 'America/Yakutat'),
+                            ('America/Yellowknife', 'America/Yellowknife'),
+                            ('Antarctica/Casey', 'Antarctica/Casey'),
+                            ('Antarctica/Davis', 'Antarctica/Davis'),
+                            ('Antarctica/DumontDUrville', 'Antarctica/DumontDUrville'),
+                            ('Antarctica/Macquarie', 'Antarctica/Macquarie'),
+                            ('Antarctica/Mawson', 'Antarctica/Mawson'),
+                            ('Antarctica/McMurdo', 'Antarctica/McMurdo'),
+                            ('Antarctica/Palmer', 'Antarctica/Palmer'),
+                            ('Antarctica/Rothera', 'Antarctica/Rothera'),
+                            ('Antarctica/Syowa', 'Antarctica/Syowa'),
+                            ('Antarctica/Troll', 'Antarctica/Troll'),
+                            ('Antarctica/Vostok', 'Antarctica/Vostok'),
+                            ('Arctic/Longyearbyen', 'Arctic/Longyearbyen'),
+                            ('Asia/Aden', 'Asia/Aden'),
+                            ('Asia/Almaty', 'Asia/Almaty'),
+                            ('Asia/Amman', 'Asia/Amman'),
+                            ('Asia/Anadyr', 'Asia/Anadyr'),
+                            ('Asia/Aqtau', 'Asia/Aqtau'),
+                            ('Asia/Aqtobe', 'Asia/Aqtobe'),
+                            ('Asia/Ashgabat', 'Asia/Ashgabat'),
+                            ('Asia/Baghdad', 'Asia/Baghdad'),
+                            ('Asia/Bahrain', 'Asia/Bahrain'),
+                            ('Asia/Baku', 'Asia/Baku'),
+                            ('Asia/Bangkok', 'Asia/Bangkok'),
+                            ('Asia/Beirut', 'Asia/Beirut'),
+                            ('Asia/Bishkek', 'Asia/Bishkek'),
+                            ('Asia/Brunei', 'Asia/Brunei'),
+                            ('Asia/Chita', 'Asia/Chita'),
+                            ('Asia/Choibalsan', 'Asia/Choibalsan'),
+                            ('Asia/Colombo', 'Asia/Colombo'),
+                            ('Asia/Damascus', 'Asia/Damascus'),
+                            ('Asia/Dhaka', 'Asia/Dhaka'),
+                            ('Asia/Dili', 'Asia/Dili'),
+                            ('Asia/Dubai', 'Asia/Dubai'),
+                            ('Asia/Dushanbe', 'Asia/Dushanbe'),
+                            ('Asia/Gaza', 'Asia/Gaza'),
+                            ('Asia/Hebron', 'Asia/Hebron'),
+                            ('Asia/Ho_Chi_Minh', 'Asia/Ho_Chi_Minh'),
+                            ('Asia/Hong_Kong', 'Asia/Hong_Kong'),
+                            ('Asia/Hovd', 'Asia/Hovd'),
+                            ('Asia/Irkutsk', 'Asia/Irkutsk'),
+                            ('Asia/Jakarta', 'Asia/Jakarta'),
+                            ('Asia/Jayapura', 'Asia/Jayapura'),
+                            ('Asia/Jerusalem', 'Asia/Jerusalem'),
+                            ('Asia/Kabul', 'Asia/Kabul'),
+                            ('Asia/Kamchatka', 'Asia/Kamchatka'),
+                            ('Asia/Karachi', 'Asia/Karachi'),
+                            ('Asia/Kathmandu', 'Asia/Kathmandu'),
+                            ('Asia/Khandyga', 'Asia/Khandyga'),
+                            ('Asia/Kolkata', 'Asia/Kolkata'),
+                            ('Asia/Krasnoyarsk', 'Asia/Krasnoyarsk'),
+                            ('Asia/Kuala_Lumpur', 'Asia/Kuala_Lumpur'),
+                            ('Asia/Kuching', 'Asia/Kuching'),
+                            ('Asia/Kuwait', 'Asia/Kuwait'),
+                            ('Asia/Macau', 'Asia/Macau'),
+                            ('Asia/Magadan', 'Asia/Magadan'),
+                            ('Asia/Makassar', 'Asia/Makassar'),
+                            ('Asia/Manila', 'Asia/Manila'),
+                            ('Asia/Muscat', 'Asia/Muscat'),
+                            ('Asia/Nicosia', 'Asia/Nicosia'),
+                            ('Asia/Novokuznetsk', 'Asia/Novokuznetsk'),
+                            ('Asia/Novosibirsk', 'Asia/Novosibirsk'),
+                            ('Asia/Omsk', 'Asia/Omsk'),
+                            ('Asia/Oral', 'Asia/Oral'),
+                            ('Asia/Phnom_Penh', 'Asia/Phnom_Penh'),
+                            ('Asia/Pontianak', 'Asia/Pontianak'),
+                            ('Asia/Pyongyang', 'Asia/Pyongyang'),
+                            ('Asia/Qatar', 'Asia/Qatar'),
+                            ('Asia/Qyzylorda', 'Asia/Qyzylorda'),
+                            ('Asia/Rangoon', 'Asia/Rangoon'),
+                            ('Asia/Riyadh', 'Asia/Riyadh'),
+                            ('Asia/Sakhalin', 'Asia/Sakhalin'),
+                            ('Asia/Samarkand', 'Asia/Samarkand'),
+                            ('Asia/Seoul', 'Asia/Seoul'),
+                            ('Asia/Shanghai', 'Asia/Shanghai'),
+                            ('Asia/Singapore', 'Asia/Singapore'),
+                            ('Asia/Srednekolymsk', 'Asia/Srednekolymsk'),
+                            ('Asia/Taipei', 'Asia/Taipei'),
+                            ('Asia/Tashkent', 'Asia/Tashkent'),
+                            ('Asia/Tbilisi', 'Asia/Tbilisi'),
+                            ('Asia/Tehran', 'Asia/Tehran'),
+                            ('Asia/Thimphu', 'Asia/Thimphu'),
+                            ('Asia/Tokyo', 'Asia/Tokyo'),
+                            ('Asia/Ulaanbaatar', 'Asia/Ulaanbaatar'),
+                            ('Asia/Urumqi', 'Asia/Urumqi'),
+                            ('Asia/Ust-Nera', 'Asia/Ust-Nera'),
+                            ('Asia/Vientiane', 'Asia/Vientiane'),
+                            ('Asia/Vladivostok', 'Asia/Vladivostok'),
+                            ('Asia/Yakutsk', 'Asia/Yakutsk'),
+                            ('Asia/Yekaterinburg', 'Asia/Yekaterinburg'),
+                            ('Asia/Yerevan', 'Asia/Yerevan'),
+                            ('Atlantic/Azores', 'Atlantic/Azores'),
+                            ('Atlantic/Bermuda', 'Atlantic/Bermuda'),
+                            ('Atlantic/Canary', 'Atlantic/Canary'),
+                            ('Atlantic/Cape_Verde', 'Atlantic/Cape_Verde'),
+                            ('Atlantic/Faroe', 'Atlantic/Faroe'),
+                            ('Atlantic/Madeira', 'Atlantic/Madeira'),
+                            ('Atlantic/Reykjavik', 'Atlantic/Reykjavik'),
+                            ('Atlantic/South_Georgia', 'Atlantic/South_Georgia'),
+                            ('Atlantic/St_Helena', 'Atlantic/St_Helena'),
+                            ('Atlantic/Stanley', 'Atlantic/Stanley'),
+                            ('Australia/Adelaide', 'Australia/Adelaide'),
+                            ('Australia/Brisbane', 'Australia/Brisbane'),
+                            ('Australia/Broken_Hill', 'Australia/Broken_Hill'),
+                            ('Australia/Currie', 'Australia/Currie'),
+                            ('Australia/Darwin', 'Australia/Darwin'),
+                            ('Australia/Eucla', 'Australia/Eucla'),
+                            ('Australia/Hobart', 'Australia/Hobart'),
+                            ('Australia/Lindeman', 'Australia/Lindeman'),
+                            ('Australia/Lord_Howe', 'Australia/Lord_Howe'),
+                            ('Australia/Melbourne', 'Australia/Melbourne'),
+                            ('Australia/Perth', 'Australia/Perth'),
+                            ('Australia/Sydney', 'Australia/Sydney'),
+                            ('Canada/Atlantic', 'Canada/Atlantic'),
+                            ('Canada/Central', 'Canada/Central'),
+                            ('Canada/Eastern', 'Canada/Eastern'),
+                            ('Canada/Mountain', 'Canada/Mountain'),
+                            ('Canada/Newfoundland', 'Canada/Newfoundland'),
+                            ('Canada/Pacific', 'Canada/Pacific'),
+                            ('Europe/Amsterdam', 'Europe/Amsterdam'),
+                            ('Europe/Andorra', 'Europe/Andorra'),
+                            ('Europe/Athens', 'Europe/Athens'),
+                            ('Europe/Belgrade', 'Europe/Belgrade'),
+                            ('Europe/Berlin', 'Europe/Berlin'),
+                            ('Europe/Bratislava', 'Europe/Bratislava'),
+                            ('Europe/Brussels', 'Europe/Brussels'),
+                            ('Europe/Bucharest', 'Europe/Bucharest'),
+                            ('Europe/Budapest', 'Europe/Budapest'),
+                            ('Europe/Busingen', 'Europe/Busingen'),
+                            ('Europe/Chisinau', 'Europe/Chisinau'),
+                            ('Europe/Copenhagen', 'Europe/Copenhagen'),
+                            ('Europe/Dublin', 'Europe/Dublin'),
+                            ('Europe/Gibraltar', 'Europe/Gibraltar'),
+                            ('Europe/Guernsey', 'Europe/Guernsey'),
+                            ('Europe/Helsinki', 'Europe/Helsinki'),
+                            ('Europe/Isle_of_Man', 'Europe/Isle_of_Man'),
+                            ('Europe/Istanbul', 'Europe/Istanbul'),
+                            ('Europe/Jersey', 'Europe/Jersey'),
+                            ('Europe/Kaliningrad', 'Europe/Kaliningrad'),
+                            ('Europe/Kiev', 'Europe/Kiev'),
+                            ('Europe/Lisbon', 'Europe/Lisbon'),
+                            ('Europe/Ljubljana', 'Europe/Ljubljana'),
+                            ('Europe/London', 'Europe/London'),
+                            ('Europe/Luxembourg', 'Europe/Luxembourg'),
+                            ('Europe/Madrid', 'Europe/Madrid'),
+                            ('Europe/Malta', 'Europe/Malta'),
+                            ('Europe/Mariehamn', 'Europe/Mariehamn'),
+                            ('Europe/Minsk', 'Europe/Minsk'),
+                            ('Europe/Monaco', 'Europe/Monaco'),
+                            ('Europe/Moscow', 'Europe/Moscow'),
+                            ('Europe/Oslo', 'Europe/Oslo'),
+                            ('Europe/Paris', 'Europe/Paris'),
+                            ('Europe/Podgorica', 'Europe/Podgorica'),
+                            ('Europe/Prague', 'Europe/Prague'),
+                            ('Europe/Riga', 'Europe/Riga'),
+                            ('Europe/Rome', 'Europe/Rome'),
+                            ('Europe/Samara', 'Europe/Samara'),
+                            ('Europe/San_Marino', 'Europe/San_Marino'),
+                            ('Europe/Sarajevo', 'Europe/Sarajevo'),
+                            ('Europe/Simferopol', 'Europe/Simferopol'),
+                            ('Europe/Skopje', 'Europe/Skopje'),
+                            ('Europe/Sofia', 'Europe/Sofia'),
+                            ('Europe/Stockholm', 'Europe/Stockholm'),
+                            ('Europe/Tallinn', 'Europe/Tallinn'),
+                            ('Europe/Tirane', 'Europe/Tirane'),
+                            ('Europe/Uzhgorod', 'Europe/Uzhgorod'),
+                            ('Europe/Vaduz', 'Europe/Vaduz'),
+                            ('Europe/Vatican', 'Europe/Vatican'),
+                            ('Europe/Vienna', 'Europe/Vienna'),
+                            ('Europe/Vilnius', 'Europe/Vilnius'),
+                            ('Europe/Volgograd', 'Europe/Volgograd'),
+                            ('Europe/Warsaw', 'Europe/Warsaw'),
+                            ('Europe/Zagreb', 'Europe/Zagreb'),
+                            ('Europe/Zaporozhye', 'Europe/Zaporozhye'),
+                            ('Europe/Zurich', 'Europe/Zurich'),
+                            ('GMT', 'GMT'),
+                            ('Indian/Antananarivo', 'Indian/Antananarivo'),
+                            ('Indian/Chagos', 'Indian/Chagos'),
+                            ('Indian/Christmas', 'Indian/Christmas'),
+                            ('Indian/Cocos', 'Indian/Cocos'),
+                            ('Indian/Comoro', 'Indian/Comoro'),
+                            ('Indian/Kerguelen', 'Indian/Kerguelen'),
+                            ('Indian/Mahe', 'Indian/Mahe'),
+                            ('Indian/Maldives', 'Indian/Maldives'),
+                            ('Indian/Mauritius', 'Indian/Mauritius'),
+                            ('Indian/Mayotte', 'Indian/Mayotte'),
+                            ('Indian/Reunion', 'Indian/Reunion'),
+                            ('Pacific/Apia', 'Pacific/Apia'),
+                            ('Pacific/Auckland', 'Pacific/Auckland'),
+                            ('Pacific/Bougainville', 'Pacific/Bougainville'),
+                            ('Pacific/Chatham', 'Pacific/Chatham'),
+                            ('Pacific/Chuuk', 'Pacific/Chuuk'),
+                            ('Pacific/Easter', 'Pacific/Easter'),
+                            ('Pacific/Efate', 'Pacific/Efate'),
+                            ('Pacific/Enderbury', 'Pacific/Enderbury'),
+                            ('Pacific/Fakaofo', 'Pacific/Fakaofo'),
+                            ('Pacific/Fiji', 'Pacific/Fiji'),
+                            ('Pacific/Funafuti', 'Pacific/Funafuti'),
+                            ('Pacific/Galapagos', 'Pacific/Galapagos'),
+                            ('Pacific/Gambier', 'Pacific/Gambier'),
+                            ('Pacific/Guadalcanal', 'Pacific/Guadalcanal'),
+                            ('Pacific/Guam', 'Pacific/Guam'),
+                            ('Pacific/Honolulu', 'Pacific/Honolulu'),
+                            ('Pacific/Johnston', 'Pacific/Johnston'),
+                            ('Pacific/Kiritimati', 'Pacific/Kiritimati'),
+                            ('Pacific/Kosrae', 'Pacific/Kosrae'),
+                            ('Pacific/Kwajalein', 'Pacific/Kwajalein'),
+                            ('Pacific/Majuro', 'Pacific/Majuro'),
+                            ('Pacific/Marquesas', 'Pacific/Marquesas'),
+                            ('Pacific/Midway', 'Pacific/Midway'),
+                            ('Pacific/Nauru', 'Pacific/Nauru'),
+                            ('Pacific/Niue', 'Pacific/Niue'),
+                            ('Pacific/Norfolk', 'Pacific/Norfolk'),
+                            ('Pacific/Noumea', 'Pacific/Noumea'),
+                            ('Pacific/Pago_Pago', 'Pacific/Pago_Pago'),
+                            ('Pacific/Palau', 'Pacific/Palau'),
+                            ('Pacific/Pitcairn', 'Pacific/Pitcairn'),
+                            ('Pacific/Pohnpei', 'Pacific/Pohnpei'),
+                            ('Pacific/Port_Moresby', 'Pacific/Port_Moresby'),
+                            ('Pacific/Rarotonga', 'Pacific/Rarotonga'),
+                            ('Pacific/Saipan', 'Pacific/Saipan'),
+                            ('Pacific/Tahiti', 'Pacific/Tahiti'),
+                            ('Pacific/Tarawa', 'Pacific/Tarawa'),
+                            ('Pacific/Tongatapu', 'Pacific/Tongatapu'),
+                            ('Pacific/Wake', 'Pacific/Wake'),
+                            ('Pacific/Wallis', 'Pacific/Wallis'),
+                            ('US/Alaska', 'US/Alaska'),
+                            ('US/Arizona', 'US/Arizona'),
+                            ('US/Central', 'US/Central'),
+                            ('US/Eastern', 'US/Eastern'),
+                            ('US/Hawaii', 'US/Hawaii'),
+                            ('US/Mountain', 'US/Mountain'),
+                            ('US/Pacific', 'US/Pacific'),
+                            ('UTC', 'UTC'),
+                        ],
+                        default='US/Eastern',
+                        max_length=64,
+                        verbose_name='Schedule Timezone',
+                    ),
+                ),
+                (
+                    'scheduledatetimefield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schedule Datetime'
+                    ),
+                ),
+                (
+                    'schedulegamefield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schdule Game'
+                    ),
+                ),
+                (
+                    'schedulerunnersfield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schedule Runners'
+                    ),
+                ),
+                (
+                    'scheduleestimatefield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schedule Estimate'
+                    ),
+                ),
+                (
+                    'schedulesetupfield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schedule Setup'
+                    ),
+                ),
+                (
+                    'schedulecommentatorsfield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schedule Commentators'
+                    ),
+                ),
+                (
+                    'schedulecommentsfield',
+                    models.CharField(
+                        blank=True, max_length=128, verbose_name='Schedule Comments'
+                    ),
+                ),
                 ('date', models.DateField()),
-                ('locked', models.BooleanField(default=False, help_text='Requires special permission to edit this event or anything associated with it')),
-                ('donationemailtemplate', models.ForeignKey(blank=True, default=None, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='event_donation_templates', to='post_office.EmailTemplate', verbose_name='Donation Email Template')),
-                ('pendingdonationemailtemplate', models.ForeignKey(blank=True, default=None, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='event_pending_donation_templates', to='post_office.EmailTemplate', verbose_name='Pending Donation Email Template')),
+                (
+                    'locked',
+                    models.BooleanField(
+                        default=False,
+                        help_text='Requires special permission to edit this event or anything associated with it',
+                    ),
+                ),
+                (
+                    'donationemailtemplate',
+                    models.ForeignKey(
+                        blank=True,
+                        default=None,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='event_donation_templates',
+                        to='post_office.EmailTemplate',
+                        verbose_name='Donation Email Template',
+                    ),
+                ),
+                (
+                    'pendingdonationemailtemplate',
+                    models.ForeignKey(
+                        blank=True,
+                        default=None,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='event_pending_donation_templates',
+                        to='post_office.EmailTemplate',
+                        verbose_name='Pending Donation Email Template',
+                    ),
+                ),
             ],
             options={
                 'ordering': ('date',),
@@ -344,55 +1398,266 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Log',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('timestamp', models.DateTimeField(auto_now_add=True, verbose_name='Timestamp')),
-                ('category', models.CharField(default='other', max_length=64, verbose_name='Category')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'timestamp',
+                    models.DateTimeField(auto_now_add=True, verbose_name='Timestamp'),
+                ),
+                (
+                    'category',
+                    models.CharField(
+                        default='other', max_length=64, verbose_name='Category'
+                    ),
+                ),
                 ('message', models.TextField(blank=True, verbose_name='Message')),
-                ('event', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to='tracker.Event')),
-                ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                (
+                    'event',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to='tracker.Event',
+                    ),
+                ),
+                (
+                    'user',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
             options={
                 'ordering': ['-timestamp'],
                 'verbose_name': 'Log',
-                'permissions': (('can_view_log', 'Can view tracker logs'), ('can_change_log', 'Can change tracker logs')),
+                'permissions': (
+                    ('can_view_log', 'Can view tracker logs'),
+                    ('can_change_log', 'Can change tracker logs'),
+                ),
             },
         ),
         migrations.CreateModel(
             name='PostbackURL',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('url', models.URLField(verbose_name='URL')),
-                ('event', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='postbacks', to='tracker.Event', verbose_name='Event')),
+                (
+                    'event',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='postbacks',
+                        to='tracker.Event',
+                        verbose_name='Event',
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
             name='Prize',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64)),
                 ('image', models.URLField(blank=True, max_length=1024, null=True)),
-                ('altimage', models.URLField(blank=True, help_text='A second image to display in situations where the default image is not appropriate (tight spaces, stream, etc...)', max_length=1024, null=True, verbose_name='Alternate Image')),
-                ('imagefile', models.FileField(blank=True, null=True, upload_to='prizes')),
-                ('description', models.TextField(blank=True, max_length=1024, null=True)),
-                ('shortdescription', models.TextField(blank=True, help_text='Alternative description text to display in tight spaces', max_length=256, verbose_name='Short Description')),
+                (
+                    'altimage',
+                    models.URLField(
+                        blank=True,
+                        help_text='A second image to display in situations where the default image is not appropriate (tight spaces, stream, etc...)',
+                        max_length=1024,
+                        null=True,
+                        verbose_name='Alternate Image',
+                    ),
+                ),
+                (
+                    'imagefile',
+                    models.FileField(blank=True, null=True, upload_to='prizes'),
+                ),
+                (
+                    'description',
+                    models.TextField(blank=True, max_length=1024, null=True),
+                ),
+                (
+                    'shortdescription',
+                    models.TextField(
+                        blank=True,
+                        help_text='Alternative description text to display in tight spaces',
+                        max_length=256,
+                        verbose_name='Short Description',
+                    ),
+                ),
                 ('extrainfo', models.TextField(blank=True, max_length=1024, null=True)),
-                ('estimatedvalue', models.DecimalField(blank=True, decimal_places=2, max_digits=20, null=True, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Estimated Value')),
-                ('minimumbid', models.DecimalField(decimal_places=2, default=Decimal('5.0'), max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Minimum Bid')),
-                ('maximumbid', models.DecimalField(blank=True, decimal_places=2, default=Decimal('5.0'), max_digits=20, null=True, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Maximum Bid')),
-                ('sumdonations', models.BooleanField(default=False, verbose_name='Sum Donations')),
-                ('randomdraw', models.BooleanField(default=True, verbose_name='Random Draw')),
-                ('ticketdraw', models.BooleanField(default=False, verbose_name='Ticket Draw')),
-                ('starttime', models.DateTimeField(blank=True, null=True, verbose_name='Start Time')),
-                ('endtime', models.DateTimeField(blank=True, null=True, verbose_name='End Time')),
-                ('maxwinners', models.IntegerField(default=1, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Max Winners')),
-                ('maxmultiwin', models.IntegerField(default=1, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Max Wins per Donor')),
-                ('provided', models.CharField(blank=True, max_length=64, null=True, verbose_name='Provided By')),
-                ('provideremail', models.EmailField(blank=True, max_length=128, null=True, verbose_name='Provider Email')),
-                ('acceptemailsent', models.BooleanField(default=False, verbose_name='Accept/Deny Email Sent')),
-                ('creator', models.CharField(blank=True, max_length=64, null=True, verbose_name='Creator')),
-                ('creatoremail', models.EmailField(blank=True, max_length=128, null=True, verbose_name='Creator Email')),
-                ('creatorwebsite', models.CharField(blank=True, max_length=128, null=True, verbose_name='Creator Website')),
-                ('state', models.CharField(choices=[('PENDING', 'Pending'), ('ACCEPTED', 'Accepted'), ('DENIED', 'Denied'), ('FLAGGED', 'Flagged')], default='PENDING', max_length=32)),
+                (
+                    'estimatedvalue',
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        max_digits=20,
+                        null=True,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Estimated Value',
+                    ),
+                ),
+                (
+                    'minimumbid',
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal('5.0'),
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Minimum Bid',
+                    ),
+                ),
+                (
+                    'maximumbid',
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        default=Decimal('5.0'),
+                        max_digits=20,
+                        null=True,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Maximum Bid',
+                    ),
+                ),
+                (
+                    'sumdonations',
+                    models.BooleanField(default=False, verbose_name='Sum Donations'),
+                ),
+                (
+                    'randomdraw',
+                    models.BooleanField(default=True, verbose_name='Random Draw'),
+                ),
+                (
+                    'ticketdraw',
+                    models.BooleanField(default=False, verbose_name='Ticket Draw'),
+                ),
+                (
+                    'starttime',
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name='Start Time'
+                    ),
+                ),
+                (
+                    'endtime',
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name='End Time'
+                    ),
+                ),
+                (
+                    'maxwinners',
+                    models.IntegerField(
+                        default=1,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Max Winners',
+                    ),
+                ),
+                (
+                    'maxmultiwin',
+                    models.IntegerField(
+                        default=1,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Max Wins per Donor',
+                    ),
+                ),
+                (
+                    'provided',
+                    models.CharField(
+                        blank=True, max_length=64, null=True, verbose_name='Provided By'
+                    ),
+                ),
+                (
+                    'provideremail',
+                    models.EmailField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        verbose_name='Provider Email',
+                    ),
+                ),
+                (
+                    'acceptemailsent',
+                    models.BooleanField(
+                        default=False, verbose_name='Accept/Deny Email Sent'
+                    ),
+                ),
+                (
+                    'creator',
+                    models.CharField(
+                        blank=True, max_length=64, null=True, verbose_name='Creator'
+                    ),
+                ),
+                (
+                    'creatoremail',
+                    models.EmailField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        verbose_name='Creator Email',
+                    ),
+                ),
+                (
+                    'creatorwebsite',
+                    models.CharField(
+                        blank=True,
+                        max_length=128,
+                        null=True,
+                        verbose_name='Creator Website',
+                    ),
+                ),
+                (
+                    'state',
+                    models.CharField(
+                        choices=[
+                            ('PENDING', 'Pending'),
+                            ('ACCEPTED', 'Accepted'),
+                            ('DENIED', 'Denied'),
+                            ('FLAGGED', 'Flagged'),
+                        ],
+                        default='PENDING',
+                        max_length=32,
+                    ),
+                ),
             ],
             options={
                 'ordering': ['event__date', 'startrun__starttime', 'starttime', 'name'],
@@ -401,7 +1666,15 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='PrizeCategory',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64, unique=True)),
             ],
             options={
@@ -412,10 +1685,42 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='PrizeTicket',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('amount', models.DecimalField(decimal_places=2, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero])),
-                ('donation', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='tickets', to='tracker.Donation')),
-                ('prize', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='tickets', to='tracker.Prize')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'amount',
+                    models.DecimalField(
+                        decimal_places=2,
+                        max_digits=20,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                    ),
+                ),
+                (
+                    'donation',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='tickets',
+                        to='tracker.Donation',
+                    ),
+                ),
+                (
+                    'prize',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='tickets',
+                        to='tracker.Prize',
+                    ),
+                ),
             ],
             options={
                 'ordering': ['-donation__timereceived'],
@@ -425,33 +1730,138 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='PrizeWinner',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('pendingcount', models.IntegerField(default=1, help_text='The number of pending wins this donor has on this prize.', validators=[tracker.validators.positive], verbose_name='Pending Count')),
-                ('acceptcount', models.IntegerField(default=0, help_text='The number of copied this winner has won and accepted.', validators=[tracker.validators.positive], verbose_name='Accept Count')),
-                ('declinecount', models.IntegerField(default=0, help_text='The number of declines this donor has put towards this prize. Set it to the max prize multi win amount to prevent this donor from being entered from future drawings.', validators=[tracker.validators.positive], verbose_name='Decline Count')),
-                ('sumcount', models.IntegerField(default=1, editable=False, help_text='The total number of prize instances associated with this winner', validators=[tracker.validators.positive], verbose_name='Sum Counts')),
-                ('emailsent', models.BooleanField(default=False, verbose_name='Notification Email Sent')),
-                ('shippingemailsent', models.BooleanField(default=False, verbose_name='Shipping Email Sent')),
-                ('trackingnumber', models.CharField(blank=True, max_length=64, verbose_name='Tracking Number')),
-                ('shippingstate', models.CharField(choices=[('PENDING', 'Pending'), ('SHIPPED', 'Shipped')], default='PENDING', max_length=64, verbose_name='Shipping State')),
-                ('shippingcost', models.DecimalField(blank=True, decimal_places=2, max_digits=20, null=True, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Shipping Cost')),
-                ('prize', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='tracker.Prize')),
-                ('winner', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='tracker.Donor')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'pendingcount',
+                    models.IntegerField(
+                        default=1,
+                        help_text='The number of pending wins this donor has on this prize.',
+                        validators=[tracker.validators.positive],
+                        verbose_name='Pending Count',
+                    ),
+                ),
+                (
+                    'acceptcount',
+                    models.IntegerField(
+                        default=0,
+                        help_text='The number of copied this winner has won and accepted.',
+                        validators=[tracker.validators.positive],
+                        verbose_name='Accept Count',
+                    ),
+                ),
+                (
+                    'declinecount',
+                    models.IntegerField(
+                        default=0,
+                        help_text='The number of declines this donor has put towards this prize. Set it to the max prize multi win amount to prevent this donor from being entered from future drawings.',
+                        validators=[tracker.validators.positive],
+                        verbose_name='Decline Count',
+                    ),
+                ),
+                (
+                    'sumcount',
+                    models.IntegerField(
+                        default=1,
+                        editable=False,
+                        help_text='The total number of prize instances associated with this winner',
+                        validators=[tracker.validators.positive],
+                        verbose_name='Sum Counts',
+                    ),
+                ),
+                (
+                    'emailsent',
+                    models.BooleanField(
+                        default=False, verbose_name='Notification Email Sent'
+                    ),
+                ),
+                (
+                    'shippingemailsent',
+                    models.BooleanField(
+                        default=False, verbose_name='Shipping Email Sent'
+                    ),
+                ),
+                (
+                    'trackingnumber',
+                    models.CharField(
+                        blank=True, max_length=64, verbose_name='Tracking Number'
+                    ),
+                ),
+                (
+                    'shippingstate',
+                    models.CharField(
+                        choices=[('PENDING', 'Pending'), ('SHIPPED', 'Shipped')],
+                        default='PENDING',
+                        max_length=64,
+                        verbose_name='Shipping State',
+                    ),
+                ),
+                (
+                    'shippingcost',
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        max_digits=20,
+                        null=True,
+                        validators=[
+                            tracker.validators.positive,
+                            tracker.validators.nonzero,
+                        ],
+                        verbose_name='Shipping Cost',
+                    ),
+                ),
+                (
+                    'prize',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT, to='tracker.Prize'
+                    ),
+                ),
+                (
+                    'winner',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT, to='tracker.Donor'
+                    ),
+                ),
             ],
-            options={
-                'verbose_name': 'Prize Winner',
-            },
+            options={'verbose_name': 'Prize Winner',},
         ),
         migrations.CreateModel(
             name='SpeedRun',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(editable=False, max_length=64)),
-                ('deprecated_runners', models.CharField(blank=True, max_length=1024, verbose_name='*DEPRECATED* Runners')),
+                (
+                    'deprecated_runners',
+                    models.CharField(
+                        blank=True, max_length=1024, verbose_name='*DEPRECATED* Runners'
+                    ),
+                ),
                 ('description', models.TextField(blank=True, max_length=1024)),
                 ('starttime', models.DateTimeField(verbose_name='Start Time')),
                 ('endtime', models.DateTimeField(verbose_name='End Time')),
-                ('event', models.ForeignKey(default=tracker.models.event.LatestEvent, on_delete=django.db.models.deletion.PROTECT, to='tracker.Event')),
+                (
+                    'event',
+                    models.ForeignKey(
+                        default=tracker.models.event.LatestEvent,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to='tracker.Event',
+                    ),
+                ),
             ],
             options={
                 'ordering': ['event__date', 'starttime'],
@@ -461,111 +1871,206 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UserProfile',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('prepend', models.CharField(blank=True, max_length=64, verbose_name='Template Prepend')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, unique=True)),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'prepend',
+                    models.CharField(
+                        blank=True, max_length=64, verbose_name='Template Prepend'
+                    ),
+                ),
+                (
+                    'user',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                        unique=True,
+                    ),
+                ),
             ],
             options={
                 'verbose_name': 'User Profile',
-                'permissions': (('show_rendertime', 'Can view page render times'), ('show_queries', 'Can view database queries'), ('sync_schedule', 'Can sync the schedule'), ('can_search', 'Can use search url')),
+                'permissions': (
+                    ('show_rendertime', 'Can view page render times'),
+                    ('show_queries', 'Can view database queries'),
+                    ('sync_schedule', 'Can sync the schedule'),
+                    ('can_search', 'Can use search url'),
+                ),
             },
         ),
         migrations.AddField(
             model_name='prize',
             name='category',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to='tracker.PrizeCategory'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to='tracker.PrizeCategory',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='endrun',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='prize_end', to='tracker.SpeedRun', verbose_name='End Run'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='prize_end',
+                to='tracker.SpeedRun',
+                verbose_name='End Run',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='event',
-            field=models.ForeignKey(default=tracker.models.event.LatestEvent, on_delete=django.db.models.deletion.PROTECT, to='tracker.Event'),
+            field=models.ForeignKey(
+                default=tracker.models.event.LatestEvent,
+                on_delete=django.db.models.deletion.PROTECT,
+                to='tracker.Event',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='startrun',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='prize_start', to='tracker.SpeedRun', verbose_name='Start Run'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='prize_start',
+                to='tracker.SpeedRun',
+                verbose_name='Start Run',
+            ),
         ),
         migrations.AddField(
             model_name='donorprizeentry',
             name='prize',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='tracker.Prize'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT, to='tracker.Prize'
+            ),
         ),
         migrations.AddField(
             model_name='donorcache',
             name='event',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='tracker.Event'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to='tracker.Event',
+            ),
         ),
         migrations.AddField(
             model_name='donation',
             name='donor',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to='tracker.Donor'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to='tracker.Donor',
+            ),
         ),
         migrations.AddField(
             model_name='donation',
             name='event',
-            field=models.ForeignKey(default=tracker.models.event.LatestEvent, on_delete=django.db.models.deletion.PROTECT, to='tracker.Event'),
+            field=models.ForeignKey(
+                default=tracker.models.event.LatestEvent,
+                on_delete=django.db.models.deletion.PROTECT,
+                to='tracker.Event',
+            ),
         ),
         migrations.AddField(
             model_name='bid',
             name='event',
-            field=models.ForeignKey(blank=True, help_text='Required for top level bids if Run is not set', null=True, on_delete=django.db.models.deletion.PROTECT, related_name='bids', to='tracker.Event', verbose_name='Event'),
+            field=models.ForeignKey(
+                blank=True,
+                help_text='Required for top level bids if Run is not set',
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='bids',
+                to='tracker.Event',
+                verbose_name='Event',
+            ),
         ),
         migrations.AddField(
             model_name='bid',
             name='parent',
-            field=mptt.fields.TreeForeignKey(blank=True, editable=False, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='options', to='tracker.Bid', verbose_name='Parent'),
+            field=mptt.fields.TreeForeignKey(
+                blank=True,
+                editable=False,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='options',
+                to='tracker.Bid',
+                verbose_name='Parent',
+            ),
         ),
         migrations.AddField(
             model_name='bid',
             name='speedrun',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='bids', to='tracker.SpeedRun', verbose_name='Run'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='bids',
+                to='tracker.SpeedRun',
+                verbose_name='Run',
+            ),
         ),
         migrations.AlterUniqueTogether(
-            name='speedrun',
-            unique_together=set([('name', 'event')]),
+            name='speedrun', unique_together=set([('name', 'event')]),
         ),
         migrations.AlterUniqueTogether(
-            name='prizewinner',
-            unique_together=set([('prize', 'winner')]),
+            name='prizewinner', unique_together=set([('prize', 'winner')]),
         ),
         migrations.AlterUniqueTogether(
-            name='prizeticket',
-            unique_together=set([('prize', 'donation')]),
+            name='prizeticket', unique_together=set([('prize', 'donation')]),
         ),
         migrations.AlterUniqueTogether(
-            name='prize',
-            unique_together=set([('name', 'event')]),
+            name='prize', unique_together=set([('name', 'event')]),
         ),
         migrations.AlterUniqueTogether(
-            name='donorprizeentry',
-            unique_together=set([('prize', 'donor')]),
+            name='donorprizeentry', unique_together=set([('prize', 'donor')]),
         ),
         migrations.AlterUniqueTogether(
-            name='donorcache',
-            unique_together=set([('event', 'donor')]),
+            name='donorcache', unique_together=set([('event', 'donor')]),
         ),
         migrations.AlterUniqueTogether(
-            name='donationbid',
-            unique_together=set([('bid', 'donation')]),
+            name='donationbid', unique_together=set([('bid', 'donation')]),
         ),
         migrations.AlterUniqueTogether(
-            name='bid',
-            unique_together=set([('event', 'name', 'speedrun', 'parent')]),
+            name='bid', unique_together=set([('event', 'name', 'speedrun', 'parent')]),
         ),
         migrations.CreateModel(
             name='Runner',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64, unique=True)),
                 ('stream', models.URLField(blank=True, max_length=128)),
                 ('twitter', models.SlugField(blank=True, max_length=15)),
                 ('youtube', models.SlugField(blank=True, max_length=20)),
-                ('donor', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='tracker.Donor')),
+                (
+                    'donor',
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to='tracker.Donor',
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
@@ -601,7 +2106,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='speedrun',
             name='deprecated_runners',
-            field=models.CharField(blank=True, editable=False, max_length=1024, verbose_name='*DEPRECATED* Runners'),
+            field=models.CharField(
+                blank=True,
+                editable=False,
+                max_length=1024,
+                verbose_name='*DEPRECATED* Runners',
+            ),
         ),
         migrations.AlterField(
             model_name='speedrun',
@@ -621,12 +2131,16 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='speedrun',
             name='endtime',
-            field=models.DateTimeField(editable=False, null=True, verbose_name='End Time'),
+            field=models.DateTimeField(
+                editable=False, null=True, verbose_name='End Time'
+            ),
         ),
         migrations.AlterField(
             model_name='speedrun',
             name='starttime',
-            field=models.DateTimeField(editable=False, null=True, verbose_name='Start Time'),
+            field=models.DateTimeField(
+                editable=False, null=True, verbose_name='Start Time'
+            ),
         ),
         migrations.AddField(
             model_name='speedrun',
@@ -641,7 +2155,13 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='speedrun',
             name='deprecated_runners',
-            field=models.CharField(blank=True, editable=False, max_length=1024, validators=[tracker.models.event.runners_exists], verbose_name='*DEPRECATED* Runners'),
+            field=models.CharField(
+                blank=True,
+                editable=False,
+                max_length=1024,
+                validators=[tracker.models.event.runners_exists],
+                verbose_name='*DEPRECATED* Runners',
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='speedrun',
@@ -650,12 +2170,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='submission',
             name='run',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tracker.SpeedRun'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='tracker.SpeedRun'
+            ),
         ),
         migrations.AddField(
             model_name='submission',
             name='runner',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tracker.Runner'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='tracker.Runner'
+            ),
         ),
         migrations.AddField(
             model_name='event',
@@ -663,9 +2187,7 @@ class Migration(migrations.Migration):
             field=timezone_field.fields.TimeZoneField(default='US/Eastern'),
         ),
         migrations.AlterField(
-            model_name='speedrun',
-            name='name',
-            field=models.CharField(max_length=64),
+            model_name='speedrun', name='name', field=models.CharField(max_length=64),
         ),
         migrations.RunPython(
             code=f0006_fill_in_order_column,
@@ -681,27 +2203,51 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='bid',
             name='biddependency',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='dependent_bids', to='tracker.Bid', verbose_name='Dependency'),
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='dependent_bids',
+                to='tracker.Bid',
+                verbose_name='Dependency',
+            ),
         ),
         migrations.AlterField(
             model_name='userprofile',
             name='user',
-            field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.OneToOneField(
+                on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL
+            ),
         ),
         migrations.AddField(
             model_name='speedrun',
             name='category',
-            field=models.TextField(blank=True, help_text='The type of run being performed', max_length=32, null=True),
+            field=models.TextField(
+                blank=True,
+                help_text='The type of run being performed',
+                max_length=32,
+                null=True,
+            ),
         ),
         migrations.AddField(
             model_name='speedrun',
             name='release_year',
-            field=models.IntegerField(blank=True, help_text='The year the game was released', null=True, verbose_name='Release Year'),
+            field=models.IntegerField(
+                blank=True,
+                help_text='The year the game was released',
+                null=True,
+                verbose_name='Release Year',
+            ),
         ),
         migrations.AddField(
             model_name='speedrun',
             name='giantbomb_id',
-            field=models.IntegerField(blank=True, help_text='Identifies the game in the GiantBomb database, to allow auto-population of game data.', null=True, verbose_name='GiantBomb Database ID'),
+            field=models.IntegerField(
+                blank=True,
+                help_text='Identifies the game in the GiantBomb database, to allow auto-population of game data.',
+                null=True,
+                verbose_name='GiantBomb Database ID',
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='speedrun',
@@ -710,89 +2256,165 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='prize',
             name='handler',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.AUTH_USER_MODEL,
+            ),
         ),
-        migrations.RunPython(
-            code=f0013_populate_prize_contributors,
-            elidable=True,
-        ),
-        migrations.RemoveField(
-            model_name='prize',
-            name='provided',
-        ),
-        migrations.RemoveField(
-            model_name='prize',
-            name='provideremail',
-        ),
+        migrations.RunPython(code=f0013_populate_prize_contributors, elidable=True,),
+        migrations.RemoveField(model_name='prize', name='provided',),
+        migrations.RemoveField(model_name='prize', name='provideremail',),
         migrations.AddField(
             model_name='donor',
             name='user',
-            field=tracker.models.fields.OneToOneOrNoneField(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=tracker.models.fields.OneToOneOrNoneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.AUTH_USER_MODEL,
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='requiresshipping',
-            field=models.BooleanField(default=True, verbose_name='Requires Postal Shipping'),
+            field=models.BooleanField(
+                default=True, verbose_name='Requires Postal Shipping'
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='shippingnotes',
-            field=models.TextField(blank=True, max_length=2048, verbose_name='Shipping Notes'),
+            field=models.TextField(
+                blank=True, max_length=2048, verbose_name='Shipping Notes'
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='winnernotes',
-            field=models.TextField(blank=True, max_length=1024, verbose_name='Winner Notes'),
+            field=models.TextField(
+                blank=True, max_length=1024, verbose_name='Winner Notes'
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='acceptemailsentcount',
-            field=models.IntegerField(default=0, help_text='The number of accepts that the previous e-mail was sent for (or 0 if none were sent yet).', validators=[tracker.validators.positive], verbose_name='Accept Count Sent For'),
+            field=models.IntegerField(
+                default=0,
+                help_text='The number of accepts that the previous e-mail was sent for (or 0 if none were sent yet).',
+                validators=[tracker.validators.positive],
+                verbose_name='Accept Count Sent For',
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='couriername',
-            field=models.CharField(blank=True, help_text='e.g. FedEx, DHL, ...', max_length=64, verbose_name='Courier Service Name'),
+            field=models.CharField(
+                blank=True,
+                help_text='e.g. FedEx, DHL, ...',
+                max_length=64,
+                verbose_name='Courier Service Name',
+            ),
         ),
         migrations.AddField(
             model_name='event',
             name='prizecontributoremailtemplate',
-            field=models.ForeignKey(blank=True, default=None, help_text=b"Email template to use when responding to prize contributor's submission requests", null=True, on_delete=django.db.models.deletion.CASCADE, related_name='event_prizecontributortemplates', to='post_office.EmailTemplate', verbose_name='Prize Contributor Accept/Deny Email Template'),
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                help_text=b"Email template to use when responding to prize contributor's submission requests",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='event_prizecontributortemplates',
+                to='post_office.EmailTemplate',
+                verbose_name='Prize Contributor Accept/Deny Email Template',
+            ),
         ),
         migrations.AddField(
             model_name='event',
             name='prizecoordinator',
-            field=models.ForeignKey(blank=True, default=None, help_text='The person responsible for managing prize acceptance/distribution', null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, verbose_name='Prize Coordinator'),
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                help_text='The person responsible for managing prize acceptance/distribution',
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.AUTH_USER_MODEL,
+                verbose_name='Prize Coordinator',
+            ),
         ),
         migrations.AddField(
             model_name='event',
             name='prizeshippedemailtemplate',
-            field=models.ForeignKey(blank=True, default=None, help_text='Email template to use when the aprize has been shipped to its recipient).', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='event_prizeshippedtemplates', to='post_office.EmailTemplate', verbose_name='Prize Shipped Email Template'),
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                help_text='Email template to use when the aprize has been shipped to its recipient).',
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='event_prizeshippedtemplates',
+                to='post_office.EmailTemplate',
+                verbose_name='Prize Shipped Email Template',
+            ),
         ),
         migrations.AddField(
             model_name='event',
             name='prizewinneracceptemailtemplate',
-            field=models.ForeignKey(blank=True, default=None, help_text='Email template to use when someone accepts a prize (and thus it needs to be shipped).', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='event_prizewinneraccepttemplates', to='post_office.EmailTemplate', verbose_name='Prize Accepted Email Template'),
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                help_text='Email template to use when someone accepts a prize (and thus it needs to be shipped).',
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='event_prizewinneraccepttemplates',
+                to='post_office.EmailTemplate',
+                verbose_name='Prize Accepted Email Template',
+            ),
         ),
         migrations.AddField(
             model_name='event',
             name='prizewinneremailtemplate',
-            field=models.ForeignKey(blank=True, default=None, help_text='Email template to use when someone wins a prize.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='event_prizewinnertemplates', to='post_office.EmailTemplate', verbose_name='Prize Winner Email Template'),
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                help_text='Email template to use when someone wins a prize.',
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='event_prizewinnertemplates',
+                to='post_office.EmailTemplate',
+                verbose_name='Prize Winner Email Template',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='reviewnotes',
-            field=models.TextField(blank=True, help_text='Notes for the contributor (for example, why a particular prize was denied)', max_length=1024, verbose_name='Review Notes'),
+            field=models.TextField(
+                blank=True,
+                help_text='Notes for the contributor (for example, why a particular prize was denied)',
+                max_length=1024,
+                verbose_name='Review Notes',
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='acceptdeadline',
-            field=models.DateTimeField(blank=True, default=None, help_text='The deadline for this winner to accept their prize (leave blank for no deadline)', null=True, verbose_name='Winner Accept Deadline'),
+            field=models.DateTimeField(
+                blank=True,
+                default=None,
+                help_text='The deadline for this winner to accept their prize (leave blank for no deadline)',
+                null=True,
+                verbose_name='Winner Accept Deadline',
+            ),
         ),
         migrations.AlterField(
             model_name='speedrun',
             name='category',
-            field=models.CharField(blank=True, help_text='The type of run being performed', max_length=64, null=True),
+            field=models.CharField(
+                blank=True,
+                help_text='The type of run being performed',
+                max_length=64,
+                null=True,
+            ),
         ),
         migrations.AlterField(
             model_name='submission',
@@ -812,49 +2434,117 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='speedrun',
             name='display_name',
-            field=models.TextField(blank=True, help_text='How to display this game on the stream.', max_length=256, verbose_name='Display Name'),
+            field=models.TextField(
+                blank=True,
+                help_text='How to display this game on the stream.',
+                max_length=256,
+                verbose_name='Display Name',
+            ),
         ),
-        migrations.RunPython(
-            code=f0023_copy_over_display_name,
-            elidable=True,
-        ),
+        migrations.RunPython(code=f0023_copy_over_display_name, elidable=True,),
         migrations.AddField(
             model_name='prize',
             name='provider',
-            field=models.CharField(blank=True, help_text='Name of the person who provided the prize to the event', max_length=64),
+            field=models.CharField(
+                blank=True,
+                help_text='Name of the person who provided the prize to the event',
+                max_length=64,
+            ),
         ),
         migrations.AlterField(
             model_name='prize',
             name='handler',
-            field=models.ForeignKey(help_text='User account responsible for prize shipping', null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                help_text='User account responsible for prize shipping',
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to=settings.AUTH_USER_MODEL,
+            ),
         ),
-        migrations.RunPython(
-            code=f0024_write_existing_providers,
-            elidable=True,
-        ),
+        migrations.RunPython(code=f0024_write_existing_providers, elidable=True,),
         migrations.AddField(
             model_name='event',
             name='minimumdonation',
-            field=models.DecimalField(decimal_places=2, default=Decimal('1.00'), help_text='Enforces a minimum donation amount on the donate page.', max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Minimum Donation'),
+            field=models.DecimalField(
+                decimal_places=2,
+                default=Decimal('1.00'),
+                help_text='Enforces a minimum donation amount on the donate page.',
+                max_digits=20,
+                validators=[tracker.validators.positive, tracker.validators.nonzero],
+                verbose_name='Minimum Donation',
+            ),
         ),
         migrations.CreateModel(
             name='Country',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(help_text='Official ISO 3166 name for the country', max_length=64, unique=True)),
-                ('alpha2', models.CharField(help_text='ISO 3166-1 Two-letter code', max_length=2, unique=True, validators=[django.core.validators.RegexValidator(message='Country Alpha-2 code must be exactly 2 uppercase alphabetic characters', regex='^[A-Z]{2}$')])),
-                ('alpha3', models.CharField(help_text='ISO 3166-1 Three-letter code', max_length=3, unique=True, validators=[django.core.validators.RegexValidator(message='Country Alpha-3 code must be exactly 3 uppercase alphabetic characters', regex='^[A-Z]{3}$')])),
-                ('numeric', models.CharField(blank=True, help_text='ISO 3166-1 numeric code', max_length=3, null=True, unique=True, validators=[django.core.validators.RegexValidator(message='Country Numeric code must be exactly 3 digits', regex='^\\\\d{3}$')])),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'name',
+                    models.CharField(
+                        help_text='Official ISO 3166 name for the country',
+                        max_length=64,
+                        unique=True,
+                    ),
+                ),
+                (
+                    'alpha2',
+                    models.CharField(
+                        help_text='ISO 3166-1 Two-letter code',
+                        max_length=2,
+                        unique=True,
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                message='Country Alpha-2 code must be exactly 2 uppercase alphabetic characters',
+                                regex='^[A-Z]{2}$',
+                            )
+                        ],
+                    ),
+                ),
+                (
+                    'alpha3',
+                    models.CharField(
+                        help_text='ISO 3166-1 Three-letter code',
+                        max_length=3,
+                        unique=True,
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                message='Country Alpha-3 code must be exactly 3 uppercase alphabetic characters',
+                                regex='^[A-Z]{3}$',
+                            )
+                        ],
+                    ),
+                ),
+                (
+                    'numeric',
+                    models.CharField(
+                        blank=True,
+                        help_text='ISO 3166-1 numeric code',
+                        max_length=3,
+                        null=True,
+                        unique=True,
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                message='Country Numeric code must be exactly 3 digits',
+                                regex='^\\\\d{3}$',
+                            )
+                        ],
+                    ),
+                ),
             ],
             options={
                 'ordering': ('alpha2',),
                 'permissions': (('can_edit_countries', 'Can edit countries'),),
             },
         ),
-        migrations.RunPython(
-            code=f0026_add_countries,
-            elidable=True,
-        ),
+        migrations.RunPython(code=f0026_add_countries, elidable=True,),
         migrations.RenameField(
             model_name='donor',
             old_name='addresscountry',
@@ -863,26 +2553,43 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='donor',
             name='addresscountry',
-            field=models.ForeignKey(blank=True, default=None, null=True, on_delete=django.db.models.deletion.CASCADE, to='tracker.Country', verbose_name='Country'),
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to='tracker.Country',
+                verbose_name='Country',
+            ),
         ),
         migrations.RunPython(
             code=f0026_migrate_to_country_code,
             reverse_code=f0026_migrate_from_country_code,
             elidable=True,
         ),
-        migrations.RemoveField(
-            model_name='donor',
-            name='migrateaddresscountry',
-        ),
+        migrations.RemoveField(model_name='donor', name='migrateaddresscountry',),
         migrations.AddField(
             model_name='event',
             name='allowed_prize_countries',
-            field=models.ManyToManyField(blank=True, help_text='List of countries whose residents are allowed to receive prizes (leave blank to allow all countries)', to='tracker.Country', verbose_name='Allowed Prize Countries'),
+            field=models.ManyToManyField(
+                blank=True,
+                help_text='List of countries whose residents are allowed to receive prizes (leave blank to allow all countries)',
+                to='tracker.Country',
+                verbose_name='Allowed Prize Countries',
+            ),
         ),
         migrations.CreateModel(
             name='CountryRegion',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(max_length=128)),
             ],
             options={
@@ -897,46 +2604,81 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='countryregion',
             name='country',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='tracker.Country'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT, to='tracker.Country'
+            ),
         ),
         migrations.AlterUniqueTogether(
-            name='countryregion',
-            unique_together=set([('name', 'country')]),
+            name='countryregion', unique_together=set([('name', 'country')]),
         ),
         migrations.AddField(
             model_name='event',
             name='disallowed_prize_regions',
-            field=models.ManyToManyField(blank=True, help_text='A blacklist of regions within allowed countries that are not allowed for drawings (e.g. Quebec in Canada)', to='tracker.CountryRegion', verbose_name='Disallowed Regions'),
+            field=models.ManyToManyField(
+                blank=True,
+                help_text='A blacklist of regions within allowed countries that are not allowed for drawings (e.g. Quebec in Canada)',
+                to='tracker.CountryRegion',
+                verbose_name='Disallowed Regions',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='allowed_prize_countries',
-            field=models.ManyToManyField(blank=True, help_text='List of countries whose residents are allowed to receive prizes (leave blank to allow all countries)', to='tracker.Country', verbose_name='Prize Countries'),
+            field=models.ManyToManyField(
+                blank=True,
+                help_text='List of countries whose residents are allowed to receive prizes (leave blank to allow all countries)',
+                to='tracker.Country',
+                verbose_name='Prize Countries',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='custom_country_filter',
-            field=models.BooleanField(default=False, help_text='If checked, use a different country filter than that of the event.', verbose_name='Use Custom Country Filter'),
+            field=models.BooleanField(
+                default=False,
+                help_text='If checked, use a different country filter than that of the event.',
+                verbose_name='Use Custom Country Filter',
+            ),
         ),
         migrations.AddField(
             model_name='prize',
             name='disallowed_prize_regions',
-            field=models.ManyToManyField(blank=True, help_text='A blacklist of regions within allowed countries that are not allowed for drawings (e.g. Quebec in Canada)', to='tracker.CountryRegion', verbose_name='Disallowed Regions'),
+            field=models.ManyToManyField(
+                blank=True,
+                help_text='A blacklist of regions within allowed countries that are not allowed for drawings (e.g. Quebec in Canada)',
+                to='tracker.CountryRegion',
+                verbose_name='Disallowed Regions',
+            ),
         ),
         migrations.AddField(
             model_name='event',
             name='prize_accept_deadline_delta',
-            field=models.IntegerField(default=14, help_text='The number of days a winner will be given to accept a prize before it is re-rolled.', validators=[tracker.validators.positive, tracker.validators.nonzero], verbose_name='Prize Accept Deadline Delta'),
+            field=models.IntegerField(
+                default=14,
+                help_text='The number of days a winner will be given to accept a prize before it is re-rolled.',
+                validators=[tracker.validators.positive, tracker.validators.nonzero],
+                verbose_name='Prize Accept Deadline Delta',
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='auth_code',
-            field=models.CharField(default=tracker.util.make_auth_code, editable=False, help_text='Used instead of a login for winners to manage prizes.', max_length=64),
+            field=models.CharField(
+                default=tracker.util.make_auth_code,
+                editable=False,
+                help_text='Used instead of a login for winners to manage prizes.',
+                max_length=64,
+            ),
         ),
         migrations.AddField(
             model_name='prizewinner',
             name='shipping_receipt_url',
-            field=models.URLField(blank=True, help_text='The URL of an image of the shipping receipt', max_length=1024, verbose_name='Shipping Receipt Image URL'),
+            field=models.URLField(
+                blank=True,
+                help_text='The URL of an image of the shipping receipt',
+                max_length=1024,
+                verbose_name='Shipping Receipt Image URL',
+            ),
         ),
         migrations.AddField(
             model_name='speedrun',
@@ -950,92 +2692,161 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterModelOptions(
             name='speedrun',
-            options={'ordering': ['event__date', 'order'], 'permissions': (('can_view_tech_notes', 'Can view tech notes'),), 'verbose_name': 'Speed Run'},
+            options={
+                'ordering': ['event__date', 'order'],
+                'permissions': (('can_view_tech_notes', 'Can view tech notes'),),
+                'verbose_name': 'Speed Run',
+            },
         ),
         migrations.AlterField(
             model_name='speedrun',
             name='coop',
-            field=models.BooleanField(default=False, help_text='Cooperative runs should be marked with this for layout purposes'),
+            field=models.BooleanField(
+                default=False,
+                help_text='Cooperative runs should be marked with this for layout purposes',
+            ),
         ),
         migrations.AddField(
             model_name='donation',
             name='requestedsolicitemail',
-            field=models.CharField(choices=[('CURR', 'Use Existing (Opt Out if not set)'), ('OPTOUT', 'Opt Out'), ('OPTIN', 'Opt In')], default='CURR', max_length=32, verbose_name='Requested Charity Email Opt In'),
+            field=models.CharField(
+                choices=[
+                    ('CURR', 'Use Existing (Opt Out if not set)'),
+                    ('OPTOUT', 'Opt Out'),
+                    ('OPTIN', 'Opt In'),
+                ],
+                default='CURR',
+                max_length=32,
+                verbose_name='Requested Charity Email Opt In',
+            ),
         ),
         migrations.AddField(
             model_name='donor',
             name='solicitemail',
-            field=models.CharField(choices=[('CURR', 'Use Existing (Opt Out if not set)'), ('OPTOUT', 'Opt Out'), ('OPTIN', 'Opt In')], default='CURR', max_length=32),
+            field=models.CharField(
+                choices=[
+                    ('CURR', 'Use Existing (Opt Out if not set)'),
+                    ('OPTOUT', 'Opt Out'),
+                    ('OPTIN', 'Opt In'),
+                ],
+                default='CURR',
+                max_length=32,
+            ),
         ),
         migrations.AlterField(
             model_name='donation',
             name='bidstate',
-            field=models.CharField(choices=[('PENDING', 'Pending'), ('IGNORED', 'Ignored'), ('PROCESSED', 'Processed'), ('FLAGGED', 'Flagged')], db_index=True, default='PENDING', max_length=255, verbose_name='Bid State'),
+            field=models.CharField(
+                choices=[
+                    ('PENDING', 'Pending'),
+                    ('IGNORED', 'Ignored'),
+                    ('PROCESSED', 'Processed'),
+                    ('FLAGGED', 'Flagged'),
+                ],
+                db_index=True,
+                default='PENDING',
+                max_length=255,
+                verbose_name='Bid State',
+            ),
         ),
         migrations.AlterField(
             model_name='donation',
             name='commentstate',
-            field=models.CharField(choices=[('ABSENT', 'Absent'), ('PENDING', 'Pending'), ('DENIED', 'Denied'), ('APPROVED', 'Approved'), ('FLAGGED', 'Flagged')], db_index=True, default='ABSENT', max_length=255, verbose_name='Comment State'),
+            field=models.CharField(
+                choices=[
+                    ('ABSENT', 'Absent'),
+                    ('PENDING', 'Pending'),
+                    ('DENIED', 'Denied'),
+                    ('APPROVED', 'Approved'),
+                    ('FLAGGED', 'Flagged'),
+                ],
+                db_index=True,
+                default='ABSENT',
+                max_length=255,
+                verbose_name='Comment State',
+            ),
         ),
         migrations.AlterField(
             model_name='donation',
             name='readstate',
-            field=models.CharField(choices=[('PENDING', 'Pending'), ('READY', 'Ready to Read'), ('IGNORED', 'Ignored'), ('READ', 'Read'), ('FLAGGED', 'Flagged')], db_index=True, default='PENDING', max_length=255, verbose_name='Read State'),
+            field=models.CharField(
+                choices=[
+                    ('PENDING', 'Pending'),
+                    ('READY', 'Ready to Read'),
+                    ('IGNORED', 'Ignored'),
+                    ('READ', 'Read'),
+                    ('FLAGGED', 'Flagged'),
+                ],
+                db_index=True,
+                default='PENDING',
+                max_length=255,
+                verbose_name='Read State',
+            ),
         ),
         migrations.AlterField(
             model_name='donation',
             name='transactionstate',
-            field=models.CharField(choices=[('PENDING', 'Pending'), ('COMPLETED', 'Completed'), ('CANCELLED', 'Cancelled'), ('FLAGGED', 'Flagged')], db_index=True, default='PENDING', max_length=64, verbose_name='Transaction State'),
+            field=models.CharField(
+                choices=[
+                    ('PENDING', 'Pending'),
+                    ('COMPLETED', 'Completed'),
+                    ('CANCELLED', 'Cancelled'),
+                    ('FLAGGED', 'Flagged'),
+                ],
+                db_index=True,
+                default='PENDING',
+                max_length=64,
+                verbose_name='Transaction State',
+            ),
         ),
         migrations.AlterField(
             model_name='donation',
             name='timereceived',
-            field=models.DateTimeField(db_index=True, default=django.utils.timezone.now, verbose_name='Time Received'),
+            field=models.DateTimeField(
+                db_index=True,
+                default=django.utils.timezone.now,
+                verbose_name='Time Received',
+            ),
         ),
         migrations.AlterModelOptions(
             name='userprofile',
-            options={'permissions': (('show_rendertime', 'Can view page render times'), ('show_queries', 'Can view database queries'), ('can_search', 'Can use search url')), 'verbose_name': 'User Profile'},
+            options={
+                'permissions': (
+                    ('show_rendertime', 'Can view page render times'),
+                    ('show_queries', 'Can view database queries'),
+                    ('can_search', 'Can use search url'),
+                ),
+                'verbose_name': 'User Profile',
+            },
         ),
-        migrations.RemoveField(
-            model_name='event',
-            name='schedulecommentatorsfield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='schedulecommentsfield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='scheduledatetimefield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='scheduleestimatefield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='schedulegamefield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='schedulerunnersfield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='schedulesetupfield',
-        ),
-        migrations.RemoveField(
-            model_name='event',
-            name='scheduletimezone',
-        ),
+        migrations.RemoveField(model_name='event', name='schedulecommentatorsfield',),
+        migrations.RemoveField(model_name='event', name='schedulecommentsfield',),
+        migrations.RemoveField(model_name='event', name='scheduledatetimefield',),
+        migrations.RemoveField(model_name='event', name='scheduleestimatefield',),
+        migrations.RemoveField(model_name='event', name='schedulegamefield',),
+        migrations.RemoveField(model_name='event', name='schedulerunnersfield',),
+        migrations.RemoveField(model_name='event', name='schedulesetupfield',),
+        migrations.RemoveField(model_name='event', name='scheduletimezone',),
         migrations.AlterField(
             model_name='donationbid',
             name='amount',
-            field=models.DecimalField(decimal_places=2, default=0, max_digits=20, validators=[tracker.validators.positive, tracker.validators.nonzero]),
+            field=models.DecimalField(
+                decimal_places=2,
+                default=0,
+                max_digits=20,
+                validators=[tracker.validators.positive, tracker.validators.nonzero],
+            ),
         ),
         migrations.AlterField(
             model_name='event',
             name='scheduleid',
-            field=models.CharField(blank=True, editable=False, max_length=128, null=True, unique=True, verbose_name='Schedule ID (LEGACY)'),
+            field=models.CharField(
+                blank=True,
+                editable=False,
+                max_length=128,
+                null=True,
+                unique=True,
+                verbose_name='Schedule ID (LEGACY)',
+            ),
         ),
     ]

--- a/migrations/0003_backfill_event_datetime.py
+++ b/migrations/0003_backfill_event_datetime.py
@@ -7,8 +7,7 @@ from django.db import migrations
 
 
 def backfill_event_datetime(apps, schema_editor):
-    # noinspection PyPep8Naming
-    Event = apps.get_model('tracker', 'Event')
+    Event = apps.get_model('tracker', 'Event')  # noqa N806
     db_alias = schema_editor.connection.alias
     for event in Event.objects.using(db_alias).order_by('date'):
         run = event.speedrun_set.order_by('starttime').first()
@@ -17,9 +16,12 @@ def backfill_event_datetime(apps, schema_editor):
             event.datetime = run.starttime
             print('run start %s' % event.datetime.astimezone(event.timezone))
         else:
-            event.datetime = event.timezone.localize(datetime.datetime.combine(event.date, datetime.time(12, 0)))
+            event.datetime = event.timezone.localize(
+                datetime.datetime.combine(event.date, datetime.time(12, 0))
+            )
             print('noon default')
         event.save()
+
 
 def noop(a, b):
     pass
@@ -30,6 +32,4 @@ class Migration(migrations.Migration):
         ('tracker', '0002_add_event_datetime'),
     ]
 
-    operations = [
-        migrations.RunPython(backfill_event_datetime, noop, elidable=True)
-    ]
+    operations = [migrations.RunPython(backfill_event_datetime, noop, elidable=True)]

--- a/migrations/0003_populate_prev_next_run.py
+++ b/migrations/0003_populate_prev_next_run.py
@@ -6,24 +6,20 @@ from django.db import migrations
 
 
 def populate_prev_next_run(apps, schema_editor):
-    # noinspection PyPep8Naming
-    Prize = apps.get_model('tracker', 'Prize')
-    # noinspection PyPep8Naming
-    SpeedRun = apps.get_model('tracker', 'SpeedRun')
+    Prize = apps.get_model('tracker', 'Prize')  # noqa N806
+    SpeedRun = apps.get_model('tracker', 'SpeedRun')  # noqa N806
     db_alias = schema_editor.connection.alias
     for prize in Prize.objects.using(db_alias):
         if prize.startrun and prize.startrun.order:
             prize.prev_run = (
-                SpeedRun.objects.using(db_alias).filter(
-                    event=prize.startrun.event_id, order__lt=prize.startrun.order
-                )
+                SpeedRun.objects.using(db_alias)
+                .filter(event=prize.startrun.event_id, order__lt=prize.startrun.order)
                 .order_by('order')
                 .last()
             )
             prize.next_run = (
-                SpeedRun.objects.using(db_alias).filter(
-                    event=prize.endrun.event_id, order__gt=prize.endrun.order
-                )
+                SpeedRun.objects.using(db_alias)
+                .filter(event=prize.endrun.event_id, order__gt=prize.endrun.order)
                 .order_by('order')
                 .first()
             )
@@ -40,6 +36,4 @@ class Migration(migrations.Migration):
         ('tracker', '0002_add_prev_next_run_to_prize'),
     ]
 
-    operations = [
-        migrations.RunPython(populate_prev_next_run, noop, elidable=True)
-    ]
+    operations = [migrations.RunPython(populate_prev_next_run, noop, elidable=True)]

--- a/migrations/0008_remove_prize_nulls.py
+++ b/migrations/0008_remove_prize_nulls.py
@@ -6,7 +6,7 @@ from django.db import migrations
 
 
 def remove_prize_nulls(apps, schema_editor):
-    Prize = apps.get_model('tracker', 'Prize')
+    Prize = apps.get_model('tracker', 'Prize')  # noqa N806
     for field in ['altimage', 'description', 'extrainfo', 'image']:
         Prize.objects.filter(**{field: None}).update(**{field: ''})
 
@@ -21,6 +21,4 @@ class Migration(migrations.Migration):
         ('tracker', '0007_add_prize_key'),
     ]
 
-    operations = [
-        migrations.RunPython(remove_prize_nulls, noop, elidable=True)
-    ]
+    operations = [migrations.RunPython(remove_prize_nulls, noop, elidable=True)]

--- a/models/donation.py
+++ b/models/donation.py
@@ -22,18 +22,22 @@ __all__ = [
     'DonorCache',
 ]
 
-_currencyChoices = (('USD', 'US Dollars'), ('CAD', 'Canadian Dollars'))
+_CURRENCY_CHOICES = (('USD', 'US Dollars'), ('CAD', 'Canadian Dollars'))
 
-DonorVisibilityChoices = (
+DONOR_VISIBILITY_CHOICES = (
     ('FULL', 'Fully Visible'),
     ('FIRST', 'First Name, Last Initial'),
     ('ALIAS', 'Alias Only'),
     ('ANON', 'Anonymous'),
 )
 
-DonationDomainChoices = (('LOCAL', 'Local'), ('CHIPIN', 'ChipIn'), ('PAYPAL', 'PayPal'))
+DONATION_DOMAIN_CHOICES = (
+    ('LOCAL', 'Local'),
+    ('CHIPIN', 'ChipIn'),
+    ('PAYPAL', 'PayPal'),
+)
 
-LanguageChoices = (
+LANGUAGE_CHOICES = (
     ('un', 'Unknown'),
     ('en', 'English'),
     ('fr', 'French'),
@@ -42,8 +46,8 @@ LanguageChoices = (
 
 
 class DonationManager(models.Manager):
-    def get_by_natural_key(self, domainId):
-        return self.get(domainId=domainId)
+    def get_by_natural_key(self, domain_id):
+        return self.get(domainId=domain_id)
 
 
 class Donation(models.Model):
@@ -51,9 +55,11 @@ class Donation(models.Model):
     donor = models.ForeignKey('Donor', on_delete=models.PROTECT, blank=True, null=True)
     event = models.ForeignKey('Event', on_delete=models.PROTECT, default=LatestEvent)
     domain = models.CharField(
-        max_length=255, default='LOCAL', choices=DonationDomainChoices
+        max_length=255, default='LOCAL', choices=DONATION_DOMAIN_CHOICES
     )
-    domainId = models.CharField(max_length=160, unique=True, editable=False, blank=True)
+    domainId = models.CharField(  # noqa N815
+        max_length=160, unique=True, editable=False, blank=True
+    )
     transactionstate = models.CharField(
         'Transaction State',
         max_length=64,
@@ -122,7 +128,7 @@ class Donation(models.Model):
         max_length=8,
         null=False,
         blank=False,
-        choices=_currencyChoices,
+        choices=_CURRENCY_CHOICES,
         verbose_name='Currency',
     )
     timereceived = models.DateTimeField(
@@ -138,7 +144,7 @@ class Donation(models.Model):
         blank=False,
         default='CURR',
         choices=(('CURR', 'Use Existing (Anonymous if not set)'),)
-        + DonorVisibilityChoices,
+        + DONOR_VISIBILITY_CHOICES,
         verbose_name='Requested Visibility',
     )
     requestedalias = models.CharField(
@@ -164,7 +170,7 @@ class Donation(models.Model):
         null=False,
         blank=False,
         default='un',
-        choices=LanguageChoices,
+        choices=LANGUAGE_CHOICES,
         verbose_name='Comment Language',
     )
 
@@ -275,7 +281,7 @@ class Donation(models.Model):
 
 
 @receiver(signals.post_save, sender=Donation)
-def DonationBidsUpdate(sender, instance, created, raw, **kwargs):
+def DonationBidsUpdate(sender, instance, created, raw, **kwargs):  # noqa N806
     if raw:
         return
     if instance.transactionstate == 'COMPLETED':
@@ -299,7 +305,7 @@ class Donor(models.Model):
         null=False,
         blank=False,
         default='FIRST',
-        choices=DonorVisibilityChoices,
+        choices=DONOR_VISIBILITY_CHOICES,
     )
     user = OneToOneOrNoneField(User, null=True, blank=True, on_delete=models.SET_NULL)
 

--- a/models/event.py
+++ b/models/event.py
@@ -25,8 +25,8 @@ __all__ = [
     'Submission',
 ]
 
-_timezoneChoices = list([(x, x) for x in pytz.common_timezones])
-_currencyChoices = (('USD', 'US Dollars'), ('CAD', 'Canadian Dollars'))
+_TIMEZONE_CHOICES = list([(x, x) for x in pytz.common_timezones])
+_CURRENCY_CHOICES = (('USD', 'US Dollars'), ('CAD', 'Canadian Dollars'))
 
 
 class EventManager(models.Manager):
@@ -87,8 +87,8 @@ class Event(models.Model):
         max_length=8,
         null=False,
         blank=False,
-        default=_currencyChoices[0][0],
-        choices=_currencyChoices,
+        default=_CURRENCY_CHOICES[0][0],
+        choices=_CURRENCY_CHOICES,
         verbose_name='Currency',
     )
     paypalimgurl = models.CharField(

--- a/models/util.py
+++ b/models/util.py
@@ -1,7 +1,7 @@
 from django.db import OperationalError
 
 
-def LatestEvent():
+def LatestEvent():  # noqa N806
     from tracker.models import Event
 
     if Event.objects.exists():

--- a/paypalutil.py
+++ b/paypalutil.py
@@ -231,7 +231,7 @@ def get_paypal_donation(paypalemail, amount, transactionid):
     return None
 
 
-REASON_CODE_DETAILS = {
+_REASON_CODE_DETAILS = {
     'echeck': (
         'Payments sent as eCheck tend to take several days to a week to clear. Unfortunately, there is nothing we can do to expedite this process. In the future, please consider using an instant payment.',
         False,
@@ -261,7 +261,7 @@ REASON_CODE_DETAILS = {
 
 
 def get_pending_reason_details(pending_reason):
-    return REASON_CODE_DETAILS.get(pending_reason, ('', True))
+    return _REASON_CODE_DETAILS.get(pending_reason, ('', True))
 
 
 def log_ipn(ipn, message=''):

--- a/prizeutil.py
+++ b/prizeutil.py
@@ -32,7 +32,7 @@ def draw_prize(prize, seed=None, rand=None):
             )
     today = datetime.datetime.today()
     delta = datetime.timedelta(days=prize.event.prize_accept_deadline_delta)
-    acceptDeadline = (
+    accept_deadline = (
         today.replace(tzinfo=util.anywhere_on_earth_tz(), hour=23, minute=59, second=59)
         + delta
     )
@@ -41,7 +41,7 @@ def draw_prize(prize, seed=None, rand=None):
     # TODO: clean this up and make it real
     # elif len(prize.eligible_donors()) <= (prize.maxwinners - len(prize.get_prize_winners())):
     #     winners = PrizeWinner.objects.bulk_create(
-    #         [PrizeWinner(prize=prize, winner_id=d['donor'], acceptdeadline=acceptDeadline) for d in eligible]
+    #         [PrizeWinner(prize=prize, winner_id=d['donor'], acceptdeadline=accept_deadline) for d in eligible]
     #     )
     #     return True, {'winners': [w.id for w in winners]}
     else:
@@ -51,15 +51,15 @@ def draw_prize(prize, seed=None, rand=None):
         for d in eligible:
             if result < d['weight']:
                 try:
-                    winRecord, created = PrizeWinner.objects.get_or_create(
+                    win_record, created = PrizeWinner.objects.get_or_create(
                         prize=prize,
                         winner_id=d['donor'],
-                        defaults=dict(acceptdeadline=acceptDeadline),
+                        defaults=dict(acceptdeadline=accept_deadline),
                     )
                     if not created:
-                        winRecord.pendingcount += 1
-                    ret['winner'] = winRecord.winner.id
-                    winRecord.save()
+                        win_record.pendingcount += 1
+                    ret['winner'] = win_record.winner.id
+                    win_record.save()
                 except Exception as e:
                     return (
                         False,

--- a/randgen.py
+++ b/randgen.py
@@ -77,10 +77,10 @@ def random_game_description(rand, gamename):
     return 'Description for ' + gamename
 
 
-def random_prize_name(rand, forGame=None):
+def random_prize_name(rand, for_game=None):
     prizename = 'prize' + str(rand.getrandbits(32))
-    if forGame:
-        prizename = forGame + prizename
+    if for_game:
+        prizename = for_game + prizename
     return prizename
 
 

--- a/randgen.py
+++ b/randgen.py
@@ -19,7 +19,7 @@ from tracker.models import (
     SpeedRun,
     Runner,
 )
-from tracker.models.donation import DonorVisibilityChoices, DonationDomainChoices
+from tracker.models.donation import DONOR_VISIBILITY_CHOICES, DONATION_DOMAIN_CHOICES
 
 
 def random_name(rand, base):
@@ -137,7 +137,7 @@ def generate_donor(rand, *, firstname=None, lastname=None, alias=None, visibilit
     donor.lastname = random_last_name(rand) if lastname is None else lastname
     alias = random_alias(rand) if alias is None else alias
     donor.visibility = (
-        pick_random_element(rand, DonorVisibilityChoices)[0]
+        pick_random_element(rand, DONOR_VISIBILITY_CHOICES)[0]
         if visibility is None
         else visibility
     )
@@ -356,7 +356,7 @@ def generate_donation(
     if domain:
         donation.domain = domain
     else:
-        donation.domain = pick_random_element(rand, DonationDomainChoices)[0]
+        donation.domain = pick_random_element(rand, DONATION_DOMAIN_CHOICES)[0]
     donation.domainId = str(rand.getrandbits(64))
     donation.fee = (donation.amount * Decimal(0.03)).quantize(
         Decimal('0.01'), rounding=decimal.ROUND_UP

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-mptt==0.10.0
 django-post-office==3.2.1
 django-timezone-field==3.1
 djangorestframework==3.9.1
+pep8-naming==0.9.1
 pre-commit==2.0.1
 python-dateutil==2.8.1
 pytz==2019.3

--- a/serializers.py
+++ b/serializers.py
@@ -9,8 +9,8 @@ _ExtraFields = {
 
 
 class TrackerSerializer(PythonSerializer):
-    def __init__(self, Model, request):
-        self.Model = Model
+    def __init__(self, model, request):
+        self.Model = model
         self.request = request
 
     def handle_field(self, obj, field):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,9 +3,9 @@ import json
 import pytz
 from django.contrib.admin.models import (
     LogEntry,
-    ADDITION as LogEntryADDITION,
-    CHANGE as LogEntryCHANGE,
-    DELETION as LogEntryDELETION,
+    ADDITION as LOG_ENTRY_ADDITION,
+    CHANGE as LOG_ENTRY_CHANGE,
+    DELETION as LOG_ENTRY_DELETION,
 )
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -74,13 +74,13 @@ class TestGeneric(APITestCase):
         self.assertEqual(
             add_entry.content_type, ContentType.objects.get_for_model(models.Runner)
         )
-        self.assertEqual(add_entry.action_flag, LogEntryADDITION)
+        self.assertEqual(add_entry.action_flag, LOG_ENTRY_ADDITION)
         change_entry = LogEntry.objects.order_by('-pk')[0]
         self.assertEqual(int(change_entry.object_id), runner.id)
         self.assertEqual(
             change_entry.content_type, ContentType.objects.get_for_model(models.Runner)
         )
-        self.assertEqual(change_entry.action_flag, LogEntryCHANGE)
+        self.assertEqual(change_entry.action_flag, LOG_ENTRY_CHANGE)
         self.assertIn('Set name to "%s".' % runner.name, change_entry.change_message)
         self.assertIn(
             'Set stream to "%s".' % runner.stream, change_entry.change_message
@@ -106,7 +106,7 @@ class TestGeneric(APITestCase):
         self.assertEqual(
             entry.content_type, ContentType.objects.get_for_model(models.Runner)
         )
-        self.assertEqual(entry.action_flag, LogEntryCHANGE)
+        self.assertEqual(entry.action_flag, LOG_ENTRY_CHANGE)
         self.assertIn(
             'Changed name from "%s" to "%s".' % (old_runner.name, runner.name),
             entry.change_message,
@@ -134,7 +134,7 @@ class TestGeneric(APITestCase):
         self.assertEqual(
             entry.content_type, ContentType.objects.get_for_model(models.SpeedRun)
         )
-        self.assertEqual(entry.action_flag, LogEntryCHANGE)
+        self.assertEqual(entry.action_flag, LOG_ENTRY_CHANGE)
         self.assertIn(
             'Changed runners from empty to "%s".' % ([str(runner1), str(runner2)],),
             entry.change_message,
@@ -153,7 +153,7 @@ class TestGeneric(APITestCase):
         self.assertEqual(
             entry.content_type, ContentType.objects.get_for_model(models.Runner)
         )
-        self.assertEqual(entry.action_flag, LogEntryDELETION)
+        self.assertEqual(entry.action_flag, LOG_ENTRY_DELETION)
 
 
 class TestSpeedRun(APITestCase):

--- a/tests/test_delete_protection.py
+++ b/tests/test_delete_protection.py
@@ -28,7 +28,7 @@ class TestDeleteProtection(TransactionTestCase):
         ]:
             m.objects.all().delete()
 
-    def assertDeleteProtected(self, deleted, protected):
+    def assertDeleteProtected(self, deleted, protected):  # noqa N806
         protected.clean()
         with self.assertRaises(ProtectedError):
             deleted.delete()
@@ -49,7 +49,7 @@ class TestDeleteProtection(TransactionTestCase):
                 self.obj.delete()
 
     @property
-    def scratchPrizeTimed(self):
+    def scratch_prize_timed(self):
         return models.Prize.objects.get_or_create(
             name='Scratch Prize Timed',
             event=self.event,
@@ -60,51 +60,51 @@ class TestDeleteProtection(TransactionTestCase):
         )[0]
 
     @property
-    def scratchPrizeRun(self):
+    def scratch_prize_run(self):
         return models.Prize.objects.get_or_create(
             name='Scratch Prize Run',
             event=self.event,
-            defaults=dict(startrun=self.scratchRun, endrun=self.scratchRun),
+            defaults=dict(startrun=self.scratch_run, endrun=self.scratch_run),
         )[0]
 
     @property
-    def scratchPrizeWinner(self):
+    def scratch_prize_winner(self):
         return models.PrizeWinner.objects.get_or_create(
-            winner=self.scratchDonor, prize=self.scratchPrizeTimed
+            winner=self.scratch_donor, prize=self.scratch_prize_timed
         )[0]
 
     @property
-    def scratchDonor(self):
+    def scratch_donor(self):
         return models.Donor.objects.get_or_create(email='scratch_donor@example.com')[0]
 
     @property
-    def scratchDonation(self):
+    def scratch_donation(self):
         return models.Donation.objects.get_or_create(
             domainId='scratch',
             defaults=dict(domain='PAYPAL', event=self.event, amount=5),
         )[0]
 
     @property
-    def scratchDonationWithDonor(self):
+    def scratch_donation_with_donor(self):
         return models.Donation.objects.get_or_create(
-            domainId='scratchDonor',
+            domainId='scratch_donor',
             defaults=dict(
                 domain='PAYPAL',
                 event=self.event,
-                donor=self.scratchDonor,
+                donor=self.scratch_donor,
                 amount=5,
                 transactionstate='COMPLETED',
             ),
         )[0]
 
     @property
-    def scratchDonationBid(self):
+    def scratch_donation_bid(self):
         return models.DonationBid.objects.get_or_create(
-            donation=self.scratchDonation, bid=self.scratchBidRun, amount=5
+            donation=self.scratch_donation, bid=self.scratch_bid_run, amount=5
         )[0]
 
     @property
-    def scratchRun(self):
+    def scratch_run(self):
         return models.SpeedRun.objects.get_or_create(
             name='Scratch Run',
             event=self.event,
@@ -115,20 +115,20 @@ class TestDeleteProtection(TransactionTestCase):
         )[0]
 
     @property
-    def scratchBidEvent(self):
+    def scratch_bid_event(self):
         return models.Bid.objects.get_or_create(name='Scratch Bid', event=self.event)[0]
 
     @property
-    def scratchBidRun(self):
+    def scratch_bid_run(self):
         return models.Bid.objects.get_or_create(
-            name='Scratch Bid', speedrun=self.scratchRun, istarget=True
+            name='Scratch Bid', speedrun=self.scratch_run, istarget=True
         )[0]
 
-    def testDeleteEvent(self):
-        self.assertDeleteProtected(self.event, self.scratchBidEvent)
-        self.assertDeleteProtected(self.event, self.scratchRun)
-        self.assertDeleteProtected(self.event, self.scratchPrizeTimed)
-        self.assertDeleteProtected(self.event, self.scratchDonation)
+    def test_delete_event(self):
+        self.assertDeleteProtected(self.event, self.scratch_bid_event)
+        self.assertDeleteProtected(self.event, self.scratch_run)
+        self.assertDeleteProtected(self.event, self.scratch_prize_timed)
+        self.assertDeleteProtected(self.event, self.scratch_donation)
         with self.Delete(
             models.Event.objects.create(
                 short='delete',
@@ -139,16 +139,16 @@ class TestDeleteProtection(TransactionTestCase):
         ):
             pass
 
-    def testDeleteRun(self):
-        with self.Delete(self.scratchRun) as run:
-            self.assertDeleteProtected(run, self.scratchPrizeRun)
-            self.assertDeleteProtected(run, self.scratchBidRun)
+    def test_delete_run(self):
+        with self.Delete(self.scratch_run) as run:
+            self.assertDeleteProtected(run, self.scratch_prize_run)
+            self.assertDeleteProtected(run, self.scratch_bid_run)
 
-    def testDeleteDonor(self):
-        with self.Delete(self.scratchDonor) as donor:
-            self.assertDeleteProtected(donor, self.scratchPrizeWinner)
-            self.assertDeleteProtected(donor, self.scratchDonationWithDonor)
+    def test_delete_donor(self):
+        with self.Delete(self.scratch_donor) as donor:
+            self.assertDeleteProtected(donor, self.scratch_prize_winner)
+            self.assertDeleteProtected(donor, self.scratch_donation_with_donor)
 
-    def testDeleteDonation(self):
-        with self.Delete(self.scratchDonation) as donation:
-            self.assertDeleteProtected(donation, self.scratchDonationBid)
+    def test_delete_donation(self):
+        with self.Delete(self.scratch_donation) as donation:
+            self.assertDeleteProtected(donation, self.scratch_donation_bid)

--- a/tests/test_donate.py
+++ b/tests/test_donate.py
@@ -9,7 +9,7 @@ from .util import today_noon, tomorrow_noon, long_ago_noon
 
 
 class TestDonorNameAssignment(TransactionTestCase):
-    def testAliasAnonToVisibilityAnon(self):
+    def test_alias_anon_to_visibility_anon(self):
         data = {
             'amount': Decimal('5.00'),
             'requestedvisibility': 'ALIAS',
@@ -42,7 +42,7 @@ class TestDonateViews(TransactionTestCase):
             locked=True,
         )
 
-    def testNormalEvent(self):
+    def test_normal_event(self):
         resp = self.client.get(reverse('tracker:donate', args=(self.normal_event.id,)))
         self.assertEqual(resp.status_code, 200)
         resp = self.client.get(
@@ -50,7 +50,7 @@ class TestDonateViews(TransactionTestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
-    def testUpcomingEvent(self):
+    def test_upcoming_event(self):
         resp = self.client.get(
             reverse('tracker:donate', args=(self.upcoming_event.id,))
         )
@@ -60,7 +60,7 @@ class TestDonateViews(TransactionTestCase):
         )
         self.assertEqual(resp.status_code, 404)
 
-    def testLockedEvent(self):
+    def test_locked_event(self):
         resp = self.client.get(reverse('tracker:donate', args=(self.locked_event.id,)))
         self.assertEqual(resp.status_code, 404)
         resp = self.client.get(

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -254,7 +254,7 @@ class TestDonorTotals(TestCase):
 
 
 class TestDonorEmailSave(TestCase):
-    def testSaveWithExistingDoesNotThrow(self):
+    def test_save_with_existing_does_not_throw(self):
         rand = random.Random(None)
         d1 = randgen.generate_donor(rand)
         d1.paypalemail = d1.email
@@ -264,20 +264,20 @@ class TestDonorEmailSave(TestCase):
 
 
 class TestDonorMerge(TestCase):
-    def testBasicMerge(self):
+    def test_basic_merge(self):
         rand = random.Random(None)
         randgen.build_random_event(rand, num_donors=10, num_donations=20, num_runs=10)
-        donorList = models.Donor.objects.all()
-        rootDonor = donorList[0]
-        donationList = []
-        for donor in donorList:
-            donationList.extend(list(donor.donation_set.all()))
-        viewutil.merge_donors(rootDonor, donorList)
-        for donor in donorList[1:]:
+        donor_list = models.Donor.objects.all()
+        root_donor = donor_list[0]
+        donation_list = []
+        for donor in donor_list:
+            donation_list.extend(list(donor.donation_set.all()))
+        viewutil.merge_donors(root_donor, donor_list)
+        for donor in donor_list[1:]:
             self.assertFalse(models.Donor.objects.filter(id=donor.id).exists())
-        self.assertEqual(len(donationList), rootDonor.donation_set.count())
-        for donation in rootDonor.donation_set.all():
-            self.assertTrue(donation in donationList)
+        self.assertEqual(len(donation_list), root_donor.donation_set.count())
+        for donation in root_donor.donation_set.all():
+            self.assertTrue(donation in donation_list)
 
 
 class TestDonorView(TestCase):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -398,14 +398,14 @@ class TestEventAdmin(TestCase):
             max_amount=prize.minimumbid,
             transactionstate='COMPLETED',
         ).save()
-        grandPrize = randgen.generate_prize(
+        grand_prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=True,
             min_amount=50,
             max_amount=50,
         )
-        grandPrize.save()
+        grand_prize.save()
         # generate 2 for summation
         randgen.generate_donation(
             self.rand,
@@ -413,8 +413,8 @@ class TestEventAdmin(TestCase):
             event=self.event,
             min_time=runs[1].starttime,
             max_time=runs[1].endtime,
-            min_amount=grandPrize.minimumbid // 2,
-            max_amount=grandPrize.minimumbid // 2,
+            min_amount=grand_prize.minimumbid // 2,
+            max_amount=grand_prize.minimumbid // 2,
             transactionstate='COMPLETED',
         ).save()
         randgen.generate_donation(
@@ -423,8 +423,8 @@ class TestEventAdmin(TestCase):
             event=self.event,
             min_time=runs[1].starttime,
             max_time=runs[1].endtime,
-            min_amount=grandPrize.minimumbid * 3 // 4,
-            max_amount=grandPrize.minimumbid * 3 // 4,
+            min_amount=grand_prize.minimumbid * 3 // 4,
+            max_amount=grand_prize.minimumbid * 3 // 4,
             transactionstate='COMPLETED',
         ).save()
         # also has another donation in
@@ -434,8 +434,8 @@ class TestEventAdmin(TestCase):
             event=self.event,
             min_time=runs[1].starttime,
             max_time=runs[1].endtime,
-            min_amount=grandPrize.minimumbid,
-            max_amount=grandPrize.minimumbid,
+            min_amount=grand_prize.minimumbid,
+            max_amount=grand_prize.minimumbid,
             transactionstate='COMPLETED',
         ).save()
         # only has donation for grand prize
@@ -445,8 +445,8 @@ class TestEventAdmin(TestCase):
             event=self.event,
             min_time=runs[1].starttime,
             max_time=runs[1].endtime,
-            min_amount=grandPrize.minimumbid,
-            max_amount=grandPrize.minimumbid,
+            min_amount=grand_prize.minimumbid,
+            max_amount=grand_prize.minimumbid,
             transactionstate='COMPLETED',
         ).save()
 
@@ -457,7 +457,7 @@ class TestEventAdmin(TestCase):
         self.assertEqual(resp.status_code, 200)
         lines = [line for line in csv.reader(io.StringIO(resp.content.decode('utf-8')))]
         self.assertEqual(len(lines), 3)
-        self.assertEqual(lines[1], ['test', grandPrize.name, '3', '1', '', ''])
+        self.assertEqual(lines[1], ['test', grand_prize.name, '3', '1', '', ''])
         self.assertEqual(
             lines[2],
             [

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -26,42 +26,42 @@ class TestRegistrationForm(TransactionTestCase):
         self.factory = RequestFactory()
 
     def run_registration(self, email):
-        regForm = tracker.forms.RegistrationForm(
+        reg_form = tracker.forms.RegistrationForm(
             data={'email': email, 'from_email': email}
         )
-        self.assertTrue(regForm.is_valid())
-        resultMail = regForm.save(
+        self.assertTrue(reg_form.is_valid())
+        result_mail = reg_form.save(
             request=self.factory.post(reverse('tracker:register'))
         )
-        self.assertIsNot(None, resultMail)
-        resultUserQuery = AuthUser.objects.filter(email=email)
-        self.assertEqual(1, resultUserQuery.count())
-        return resultUserQuery[0]
+        self.assertIsNot(None, result_mail)
+        result_user_query = AuthUser.objects.filter(email=email)
+        self.assertEqual(1, result_user_query.count())
+        return result_user_query[0]
 
-    def testRegisterPerson(self):
-        regEmail = 'testemail@test.com'
-        userObj = self.run_registration(regEmail)
-        self.assertEqual(regEmail, userObj.username)
-        self.assertEqual(regEmail, userObj.email)
-        self.assertFalse(userObj.is_active)
-        self.assertFalse(userObj.is_staff)
+    def test_register_person(self):
+        reg_email = 'testemail@test.com'
+        user_obj = self.run_registration(reg_email)
+        self.assertEqual(reg_email, user_obj.username)
+        self.assertEqual(reg_email, user_obj.email)
+        self.assertFalse(user_obj.is_active)
+        self.assertFalse(user_obj.is_staff)
 
-    def testRegisterPersonLongEmail(self):
-        regEmail = 'test' * 9 + '@anothertest.com'
-        userObj = self.run_registration(regEmail)
-        self.assertGreaterEqual(30, len(userObj.username))
-        self.assertEqual(regEmail, userObj.email)
-        self.assertFalse(userObj.is_active)
-        self.assertFalse(userObj.is_staff)
+    def test_register_person_long_email(self):
+        reg_email = 'test' * 9 + '@anothertest.com'
+        user_obj = self.run_registration(reg_email)
+        self.assertGreaterEqual(30, len(user_obj.username))
+        self.assertEqual(reg_email, user_obj.email)
+        self.assertFalse(user_obj.is_active)
+        self.assertFalse(user_obj.is_staff)
 
-    def testClashingRegistrationEmails(self):
-        regEmailPrefix = 'prefix' * 9
-        self.assertLess(30, len(regEmailPrefix))
-        regEmail1 = regEmailPrefix + '@test1.com'
-        regEmail2 = regEmailPrefix + '@test2.com'
-        userObj1 = self.run_registration(regEmail1)
-        userObj2 = self.run_registration(regEmail2)
-        self.assertNotEqual(userObj1, userObj2)
+    def test_clashing_registration_emails(self):
+        reg_email_prefix = 'prefix' * 9
+        self.assertLess(30, len(reg_email_prefix))
+        reg_email1 = reg_email_prefix + '@test1.com'
+        reg_email2 = reg_email_prefix + '@test2.com'
+        user1 = self.run_registration(reg_email1)
+        user2 = self.run_registration(reg_email2)
+        self.assertNotEqual(user1, user2)
 
 
 class TestRegistrationConfirmationForm(TransactionTestCase):

--- a/tests/test_mod_filter.py
+++ b/tests/test_mod_filter.py
@@ -13,7 +13,7 @@ class TestWordFilter(TransactionTestCase):
             short='ev1', name='Event 1', targetamount=5, datetime=today_noon
         )
 
-    def testRejectionOfWordMatch(self):
+    def test_rejection_of_word_match(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='HYPE', amount=5
         )
@@ -21,7 +21,7 @@ class TestWordFilter(TransactionTestCase):
         self.assertEqual(donation.readstate, 'IGNORED')
         self.assertTrue('DENIED due to matching filter word' in donation.modcomment)
 
-    def testNoRejectionForPartialWordMatch(self):
+    def test_no_rejection_for_partial_word_match(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='HYPED', amount=5
         )
@@ -29,7 +29,7 @@ class TestWordFilter(TransactionTestCase):
         self.assertNotEqual(donation.readstate, 'IGNORED')
         self.assertFalse('DENIED due to matching filter word' in donation.modcomment)
 
-    def testNoRejectionForNoMatch(self):
+    def test_no_rejection_for_no_match(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='relaxed', amount=5
         )
@@ -37,7 +37,7 @@ class TestWordFilter(TransactionTestCase):
         self.assertNotEqual(donation.readstate, 'IGNORED')
         self.assertFalse('DENIED due to matching filter word' in donation.modcomment)
 
-    def testNoRejectionOfExistingDonations(self):
+    def test_no_rejection_of_existing_donations(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='relaxed', amount=5
         )
@@ -54,7 +54,7 @@ class TestAmountFilter(TransactionTestCase):
             short='ev1', name='Event 1', targetamount=5, datetime=today_noon
         )
 
-    def testRejectionOfAmountMatch(self):
+    def test_rejection_of_amount_match(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='HYPE', amount=Decimal('4.20')
         )
@@ -62,7 +62,7 @@ class TestAmountFilter(TransactionTestCase):
         self.assertEqual(donation.readstate, 'IGNORED')
         self.assertTrue('DENIED due to matching filter amount' in donation.modcomment)
 
-    def testNoRejectionOfUnmatchedAmount(self):
+    def test_no_rejection_of_unmatched_amount(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='HYPE', amount=5
         )
@@ -70,7 +70,7 @@ class TestAmountFilter(TransactionTestCase):
         self.assertNotEqual(donation.readstate, 'IGNORED')
         self.assertFalse('DENIED due to matching filter amount' in donation.modcomment)
 
-    def testNoRejectionOfExistingDonations(self):
+    def test_no_rejection_of_existing_donations(self):
         donation = models.Donation.objects.create(
             event=self.event, comment='HYPE', amount=5
         )

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -28,91 +28,91 @@ class TestPrizeGameRange(TransactionTestCase):
         prize = randgen.generate_prize(
             self.rand, event=self.event, start_run=run, end_run=run
         )
-        prizeRuns = prize.games_range()
-        self.assertEqual(1, prizeRuns.count())
-        self.assertEqual(run.id, prizeRuns[0].id)
+        prize_runs = prize.games_range()
+        self.assertEqual(1, prize_runs.count())
+        self.assertEqual(run.id, prize_runs[0].id)
 
     def test_prize_range_pair(self):
         runs = randgen.generate_runs(self.rand, self.event, 5, scheduled=True)
-        startRun = runs[2]
-        endRun = runs[3]
+        start_run = runs[2]
+        end_run = runs[3]
         prize = randgen.generate_prize(
-            self.rand, event=self.event, start_run=startRun, end_run=endRun
+            self.rand, event=self.event, start_run=start_run, end_run=end_run
         )
-        prizeRuns = prize.games_range()
-        self.assertEqual(2, prizeRuns.count())
-        self.assertEqual(startRun.id, prizeRuns[0].id)
-        self.assertEqual(endRun.id, prizeRuns[1].id)
+        prize_runs = prize.games_range()
+        self.assertEqual(2, prize_runs.count())
+        self.assertEqual(start_run.id, prize_runs[0].id)
+        self.assertEqual(end_run.id, prize_runs[1].id)
 
     def test_prize_range_gap(self):
         runs = randgen.generate_runs(self.rand, self.event, 7, scheduled=True)
-        runsSlice = runs[2:5]
+        runs_slice = runs[2:5]
         prize = randgen.generate_prize(
-            self.rand, event=self.event, start_run=runsSlice[0], end_run=runsSlice[-1]
+            self.rand, event=self.event, start_run=runs_slice[0], end_run=runs_slice[-1]
         )
-        prizeRuns = prize.games_range()
-        self.assertEqual(len(runsSlice), prizeRuns.count())
-        for i in range(0, len(runsSlice)):
-            self.assertEqual(runsSlice[i].id, prizeRuns[i].id)
+        prize_runs = prize.games_range()
+        self.assertEqual(len(runs_slice), prize_runs.count())
+        for i in range(0, len(runs_slice)):
+            self.assertEqual(runs_slice[i].id, prize_runs[i].id)
 
     def test_time_prize_no_range(self):
         runs = randgen.generate_runs(self.rand, self.event, 7, scheduled=True)
-        eventEnd = runs[-1].endtime
-        timeA = randgen.random_time(self.rand, self.event.datetime, eventEnd)
-        timeB = randgen.random_time(self.rand, self.event.datetime, eventEnd)
-        randomStart = min(timeA, timeB)
-        randomEnd = max(timeA, timeB)
+        event_end = runs[-1].endtime
+        time_a = randgen.random_time(self.rand, self.event.datetime, event_end)
+        time_b = randgen.random_time(self.rand, self.event.datetime, event_end)
+        random_start = min(time_a, time_b)
+        random_end = max(time_a, time_b)
         prize = randgen.generate_prize(
-            self.rand, event=self.event, start_time=randomStart, end_time=randomEnd
+            self.rand, event=self.event, start_time=random_start, end_time=random_end
         )
-        prizeRuns = prize.games_range()
-        self.assertEqual(0, prizeRuns.count())
-        self.assertEqual(randomStart, prize.start_draw_time())
-        self.assertEqual(randomEnd, prize.end_draw_time())
+        prize_runs = prize.games_range()
+        self.assertEqual(0, prize_runs.count())
+        self.assertEqual(random_start, prize.start_draw_time())
+        self.assertEqual(random_end, prize.end_draw_time())
 
 
 class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
     def setUp(self):
-        self.eventStart = parse_date('2014-01-01 16:00:00Z')
+        self.event_start = parse_date('2014-01-01 16:00:00Z')
         self.rand = random.Random(516273)
         self.event = randgen.build_random_event(
-            self.rand, start_time=self.eventStart, num_donors=100, num_runs=50
+            self.rand, start_time=self.event_start, num_donors=100, num_runs=50
         )
-        self.runsList = list(models.SpeedRun.objects.filter(event=self.event))
-        self.donorList = list(models.Donor.objects.all())
+        self.runs_list = list(models.SpeedRun.objects.filter(event=self.event))
+        self.donor_list = list(models.Donor.objects.all())
 
     def test_draw_random_prize_no_donations(self):
-        prizeList = randgen.generate_prizes(
-            self.rand, self.event, 50, list_of_runs=self.runsList
+        prize_list = randgen.generate_prizes(
+            self.rand, self.event, 50, list_of_runs=self.runs_list
         )
-        for prize in prizeList:
+        for prize in prize_list:
             for randomness in [True, False]:
-                for useSum in [True, False]:
+                for use_sum in [True, False]:
                     prize.randomdraw = randomness
-                    prize.sumdonations = useSum
+                    prize.sumdonations = use_sum
                     prize.save()
-                    eligibleDonors = prize.eligible_donors()
-                    self.assertEqual(0, len(eligibleDonors))
+                    eligible_donors = prize.eligible_donors()
+                    self.assertEqual(0, len(eligible_donors))
                     result, message = prizeutil.draw_prize(prize)
                     self.assertFalse(result)
                     self.assertEqual(0, prize.current_win_count())
 
     def test_draw_prize_one_donor(self):
-        startRun = self.runsList[14]
-        endRun = self.runsList[28]
-        for useRandom in [True, False]:
-            for useSum in [True, False]:
-                for donationSize in ['top', 'bottom', 'above', 'below', 'within']:
+        start_run = self.runs_list[14]
+        end_run = self.runs_list[28]
+        for use_random in [True, False]:
+            for use_sum in [True, False]:
+                for donation_size in ['top', 'bottom', 'above', 'below', 'within']:
                     prize = randgen.generate_prize(
                         self.rand,
                         event=self.event,
-                        sum_donations=useSum,
-                        random_draw=useRandom,
-                        start_run=startRun,
-                        end_run=endRun,
+                        sum_donations=use_sum,
+                        random_draw=use_random,
+                        start_run=start_run,
+                        end_run=end_run,
                     )
                     prize.save()
-                    donor = randgen.pick_random_element(self.rand, self.donorList)
+                    donor = randgen.pick_random_element(self.rand, self.donor_list)
                     donation = randgen.generate_donation(
                         self.rand,
                         donor=donor,
@@ -120,46 +120,46 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                         min_time=prize.start_draw_time(),
                         max_time=prize.end_draw_time(),
                     )
-                    if donationSize == 'above':
+                    if donation_size == 'above':
                         donation.amount = prize.maximumbid + Decimal('5.00')
-                    elif donationSize == 'top':
+                    elif donation_size == 'top':
                         donation.amount = prize.maximumbid
-                    elif donationSize == 'within':
+                    elif donation_size == 'within':
                         donation.amount = randgen.random_amount(
                             self.rand,
                             min_amount=prize.minimumbid,
                             max_amount=prize.maximumbid,
                         )
-                    elif donationSize == 'bottom':
+                    elif donation_size == 'bottom':
                         donation.amount = prize.minimumbid
-                    elif donationSize == 'below':
+                    elif donation_size == 'below':
                         donation.amount = max(
                             Decimal('0.00'), prize.minimumbid - Decimal('5.00')
                         )
                     donation.save()
-                    eligibleDonors = prize.eligible_donors()
-                    if donationSize == 'below' and prize.randomdraw:
-                        self.assertEqual(0, len(eligibleDonors))
+                    eligible_donors = prize.eligible_donors()
+                    if donation_size == 'below' and prize.randomdraw:
+                        self.assertEqual(0, len(eligible_donors))
                     else:
-                        self.assertEqual(1, len(eligibleDonors))
-                        self.assertEqual(donor.id, eligibleDonors[0]['donor'])
-                        self.assertEqual(donation.amount, eligibleDonors[0]['amount'])
+                        self.assertEqual(1, len(eligible_donors))
+                        self.assertEqual(donor.id, eligible_donors[0]['donor'])
+                        self.assertEqual(donation.amount, eligible_donors[0]['amount'])
                         if prize.sumdonations and prize.randomdraw:
-                            if donationSize == 'top' or donationSize == 'above':
-                                expectedRatio = float(
+                            if donation_size == 'top' or donation_size == 'above':
+                                expected_ratio = float(
                                     prize.maximumbid / prize.minimumbid
                                 )
                             else:
-                                expectedRatio = float(
+                                expected_ratio = float(
                                     donation.amount / prize.minimumbid
                                 )
                             self.assertAlmostEqual(
-                                expectedRatio, eligibleDonors[0]['weight']
+                                expected_ratio, eligible_donors[0]['weight']
                             )
                         else:
-                            self.assertEqual(1.0, eligibleDonors[0]['weight'])
+                            self.assertEqual(1.0, eligible_donors[0]['weight'])
                     result, message = prizeutil.draw_prize(prize)
-                    if donationSize != 'below' or not prize.randomdraw:
+                    if donation_size != 'below' or not prize.randomdraw:
                         self.assertTrue(result)
                         self.assertEqual(donor, prize.get_winner())
                     else:
@@ -170,19 +170,19 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                     prize.delete()
 
     def test_draw_prize_multiple_donors_random_nosum(self):
-        startRun = self.runsList[28]
-        endRun = self.runsList[30]
+        start_run = self.runs_list[28]
+        end_run = self.runs_list[30]
         prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=False,
             random_draw=True,
-            start_run=startRun,
-            end_run=endRun,
+            start_run=start_run,
+            end_run=end_run,
         )
         prize.save()
-        donationDonors = {}
-        for donor in self.donorList:
+        donation_donors = {}
+        for donor in self.donor_list:
             if self.rand.getrandbits(1) == 0:
                 donation = randgen.generate_donation(
                     self.rand,
@@ -194,7 +194,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                     max_time=prize.end_draw_time(),
                 )
                 donation.save()
-                donationDonors[donor.id] = donor
+                donation_donors[donor.id] = donor
             # Add a few red herrings to make sure out of range donations aren't
             # used
             donation2 = randgen.generate_donation(
@@ -215,25 +215,25 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                 min_time=prize.end_draw_time() + datetime.timedelta(seconds=1),
             )
             donation3.save()
-        eligibleDonors = prize.eligible_donors()
-        self.assertEqual(len(list(donationDonors.keys())), len(eligibleDonors))
-        for eligibleDonor in eligibleDonors:
+        eligible_donors = prize.eligible_donors()
+        self.assertEqual(len(list(donation_donors.keys())), len(eligible_donors))
+        for eligible_donor in eligible_donors:
             found = False
-            if eligibleDonor['donor'] in donationDonors:
-                donor = donationDonors[eligibleDonor['donor']]
+            if eligible_donor['donor'] in donation_donors:
+                donor = donation_donors[eligible_donor['donor']]
                 donation = donor.donation_set.filter(
                     timereceived__gte=prize.start_draw_time(),
                     timereceived__lte=prize.end_draw_time(),
                 )[0]
-                self.assertEqual(donation.amount, eligibleDonor['amount'])
-                self.assertEqual(1.0, eligibleDonor['weight'])
+                self.assertEqual(donation.amount, eligible_donor['amount'])
+                self.assertEqual(1.0, eligible_donor['weight'])
                 found = True
             self.assertTrue(found and 'Could not find the donor in the list')
         winners = []
         for seed in [15634, 12512, 666]:
             result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
-            self.assertIn(prize.get_winner().id, donationDonors)
+            self.assertIn(prize.get_winner().id, donation_donors)
             winners.append(prize.get_winner())
             current = prize.get_winner()
             prize.prizewinner_set.all().delete()
@@ -248,23 +248,23 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         self.assertNotEqual(winners[0], winners[2])
 
     def test_draw_prize_multiple_donors_random_sum(self):
-        startRun = self.runsList[41]
-        endRun = self.runsList[46]
+        start_run = self.runs_list[41]
+        end_run = self.runs_list[46]
         prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=True,
             random_draw=True,
-            start_run=startRun,
-            end_run=endRun,
+            start_run=start_run,
+            end_run=end_run,
         )
         prize.save()
-        donationDonors = {}
-        for donor in self.donorList:
-            numDonations = self.rand.getrandbits(4)
-            redHerrings = self.rand.getrandbits(4)
-            donationDonors[donor.id] = {'donor': donor, 'amount': Decimal('0.00')}
-            for i in range(0, numDonations):
+        donation_donors = {}
+        for donor in self.donor_list:
+            num_donations = self.rand.getrandbits(4)
+            red_herrings = self.rand.getrandbits(4)
+            donation_donors[donor.id] = {'donor': donor, 'amount': Decimal('0.00')}
+            for i in range(0, num_donations):
                 donation = randgen.generate_donation(
                     self.rand,
                     donor=donor,
@@ -275,9 +275,9 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                     max_time=prize.end_draw_time(),
                 )
                 donation.save()
-                donationDonors[donor.id]['amount'] += donation.amount
+                donation_donors[donor.id]['amount'] += donation.amount
             # toss in a few extras to keep the drawer on its toes
-            for i in range(0, redHerrings):
+            for i in range(0, red_herrings):
                 donation = None
                 if self.rand.getrandbits(1) == 0:
                     donation = randgen.generate_donation(
@@ -299,31 +299,31 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                         min_time=prize.end_draw_time() + datetime.timedelta(seconds=1),
                     )
                 donation.save()
-            if donationDonors[donor.id]['amount'] < prize.minimumbid:
-                del donationDonors[donor.id]
-        eligibleDonors = prize.eligible_donors()
-        self.assertEqual(len(list(donationDonors.keys())), len(eligibleDonors))
+            if donation_donors[donor.id]['amount'] < prize.minimumbid:
+                del donation_donors[donor.id]
+        eligible_donors = prize.eligible_donors()
+        self.assertEqual(len(list(donation_donors.keys())), len(eligible_donors))
         found = False
-        for eligibleDonor in eligibleDonors:
-            if eligibleDonor['donor'] in donationDonors:
-                entry = donationDonors[eligibleDonor['donor']]
+        for eligible_donor in eligible_donors:
+            if eligible_donor['donor'] in donation_donors:
+                entry = donation_donors[eligible_donor['donor']]
                 donor = entry['donor']
                 if entry['amount'] >= prize.minimumbid:
                     donations = donor.donation_set.filter(
                         timereceived__gte=prize.start_draw_time(),
                         timereceived__lte=prize.end_draw_time(),
                     )
-                    countAmount = Decimal('0.00')
+                    count_amount = Decimal('0.00')
                     for donation in donations:
-                        countAmount += donation.amount
-                    self.assertEqual(entry['amount'], eligibleDonor['amount'])
-                    self.assertEqual(countAmount, eligibleDonor['amount'])
+                        count_amount += donation.amount
+                    self.assertEqual(entry['amount'], eligible_donor['amount'])
+                    self.assertEqual(count_amount, eligible_donor['amount'])
                     self.assertAlmostEqual(
                         min(
                             prize.maximumbid / prize.minimumbid,
                             entry['amount'] / prize.minimumbid,
                         ),
-                        Decimal(eligibleDonor['weight']),
+                        Decimal(eligible_donor['weight']),
                     )
                     found = True
         # FIXME: what is this actually asserting? it's not very clear to me by glancing at it
@@ -332,7 +332,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         for seed in [51234, 235426, 62363245]:
             result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
-            self.assertIn(prize.get_winner().id, donationDonors)
+            self.assertIn(prize.get_winner().id, donation_donors)
             winners.append(prize.get_winner())
             current = prize.get_winner()
             prize.prizewinner_set.all().delete()
@@ -347,23 +347,23 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
         self.assertNotEqual(winners[0], winners[2])
 
     def test_draw_prize_multiple_donors_norandom_nosum(self):
-        startRun = self.runsList[25]
-        endRun = self.runsList[34]
+        start_run = self.runs_list[25]
+        end_run = self.runs_list[34]
         prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=False,
             random_draw=False,
-            start_run=startRun,
-            end_run=endRun,
+            start_run=start_run,
+            end_run=end_run,
         )
         prize.save()
-        largestDonor = None
-        largestAmount = Decimal('0.00')
-        for donor in self.donorList:
-            numDonations = self.rand.getrandbits(4)
-            redHerrings = self.rand.getrandbits(4)
-            for i in range(0, numDonations):
+        largest_donor = None
+        largest_amount = Decimal('0.00')
+        for donor in self.donor_list:
+            num_donations = self.rand.getrandbits(4)
+            red_herrings = self.rand.getrandbits(4)
+            for i in range(0, num_donations):
                 donation = randgen.generate_donation(
                     self.rand,
                     donor=donor,
@@ -374,11 +374,11 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                     max_time=prize.end_draw_time(),
                 )
                 donation.save()
-                if donation.amount > largestAmount:
-                    largestDonor = donor
-                    largestAmount = donation.amount
+                if donation.amount > largest_amount:
+                    largest_donor = donor
+                    largest_amount = donation.amount
             # toss in a few extras to keep the drawer on its toes
-            for i in range(0, redHerrings):
+            for i in range(0, red_herrings):
                 donation = None
                 if self.rand.getrandbits(1) == 0:
                     donation = randgen.generate_donation(
@@ -402,59 +402,59 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                         min_time=prize.end_draw_time() + datetime.timedelta(seconds=1),
                     )
                 donation.save()
-        eligibleDonors = prize.eligible_donors()
-        self.assertEqual(1, len(eligibleDonors))
-        self.assertEqual(largestDonor.id, eligibleDonors[0]['donor'])
-        self.assertEqual(1.0, eligibleDonors[0]['weight'])
-        self.assertEqual(largestAmount, eligibleDonors[0]['amount'])
+        eligible_donors = prize.eligible_donors()
+        self.assertEqual(1, len(eligible_donors))
+        self.assertEqual(largest_donor.id, eligible_donors[0]['donor'])
+        self.assertEqual(1.0, eligible_donors[0]['weight'])
+        self.assertEqual(largest_amount, eligible_donors[0]['amount'])
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
             result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
-            self.assertEqual(largestDonor.id, prize.get_winner().id)
-        newDonor = randgen.generate_donor(self.rand)
-        newDonor.save()
-        newDonation = randgen.generate_donation(
+            self.assertEqual(largest_donor.id, prize.get_winner().id)
+        new_donor = randgen.generate_donor(self.rand)
+        new_donor.save()
+        new_donation = randgen.generate_donation(
             self.rand,
-            donor=newDonor,
+            donor=new_donor,
             event=self.event,
             min_amount=Decimal('1000.01'),
             max_amount=Decimal('2000.00'),
             min_time=prize.start_draw_time(),
             max_time=prize.end_draw_time(),
         )
-        newDonation.save()
-        eligibleDonors = prize.eligible_donors()
-        self.assertEqual(1, len(eligibleDonors))
-        self.assertEqual(newDonor.id, eligibleDonors[0]['donor'])
-        self.assertEqual(1.0, eligibleDonors[0]['weight'])
-        self.assertEqual(newDonation.amount, eligibleDonors[0]['amount'])
+        new_donation.save()
+        eligible_donors = prize.eligible_donors()
+        self.assertEqual(1, len(eligible_donors))
+        self.assertEqual(new_donor.id, eligible_donors[0]['donor'])
+        self.assertEqual(1.0, eligible_donors[0]['weight'])
+        self.assertEqual(new_donation.amount, eligible_donors[0]['amount'])
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
             result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
-            self.assertEqual(newDonor.id, prize.get_winner().id)
+            self.assertEqual(new_donor.id, prize.get_winner().id)
 
     def test_draw_prize_multiple_donors_norandom_sum(self):
-        startRun = self.runsList[5]
-        endRun = self.runsList[9]
+        start_run = self.runs_list[5]
+        end_run = self.runs_list[9]
         prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=True,
             random_draw=False,
-            start_run=startRun,
-            end_run=endRun,
+            start_run=start_run,
+            end_run=end_run,
         )
         prize.save()
-        donationDonors = {}
-        for donor in self.donorList:
-            numDonations = self.rand.getrandbits(4)
-            redHerrings = self.rand.getrandbits(4)
-            donationDonors[donor.id] = {'donor': donor, 'amount': Decimal('0.00')}
-            for i in range(0, numDonations):
+        donation_donors = {}
+        for donor in self.donor_list:
+            num_donations = self.rand.getrandbits(4)
+            red_herrings = self.rand.getrandbits(4)
+            donation_donors[donor.id] = {'donor': donor, 'amount': Decimal('0.00')}
+            for i in range(0, num_donations):
                 donation = randgen.generate_donation(
                     self.rand,
                     donor=donor,
@@ -465,9 +465,9 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                     max_time=prize.end_draw_time(),
                 )
                 donation.save()
-                donationDonors[donor.id]['amount'] += donation.amount
+                donation_donors[donor.id]['amount'] += donation.amount
             # toss in a few extras to keep the drawer on its toes
-            for i in range(0, redHerrings):
+            for i in range(0, red_herrings):
                 donation = None
                 if self.rand.getrandbits(1) == 0:
                     donation = randgen.generate_donation(
@@ -491,46 +491,46 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                         min_time=prize.end_draw_time() + datetime.timedelta(seconds=1),
                     )
                 donation.save()
-        maxDonor = max(list(donationDonors.items()), key=lambda x: x[1]['amount'])[1]
-        eligibleDonors = prize.eligible_donors()
-        self.assertEqual(1, len(eligibleDonors))
-        self.assertEqual(maxDonor['donor'].id, eligibleDonors[0]['donor'])
-        self.assertEqual(1.0, eligibleDonors[0]['weight'])
-        self.assertEqual(maxDonor['amount'], eligibleDonors[0]['amount'])
+        max_donor = max(list(donation_donors.items()), key=lambda x: x[1]['amount'])[1]
+        eligible_donors = prize.eligible_donors()
+        self.assertEqual(1, len(eligible_donors))
+        self.assertEqual(max_donor['donor'].id, eligible_donors[0]['donor'])
+        self.assertEqual(1.0, eligible_donors[0]['weight'])
+        self.assertEqual(max_donor['amount'], eligible_donors[0]['amount'])
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
             result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
-            self.assertEqual(maxDonor['donor'].id, prize.get_winner().id)
-        oldMaxDonor = maxDonor
-        del donationDonors[oldMaxDonor['donor'].id]
-        maxDonor = max(list(donationDonors.items()), key=lambda x: x[1]['amount'])[1]
-        diff = oldMaxDonor['amount'] - maxDonor['amount']
-        newDonor = maxDonor['donor']
-        newDonation = randgen.generate_donation(
+            self.assertEqual(max_donor['donor'].id, prize.get_winner().id)
+        old_max_donor = max_donor
+        del donation_donors[old_max_donor['donor'].id]
+        max_donor = max(list(donation_donors.items()), key=lambda x: x[1]['amount'])[1]
+        diff = old_max_donor['amount'] - max_donor['amount']
+        new_donor = max_donor['donor']
+        new_donation = randgen.generate_donation(
             self.rand,
-            donor=newDonor,
+            donor=new_donor,
             event=self.event,
             min_amount=diff + Decimal('0.01'),
             max_amount=diff + Decimal('100.00'),
             min_time=prize.start_draw_time(),
             max_time=prize.end_draw_time(),
         )
-        newDonation.save()
-        maxDonor['amount'] += newDonation.amount
+        new_donation.save()
+        max_donor['amount'] += new_donation.amount
         prize = models.Prize.objects.get(id=prize.id)
-        eligibleDonors = prize.eligible_donors()
-        self.assertEqual(1, len(eligibleDonors))
-        self.assertEqual(maxDonor['donor'].id, eligibleDonors[0]['donor'])
-        self.assertEqual(1.0, eligibleDonors[0]['weight'])
-        self.assertEqual(maxDonor['amount'], eligibleDonors[0]['amount'])
+        eligible_donors = prize.eligible_donors()
+        self.assertEqual(1, len(eligible_donors))
+        self.assertEqual(max_donor['donor'].id, eligible_donors[0]['donor'])
+        self.assertEqual(1.0, eligible_donors[0]['weight'])
+        self.assertEqual(max_donor['amount'], eligible_donors[0]['amount'])
         for seed in [9524, 373, 747]:
             prize.prizewinner_set.all().delete()
             prize.save()
             result, message = prizeutil.draw_prize(prize, seed)
             self.assertTrue(result)
-            self.assertEqual(maxDonor['donor'].id, prize.get_winner().id)
+            self.assertEqual(max_donor['donor'].id, prize.get_winner().id)
 
 
 class TestDonorPrizeEntryDraw(TransactionTestCase):
@@ -539,7 +539,7 @@ class TestDonorPrizeEntryDraw(TransactionTestCase):
         self.event = randgen.generate_event(self.rand)
         self.event.save()
 
-    def testSingleEntry(self):
+    def test_single_entry(self):
         donor = randgen.generate_donor(self.rand)
         donor.save()
         prize = randgen.generate_prize(self.rand, event=self.event)
@@ -551,31 +551,31 @@ class TestDonorPrizeEntryDraw(TransactionTestCase):
         self.assertEqual(donor.pk, eligible[0]['donor'])
         self.assertEqual(entry.weight, eligible[0]['weight'])
 
-    def testMultipleEntries(self):
-        numDonors = 5
+    def test_multiple_entries(self):
+        num_donors = 5
         donors = []
         prize = randgen.generate_prize(self.rand, event=self.event)
         prize.save()
-        for i in range(0, numDonors):
+        for i in range(0, num_donors):
             donor = randgen.generate_donor(self.rand)
             donor.save()
             entry = models.DonorPrizeEntry(donor=donor, prize=prize)
             entry.save()
             donors.append(donor.pk)
         eligible = prize.eligible_donors()
-        self.assertEqual(numDonors, len(eligible))
-        for donorId in [x['donor'] for x in eligible]:
-            self.assertTrue(donorId in donors)
+        self.assertEqual(num_donors, len(eligible))
+        for donor_id in [x['donor'] for x in eligible]:
+            self.assertTrue(donor_id in donors)
 
 
 class TestPrizeMultiWin(TransactionTestCase):
     def setUp(self):
-        self.eventStart = parse_date('2012-01-01 01:00:00Z')
+        self.event_start = parse_date('2012-01-01 01:00:00Z')
         self.rand = random.Random()
-        self.event = randgen.build_random_event(self.rand, start_time=self.eventStart)
+        self.event = randgen.build_random_event(self.rand, start_time=self.event_start)
         self.event.save()
 
-    def testWinMultiPrize(self):
+    def test_win_multi_prize(self):
         donor = randgen.generate_donor(self.rand)
         donor.save()
         prize = randgen.generate_prize(self.rand)
@@ -586,20 +586,20 @@ class TestPrizeMultiWin(TransactionTestCase):
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result, msg)
-        prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
-        self.assertEqual(1, prizeWinner.pendingcount)
+        prize_winner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
+        self.assertEqual(1, prize_winner.pendingcount)
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result, msg)
-        prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
-        self.assertEqual(2, prizeWinner.pendingcount)
+        prize_winner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
+        self.assertEqual(2, prize_winner.pendingcount)
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result, msg)
-        prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
-        self.assertEqual(3, prizeWinner.pendingcount)
+        prize_winner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
+        self.assertEqual(3, prize_winner.pendingcount)
         result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result, msg)
 
-    def testWinMultiPrizeWithAccept(self):
+    def test_win_multi_prize_with_accept(self):
         donor = randgen.generate_donor(self.rand)
         donor.save()
         prize = randgen.generate_prize(self.rand)
@@ -608,17 +608,17 @@ class TestPrizeMultiWin(TransactionTestCase):
         prize.maxmultiwin = 3
         prize.save()
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
-        prizeWinner = models.PrizeWinner.objects.create(
+        prize_winner = models.PrizeWinner.objects.create(
             winner=donor, prize=prize, pendingcount=1, acceptcount=1
         )
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
-        prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
-        self.assertEqual(2, prizeWinner.pendingcount)
+        prize_winner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
+        self.assertEqual(2, prize_winner.pendingcount)
         result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
 
-    def testWinMultiPrizeWithDeny(self):
+    def test_win_multi_prize_with_deny(self):
         donor = randgen.generate_donor(self.rand)
         donor.save()
         prize = randgen.generate_prize(self.rand)
@@ -627,17 +627,17 @@ class TestPrizeMultiWin(TransactionTestCase):
         prize.maxmultiwin = 3
         prize.save()
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
-        prizeWinner = models.PrizeWinner.objects.create(
+        prize_winner = models.PrizeWinner.objects.create(
             winner=donor, prize=prize, pendingcount=1, declinecount=1
         )
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
-        prizeWinner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
-        self.assertEqual(2, prizeWinner.pendingcount)
+        prize_winner = models.PrizeWinner.objects.get(winner=donor, prize=prize)
+        self.assertEqual(2, prize_winner.pendingcount)
         result, msg = prizeutil.draw_prize(prize)
         self.assertFalse(result)
 
-    def testWinMultiPrizeLowerThanMaxWin(self):
+    def test_win_multi_prize_lower_than_max_win(self):
         donor = randgen.generate_donor(self.rand)
         donor.save()
         prize = randgen.generate_prize(self.rand)
@@ -646,7 +646,7 @@ class TestPrizeMultiWin(TransactionTestCase):
         prize.maxmultiwin = 2
         prize.save()
         models.DonorPrizeEntry.objects.create(donor=donor, prize=prize)
-        prizeWinner = models.PrizeWinner.objects.create(
+        prize_winner = models.PrizeWinner.objects.create(
             winner=donor, prize=prize, pendingcount=1, declinecount=1
         )
         result, msg = prizeutil.draw_prize(prize)
@@ -656,8 +656,8 @@ class TestPrizeMultiWin(TransactionTestCase):
         models.DonorPrizeEntry.objects.create(donor=donor2, prize=prize)
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
-        prizeWinner = models.PrizeWinner.objects.get(winner=donor2, prize=prize)
-        self.assertEqual(1, prizeWinner.pendingcount)
+        prize_winner = models.PrizeWinner.objects.get(winner=donor2, prize=prize)
+        self.assertEqual(1, prize_winner.pendingcount)
         result, msg = prizeutil.draw_prize(prize)
         self.assertTrue(result)
         result, msg = prizeutil.draw_prize(prize)
@@ -675,7 +675,7 @@ class TestPersistentPrizeWinners(TransactionTestCase):
 
     def test_decline_prize_single(self):
         amount = Decimal('50.0')
-        targetPrize = randgen.generate_prize(
+        target_prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=False,
@@ -684,70 +684,70 @@ class TestPersistentPrizeWinners(TransactionTestCase):
             max_amount=amount,
             maxwinners=1,
         )
-        targetPrize.save()
-        self.assertEqual(0, len(targetPrize.eligible_donors()))
-        donorA = randgen.generate_donor(self.rand)
-        donorA.save()
-        donorB = randgen.generate_donor(self.rand)
-        donorB.save()
-        donationA = randgen.generate_donation(
+        target_prize.save()
+        self.assertEqual(0, len(target_prize.eligible_donors()))
+        donor_a = randgen.generate_donor(self.rand)
+        donor_a.save()
+        donor_b = randgen.generate_donor(self.rand)
+        donor_b.save()
+        donation_a = randgen.generate_donation(
             self.rand,
-            donor=donorA,
+            donor=donor_a,
             min_amount=amount,
             max_amount=amount,
             event=self.event,
         )
-        donationA.save()
-        self.assertEqual(1, len(targetPrize.eligible_donors()))
-        self.assertEqual(donorA.id, targetPrize.eligible_donors()[0]['donor'])
-        prizeutil.draw_prize(targetPrize)
-        self.assertEqual(donorA, targetPrize.get_winner())
-        self.assertEqual(0, len(targetPrize.eligible_donors()))
-        donationB = randgen.generate_donation(
+        donation_a.save()
+        self.assertEqual(1, len(target_prize.eligible_donors()))
+        self.assertEqual(donor_a.id, target_prize.eligible_donors()[0]['donor'])
+        prizeutil.draw_prize(target_prize)
+        self.assertEqual(donor_a, target_prize.get_winner())
+        self.assertEqual(0, len(target_prize.eligible_donors()))
+        donation_b = randgen.generate_donation(
             self.rand,
-            donor=donorB,
+            donor=donor_b,
             min_amount=amount,
             max_amount=amount,
             event=self.event,
         )
-        donationB.save()
-        self.assertEqual(1, len(targetPrize.eligible_donors()))
-        self.assertEqual(donorB.id, targetPrize.eligible_donors()[0]['donor'])
-        prizeWinnerEntry = targetPrize.prizewinner_set.filter(winner=donorA)[0]
-        prizeWinnerEntry.pendingcount = 0
-        prizeWinnerEntry.declinecount = 1
-        prizeWinnerEntry.save()
-        self.assertEqual(1, len(targetPrize.eligible_donors()))
-        self.assertEqual(donorB.id, targetPrize.eligible_donors()[0]['donor'])
-        prizeutil.draw_prize(targetPrize)
-        self.assertEqual(donorB, targetPrize.get_winner())
-        self.assertEqual(1, targetPrize.current_win_count())
-        self.assertEqual(0, len(targetPrize.eligible_donors()))
+        donation_b.save()
+        self.assertEqual(1, len(target_prize.eligible_donors()))
+        self.assertEqual(donor_b.id, target_prize.eligible_donors()[0]['donor'])
+        prize_winner_entry = target_prize.prizewinner_set.filter(winner=donor_a)[0]
+        prize_winner_entry.pendingcount = 0
+        prize_winner_entry.declinecount = 1
+        prize_winner_entry.save()
+        self.assertEqual(1, len(target_prize.eligible_donors()))
+        self.assertEqual(donor_b.id, target_prize.eligible_donors()[0]['donor'])
+        prizeutil.draw_prize(target_prize)
+        self.assertEqual(donor_b, target_prize.get_winner())
+        self.assertEqual(1, target_prize.current_win_count())
+        self.assertEqual(0, len(target_prize.eligible_donors()))
 
     def test_cannot_exceed_max_winners(self):
-        targetPrize = randgen.generate_prize(self.rand, event=self.event)
-        targetPrize.maxwinners = 2
-        targetPrize.save()
-        numDonors = 4
+        target_prize = randgen.generate_prize(self.rand, event=self.event)
+        target_prize.maxwinners = 2
+        target_prize.save()
+        num_donors = 4
         donors = []
-        for i in range(0, numDonors):
+        for i in range(0, num_donors):
             donor = randgen.generate_donor(self.rand)
             donor.save()
             donors.append(donor)
-        pw0 = models.PrizeWinner(winner=donors[0], prize=targetPrize)
-        pw0.clean()
-        pw0.save()
-        pw1 = models.PrizeWinner(winner=donors[1], prize=targetPrize)
-        pw1.clean()
-        pw1.save()
+        winner0 = models.PrizeWinner(winner=donors[0], prize=target_prize)
+        winner0.clean()
+        winner0.save()
+        winner1 = models.PrizeWinner(winner=donors[1], prize=target_prize)
+        winner1.clean()
+        winner1.save()
         with self.assertRaises(ValidationError):
-            pw2 = models.PrizeWinner(winner=donors[2], prize=targetPrize)
-            pw2.clean()
-        pw0.pendingcount = 0
-        pw0.declinecount = 1
-        pw0.save()
-        pw2.clean()
-        pw2.save()
+            winner2 = models.PrizeWinner(winner=donors[2], prize=target_prize)
+            winner2.clean()
+        winner0.pendingcount = 0
+        winner0.declinecount = 1
+        winner0.save()
+        winner2.clean()
+        winner2.save()
 
 
 class TestPrizeCountryFilter(TransactionTestCase):
@@ -758,7 +758,7 @@ class TestPrizeCountryFilter(TransactionTestCase):
         self.event = randgen.build_random_event(self.rand)
         self.event.save()
 
-    def testCountryFilterEvent(self):
+    def test_country_filter_event(self):
         countries = list(models.Country.objects.all()[0:4])
         self.event.allowed_prize_countries.add(countries[0])
         self.event.allowed_prize_countries.add(countries[1])
@@ -800,7 +800,7 @@ class TestPrizeCountryFilter(TransactionTestCase):
         eligible = prize.eligible_donors()
         self.assertEqual(4, len(eligible))
 
-    def testCountryFilterPrize(self):
+    def test_country_filter_prize(self):
         # TODO: fix this so either there's less boilerplate, or the boilerplate is shared
         countries = list(models.Country.objects.all()[0:4])
         prize = models.Prize.objects.create(event=self.event)
@@ -855,14 +855,14 @@ class TestPrizeCountryFilter(TransactionTestCase):
         eligible = prize.eligible_donors()
         self.assertEqual(4, len(eligible))
 
-    def testCountryRegionBlacklistFilterEvent(self):
+    def test_country_region_blacklist_filter_event(self):
         # Somewhat ethnocentric testing
         country = models.Country.objects.all()[0]
         prize = models.Prize.objects.create(event=self.event)
         donors = []
-        allowedState = 'StateOne'
-        disallowedState = 'StateTwo'
-        for state in [allowedState, disallowedState]:
+        allowed_state = 'StateOne'
+        disallowed_state = 'StateTwo'
+        for state in [allowed_state, disallowed_state]:
             donor = randgen.generate_donor(self.rand)
             donor.addresscountry = country
             donor.addressstate = state
@@ -880,24 +880,24 @@ class TestPrizeCountryFilter(TransactionTestCase):
         eligible = prize.eligible_donors()
         self.assertEqual(2, len(eligible))
         # Test a different country set
-        countryRegion = models.CountryRegion.objects.create(
-            country=country, name=disallowedState
+        country_region = models.CountryRegion.objects.create(
+            country=country, name=disallowed_state
         )
-        self.event.disallowed_prize_regions.add(countryRegion)
+        self.event.disallowed_prize_regions.add(country_region)
         self.event.save()
         self.assertTrue(prize.is_donor_allowed_to_receive(donors[0]))
         self.assertFalse(prize.is_donor_allowed_to_receive(donors[1]))
         eligible = prize.eligible_donors()
         self.assertEqual(1, len(eligible))
 
-    def testCountryRegionBlacklistFilterPrize(self):
+    def test_country_region_blacklist_filter_prize(self):
         # Somewhat ethnocentric testing
         country = models.Country.objects.all()[0]
         prize = models.Prize.objects.create(event=self.event)
         donors = []
-        allowedState = 'StateOne'
-        disallowedState = 'StateTwo'
-        for state in [allowedState, disallowedState]:
+        allowed_state = 'StateOne'
+        disallowed_state = 'StateTwo'
+        for state in [allowed_state, disallowed_state]:
             donor = randgen.generate_donor(self.rand)
             donor.addresscountry = country
             donor.addressstate = state
@@ -913,10 +913,10 @@ class TestPrizeCountryFilter(TransactionTestCase):
         eligible = prize.eligible_donors()
         self.assertEqual(2, len(eligible))
         # Test a different country set
-        countryRegion = models.CountryRegion.objects.create(
-            country=country, name=disallowedState
+        country_region = models.CountryRegion.objects.create(
+            country=country, name=disallowed_state
         )
-        prize.disallowed_prize_regions.add(countryRegion)
+        prize.disallowed_prize_regions.add(country_region)
         prize.custom_country_filter = True
         prize.save()
         eligible = prize.eligible_donors()
@@ -934,7 +934,7 @@ class TestPrizeDrawAcceptOffset(TransactionTestCase):
         self.event.prize_accept_deadline_delta = 10
         # TODO: it should not take this much set-up to draw a single donor to a single prize
         amount = Decimal('50.0')
-        targetPrize = randgen.generate_prize(
+        target_prize = randgen.generate_prize(
             self.rand,
             event=self.event,
             sum_donations=False,
@@ -943,47 +943,47 @@ class TestPrizeDrawAcceptOffset(TransactionTestCase):
             max_amount=amount,
             maxwinners=1,
         )
-        targetPrize.save()
+        target_prize.save()
         winner = randgen.generate_donor(self.rand)
         winner.save()
-        winningDonation = randgen.generate_donation(
+        winning_donation = randgen.generate_donation(
             self.rand,
             donor=winner,
             min_amount=amount,
             max_amount=amount,
             event=self.event,
         )
-        winningDonation.save()
-        self.assertEqual(1, len(targetPrize.eligible_donors()))
-        self.assertEqual(winner.id, targetPrize.eligible_donors()[0]['donor'])
+        winning_donation.save()
+        self.assertEqual(1, len(target_prize.eligible_donors()))
+        self.assertEqual(winner.id, target_prize.eligible_donors()[0]['donor'])
         self.assertEqual(0, len(prizeutil.get_past_due_prize_winners(self.event)))
-        currentDate = datetime.date.today()
-        result, status = prizeutil.draw_prize(targetPrize)
-        prizeWin = models.PrizeWinner.objects.get(prize=targetPrize)
+        current_date = datetime.date.today()
+        result, status = prizeutil.draw_prize(target_prize)
+        prize_win = models.PrizeWinner.objects.get(prize=target_prize)
         self.assertEqual(
-            prizeWin.accept_deadline_date(),
-            currentDate
+            prize_win.accept_deadline_date(),
+            current_date
             + datetime.timedelta(days=self.event.prize_accept_deadline_delta),
         )
 
-        prizeWin.acceptdeadline = datetime.datetime.utcnow().replace(
+        prize_win.acceptdeadline = datetime.datetime.utcnow().replace(
             tzinfo=pytz.utc
         ) - datetime.timedelta(days=2)
-        prizeWin.save()
-        self.assertEqual(0, len(targetPrize.eligible_donors()))
-        pastDue = prizeutil.get_past_due_prize_winners(self.event)
+        prize_win.save()
+        self.assertEqual(0, len(target_prize.eligible_donors()))
+        past_due = prizeutil.get_past_due_prize_winners(self.event)
         self.assertEqual(1, len(prizeutil.get_past_due_prize_winners(self.event)))
-        self.assertEqual(prizeWin, pastDue[0])
+        self.assertEqual(prize_win, past_due[0])
 
 
 class TestBackfillPrevNextMigrations(MigrationsTestCase):
     migrate_from = '0001_squashed_0020_add_runner_pronouns_and_platform'
     migrate_to = '0003_populate_prev_next_run'
 
-    def setUpBeforeMigration(self, apps):
-        Prize = apps.get_model('tracker', 'Prize')
-        Event = apps.get_model('tracker', 'Event')
-        SpeedRun = apps.get_model('tracker', 'SpeedRun')
+    def setUpBeforeMigration(self, apps):  # noqa N806
+        Prize = apps.get_model('tracker', 'Prize')  # noqa N806
+        Event = apps.get_model('tracker', 'Event')  # noqa N806
+        SpeedRun = apps.get_model('tracker', 'SpeedRun')  # noqa N806
         self.rand = random.Random(None)
         self.event = Event.objects.create(
             short='test', name='Test Event', datetime=today_noon, targetamount=100
@@ -1008,7 +1008,7 @@ class TestBackfillPrevNextMigrations(MigrationsTestCase):
         )
 
     def test_prev_next_backfilled(self):
-        Prize = self.apps.get_model('tracker', 'Prize')
+        Prize = self.apps.get_model('tracker', 'Prize')  # noqa N806
         prize1 = Prize.objects.get(pk=self.prize1.id)
         prize2 = Prize.objects.get(pk=self.prize2.id)
         prize3 = Prize.objects.get(pk=self.prize3.id)
@@ -1448,7 +1448,8 @@ class TestPrizeKey(TestCase):
 
 
 class TestPrizeAdmin(TestCase):
-    def assertMessages(self, response, messages):  # TODO: util?
+    # TODO: util?
+    def assertMessages(self, response, messages):  # noqa N806
         self.assertSetEqual(
             {str(m) for m in response.wsgi_request._messages}, set(messages)
         )

--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -107,9 +107,9 @@ class TestMoveSpeedRun(TransactionTestCase):
         )
 
     def test_after_to_before(self):
-        from tracker.views.commands import MoveSpeedRun
+        from tracker.views.commands import move_speedrun
 
-        output, status = MoveSpeedRun(
+        output, status = move_speedrun(
             {'moving': self.run2.id, 'other': self.run1.id, 'before': True}
         )
         self.assertEqual(status, 200)
@@ -122,9 +122,9 @@ class TestMoveSpeedRun(TransactionTestCase):
         self.assertEqual(self.run3.order, 3)
 
     def test_after_to_after(self):
-        from tracker.views.commands import MoveSpeedRun
+        from tracker.views.commands import move_speedrun
 
-        output, status = MoveSpeedRun(
+        output, status = move_speedrun(
             {'moving': self.run3.id, 'other': self.run1.id, 'before': False}
         )
         self.assertEqual(status, 200)
@@ -137,9 +137,9 @@ class TestMoveSpeedRun(TransactionTestCase):
         self.assertEqual(self.run3.order, 2)
 
     def test_before_to_before(self):
-        from tracker.views.commands import MoveSpeedRun
+        from tracker.views.commands import move_speedrun
 
-        output, status = MoveSpeedRun(
+        output, status = move_speedrun(
             {'moving': self.run1.id, 'other': self.run3.id, 'before': True}
         )
         self.assertEqual(status, 200)
@@ -152,9 +152,9 @@ class TestMoveSpeedRun(TransactionTestCase):
         self.assertEqual(self.run3.order, 3)
 
     def test_before_to_after(self):
-        from tracker.views.commands import MoveSpeedRun
+        from tracker.views.commands import move_speedrun
 
-        output, status = MoveSpeedRun(
+        output, status = move_speedrun(
             {'moving': self.run1.id, 'other': self.run2.id, 'before': False}
         )
         self.assertEqual(status, 200)
@@ -167,9 +167,9 @@ class TestMoveSpeedRun(TransactionTestCase):
         self.assertEqual(self.run3.order, 3)
 
     def test_unordered_to_before(self):
-        from tracker.views.commands import MoveSpeedRun
+        from tracker.views.commands import move_speedrun
 
-        output, status = MoveSpeedRun(
+        output, status = move_speedrun(
             {'moving': self.run4.id, 'other': self.run2.id, 'before': True}
         )
         self.assertEqual(status, 200)
@@ -182,9 +182,9 @@ class TestMoveSpeedRun(TransactionTestCase):
         self.assertEqual(self.run4.order, 2)
 
     def test_unordered_to_after(self):
-        from tracker.views.commands import MoveSpeedRun
+        from tracker.views.commands import move_speedrun
 
-        output, status = MoveSpeedRun(
+        output, status = move_speedrun(
             {'moving': self.run4.id, 'other': self.run2.id, 'before': False}
         )
         self.assertEqual(status, 200)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,44 +6,44 @@ import tracker.util as util
 
 
 class TestRandomNumReplace(TestCase):
-    def testMakeAuthCode(self):
-        authLen = 555
-        testCreate = util.make_auth_code(length=authLen)
-        self.assertEqual(authLen, len(testCreate))
-        self.assertTrue(re.match('[0-9A-Za-z]+', testCreate))
+    def test_make_auth_code(self):
+        auth_len = 555
+        test_create = util.make_auth_code(length=auth_len)
+        self.assertEqual(auth_len, len(test_create))
+        self.assertTrue(re.match('[0-9A-Za-z]+', test_create))
 
-    def testReplaceNoLimit(self):
+    def test_replace_no_limit(self):
         original = 'test'
-        replaceLen = 8
-        modified = util.random_num_replace(original, replaceLen)
-        self.assertEqual(len(original) + replaceLen, len(modified))
+        replace_len = 8
+        modified = util.random_num_replace(original, replace_len)
+        self.assertEqual(len(original) + replace_len, len(modified))
         self.assertEqual(original, modified[0 : len(original)])
         self.assertTrue(re.match('[0-9A-Za-z]+', modified[len(original) :]))
 
-    def testReplaceWithLimit(self):
+    def test_replace_with_limit(self):
         original = 'testingstuff'
-        replaceLen = 4
-        totalLen = len(original) + 2
-        unreplacedLen = totalLen - replaceLen
-        modified = util.random_num_replace(original, replaceLen, max_length=totalLen)
-        self.assertEqual(totalLen, len(modified))
-        self.assertEqual(original[:unreplacedLen], modified[:unreplacedLen])
-        self.assertTrue(re.match('[0-9A-Za-z]+', modified[unreplacedLen:]))
+        replace_len = 4
+        total_len = len(original) + 2
+        unreplaced_len = total_len - replace_len
+        modified = util.random_num_replace(original, replace_len, max_length=total_len)
+        self.assertEqual(total_len, len(modified))
+        self.assertEqual(original[:unreplaced_len], modified[:unreplaced_len])
+        self.assertTrue(re.match('[0-9A-Za-z]+', modified[unreplaced_len:]))
 
-    def testReplaceStrictLimit(self):
+    def test_replace_strict_limit(self):
         original = 'testingstuffmore'
-        replaceLen = 6
-        unreplacedLen = len(original) - replaceLen
+        replace_len = 6
+        unreplaced_len = len(original) - replace_len
         modified = util.random_num_replace(
-            original, replaceLen, max_length=len(original)
+            original, replace_len, max_length=len(original)
         )
         self.assertEqual(len(original), len(modified))
-        self.assertEqual(original[:unreplacedLen], modified[:unreplacedLen])
-        self.assertTrue(re.match('[0-9A-Za-z]+', modified[unreplacedLen:]))
+        self.assertEqual(original[:unreplaced_len], modified[:unreplaced_len])
+        self.assertTrue(re.match('[0-9A-Za-z]+', modified[unreplaced_len:]))
 
-    def testInvalidReplaceLen(self):
+    def test_invalid_replace_len(self):
         original = 'short'
-        replaceLen = 8
-        maxLen = 7
+        replace_len = 8
+        max_len = 7
         with self.assertRaises(Exception):
-            util.random_num_replace(original, replaceLen, max_length=maxLen)
+            util.random_num_replace(original, replace_len, max_length=max_len)

--- a/tests/util.py
+++ b/tests/util.py
@@ -83,7 +83,7 @@ class MigrationsTestCase(TransactionTestCase):
         executor.loader.build_graph()
         executor.migrate(executor.loader.graph.leaf_nodes(self.app))
 
-    def setUpBeforeMigration(self, apps):
+    def setUpBeforeMigration(self, apps):  # noqa N806
         pass
 
 
@@ -114,7 +114,7 @@ class APITestCase(TransactionTestCase):
     model_name = None
     encoder = DjangoJSONEncoder()
 
-    def parseJSON(self, response, status_code=200):
+    def parseJSON(self, response, status_code=200):  # noqa N806
         self.assertEqual(
             response.status_code,
             status_code,
@@ -127,7 +127,7 @@ class APITestCase(TransactionTestCase):
                 'Could not parse json: %s\n"""%s"""' % (e, response.content)
             )
 
-    def assertModelPresent(self, expected_model, data, partial=False):
+    def assertModelPresent(self, expected_model, data, partial=False):  # noqa N806
         found_model = None
         for model in data:
             if (
@@ -171,7 +171,7 @@ class APITestCase(TransactionTestCase):
                 % (expected_model['model'], expected_model['pk'], '\n'.join(problems))
             )
 
-    def assertModelNotPresent(self, unexpected_model, data):
+    def assertModelNotPresent(self, unexpected_model, data):  # noqa N806
         found_model = None
         for model in data:
             if (

--- a/ui/views.py
+++ b/ui/views.py
@@ -156,7 +156,7 @@ def donate(request, event):
         'prize', {'feed': 'current', 'event': event.id}
     )
 
-    bidsArray = [bid_info(o) for o in bids]
+    bids_array = [bid_info(o) for o in bids]
 
     def prize_info(prize):
         result = {
@@ -170,19 +170,19 @@ def donate(request, event):
         }
         return result
 
-    prizesArray = [prize_info(o) for o in prizes.all()]
+    prizes_array = [prize_info(o) for o in prizes.all()]
 
     def to_json(value):
         if hasattr(value, 'id'):
             return value.id
         return value
 
-    initialForm = {
+    initial_form = {
         k: to_json(commentform.cleaned_data[k])
         for k, v in list(commentform.fields.items())
         if commentform.is_bound and k in commentform.cleaned_data
     }
-    pickedIncentives = [
+    picked_incentives = [
         {
             k: to_json(form.cleaned_data[k])
             for k, v in list(form.fields.items())
@@ -219,10 +219,10 @@ def donate(request, event):
                             'fields'
                         ],
                         'minimumDonation': float(event.minimumdonation),
-                        'prizes': prizesArray,
-                        'incentives': bidsArray,
-                        'initialForm': initialForm,
-                        'initialIncentives': pickedIncentives,
+                        'prizes': prizes_array,
+                        'incentives': bids_array,
+                        'initialForm': initial_form,
+                        'initialIncentives': picked_incentives,
                         'donateUrl': request.get_full_path(),
                         'prizesUrl': request.build_absolute_uri(
                             reverse('tracker:prizeindex', args=(event.id,))

--- a/util.py
+++ b/util.py
@@ -31,8 +31,8 @@ def natural_list_parse(s, symbol_only=False):
 def labelify(labels):
     """reverses an array of labels to become a dictionary of indices"""
     result = {}
-    for labelIndex in range(0, len(labels)):
-        result[labels[labelIndex]] = labelIndex
+    for label_index in range(0, len(labels)):
+        result[labels[label_index]] = label_index
     return result
 
 
@@ -81,14 +81,14 @@ def random_num_replace(
                 max_length, replacements
             )
         )
-    originalLength = len(s)
-    endReplacements = min(max_length - len(s), replacements)
-    s += make_auth_code(endReplacements, rand_source=rand_source)
-    if endReplacements < replacements:
-        replacementsLeft = replacements - endReplacements
+    original_length = len(s)
+    end_replacements = min(max_length - len(s), replacements)
+    s += make_auth_code(end_replacements, rand_source=rand_source)
+    if end_replacements < replacements:
+        replacements_left = replacements - end_replacements
         s = (
-            s[: originalLength - replacementsLeft]
-            + make_auth_code(replacementsLeft, rand_source)
-            + s[originalLength:]
+            s[: original_length - replacements_left]
+            + make_auth_code(replacements_left, rand_source)
+            + s[original_length:]
         )
     return s

--- a/views/api.py
+++ b/views/api.py
@@ -332,7 +332,7 @@ def search(request):
     donor_names = present(search_params, 'donor_names')
     all_comments = present(search_params, 'all_comments')
     tech_notes = present(search_params, 'tech_notes')
-    Model = modelmap.get(search_type, None)
+    Model = modelmap.get(search_type, None)  # noqa N806
     if Model is None:
         raise KeyError('%s is not a recognized model type' % search_type)
     if queries and not request.user.has_perm('tracker.view_queries'):
@@ -459,7 +459,7 @@ def parse_value(Model, field, value, user=None):
         return None
     else:
         model_field = Model._meta.get_field(field)
-        RelatedModel = model_field.related_model
+        RelatedModel = model_field.related_model  # noqa N806
         if RelatedModel is None:
             return value
         if model_field.many_to_many:
@@ -552,7 +552,7 @@ def filter_fields(fields, model_admin, request, obj=None):
 def add(request):
     add_params = request.POST
     add_type = add_params['type']
-    Model = modelmap.get(add_type, None)
+    Model = modelmap.get(add_type, None)  # noqa N806
     if Model is None:
         raise KeyError('%s is not a recognized model type' % add_type)
     model_admin = get_admin(Model)
@@ -606,7 +606,7 @@ def add(request):
 def delete(request):
     delete_params = request.POST
     delete_type = delete_params['type']
-    Model = modelmap.get(delete_type, None)
+    Model = modelmap.get(delete_type, None)  # noqa N806
     if Model is None:
         raise KeyError('%s is not a recognized model type' % delete_type)
     obj = Model.objects.get(pk=delete_params['id'])
@@ -635,10 +635,9 @@ def delete(request):
 def edit(request):
     edit_params = request.POST
     edit_type = edit_params['type']
-    Model = modelmap.get(edit_type, None)
-    if Model is None:
+    if modelmap.get(edit_type, None) is None:
         raise KeyError('%s is not a recognized model type' % edit_type)
-    Model = modelmap[edit_type]
+    Model = modelmap[edit_type]  # noqa N806
     model_admin = get_admin(Model)
     obj = Model.objects.get(pk=edit_params['id'])
     if not model_admin.has_change_permission(request, obj):

--- a/views/api.py
+++ b/views/api.py
@@ -453,7 +453,7 @@ def to_natural_key(key):
     return key if type(key) == list else [key]
 
 
-def parse_value(Model, field, value, user=None):
+def parse_value(Model, field, value, user=None):  # noqa N806
     user = user or AnonymousUser()
     if value == 'None':
         return None
@@ -521,7 +521,7 @@ def root(request):
     raise Http404
 
 
-def get_admin(Model):
+def get_admin(Model):  # noqa N806
     return admin.site._registry[Model]
 
 

--- a/views/commands.py
+++ b/views/commands.py
@@ -1,11 +1,11 @@
 from tracker.models import SpeedRun
 
 __all__ = [
-    'MoveSpeedRun',
+    'move_speedrun',
 ]
 
 
-def MoveSpeedRun(data):
+def move_speedrun(data):  # noqa N806
     moving = SpeedRun.objects.get(pk=data['moving'])
     other = SpeedRun.objects.get(pk=data['other'])
     before = bool(data['before'])
@@ -57,4 +57,4 @@ def MoveSpeedRun(data):
     return models, 200
 
 
-MoveSpeedRun.permission = 'tracker.change_speedrun'
+move_speedrun.permission = 'tracker.change_speedrun'

--- a/views/public.py
+++ b/views/public.py
@@ -49,13 +49,13 @@ def eventlist(request):
 
 def index(request, event=None):
     event = viewutil.get_event(event)
-    eventParams = {}
+    event_params = {}
 
     if event.id:
-        eventParams['event'] = event.id
+        event_params['event'] = event.id
 
     agg = Donation.objects.filter(
-        transactionstate='COMPLETED', testdonation=False, **eventParams
+        transactionstate='COMPLETED', testdonation=False, **event_params
     ).aggregate(
         amount=Cast(Coalesce(Sum('amount'), 0), output_field=FloatField()),
         count=Count('amount'),
@@ -64,10 +64,10 @@ def index(request, event=None):
     )
     agg['target'] = float(event.targetamount)
     count = {
-        'runs': filters.run_model_query('run', eventParams).count(),
-        'prizes': filters.run_model_query('prize', eventParams).count(),
-        'bids': filters.run_model_query('bid', eventParams).count(),
-        'donors': filters.run_model_query('donorcache', eventParams)
+        'runs': filters.run_model_query('run', event_params).count(),
+        'prizes': filters.run_model_query('prize', event_params).count(),
+        'bids': filters.run_model_query('bid', event_params).count(),
+        'donors': filters.run_model_query('donorcache', event_params)
         .values('donor')
         .distinct()
         .count(),
@@ -130,15 +130,15 @@ def bidindex(request, event=None):
 
     toplevel = [b for b in bids if b.parent_id is None]
     total = sum((b.total for b in toplevel), 0)
-    choiceTotal = sum((b.total for b in toplevel if not b.goal), 0)
-    challengeTotal = sum((b.total for b in toplevel if b.goal), 0)
+    choice_total = sum((b.total for b in toplevel if not b.goal), 0)
+    challenge_total = sum((b.total for b in toplevel if b.goal), 0)
 
     bids = [get_bid_info(bid, bids) for bid in bids if bid.parent_id is None]
 
     if event.id:
-        bidNameSpan = 2
+        bid_name_span = 2
     else:
-        bidNameSpan = 1
+        bid_name_span = 1
 
     return views_common.tracker_response(
         request,
@@ -147,9 +147,9 @@ def bidindex(request, event=None):
             'bids': bids,
             'total': total,
             'event': event,
-            'bidNameSpan': bidNameSpan,
-            'choiceTotal': choiceTotal,
-            'challengeTotal': challengeTotal,
+            'bidNameSpan': bid_name_span,
+            'choiceTotal': choice_total,
+            'challengeTotal': challenge_total,
         },
     )
 
@@ -390,10 +390,10 @@ def runindex(request, event=None):
             reverse('tracker:runindex', args=(Event.objects.latest().short,))
         )
 
-    searchParams = {}
-    searchParams['event'] = event.id
+    search_params = {}
+    search_params['event'] = event.id
 
-    runs = filters.run_model_query('run', searchParams)
+    runs = filters.run_model_query('run', search_params)
     runs = runs.annotate(hasbids=Sum('bids'))
 
     return views_common.tracker_response(
@@ -413,12 +413,12 @@ def run_detail(request, pk):
             .select_related('speedrun', 'event', 'parent')
             .prefetch_related('options')
         )
-        topLevelBids = [bid for bid in bids if bid.parent is None]
+        top_level_bids = [bid for bid in bids if bid.parent is None]
 
         return views_common.tracker_response(
             request,
             'tracker/run.html',
-            {'event': event, 'run': run, 'runners': runners, 'bids': topLevelBids},
+            {'event': event, 'run': run, 'runners': runners, 'bids': top_level_bids},
         )
 
     except SpeedRun.DoesNotExist:
@@ -436,10 +436,10 @@ def prizeindex(request, event=None):
             reverse('tracker:prizeindex', args=(Event.objects.latest().short,))
         )
 
-    searchParams = {}
-    searchParams['event'] = event.id
+    search_params = {}
+    search_params['event'] = event.id
 
-    prizes = filters.run_model_query('prize', searchParams)
+    prizes = filters.run_model_query('prize', search_params)
     prizes = prizes.select_related('startrun', 'endrun', 'category').prefetch_related(
         'prizewinner_set'
     )


### PR DESCRIPTION
> Also, snake case everything, because this is Python, not... well, anything else.

`pep8-naming` is a plugin for `flake8` that lints variable naming conventions as suggested by PEP8. A lot of the codebase was using camelCase identifiers or (appropriately) using PascalCase for some variables that represent classes/etc, so this PR also goes through and fixes all naming anomolies, with the necessary ignores in place to preserve those meta-semantics.

_If you want to run `flake8` locally (outside of `pre-commit`), you'll need to run `pip install -r requirements.txt` again after this commit as it adds a new requirement on `pep8-naming`. Pre-commit will automatically install and use its isolated dependency on your next commit_

### Verification Process

Running `flake8` with the plugin. Running tests. Auditing changes to make sure named exports were updated or preserved appropriately and that dictionary keys for external dependencies were not updated (e.g. variable names for templates).