### PR TITLE
fix donate prizes max height when prizes overflow

### DIFF
--- a/bundles/tracker/donation/components/DonationPrizes.mod.css
+++ b/bundles/tracker/donation/components/DonationPrizes.mod.css
@@ -19,3 +19,8 @@
   padding: 8px 16px;
   border-bottom: var(--border-secondary);
 }
+
+.prizes {
+  height: 240px;
+  overflow-y: scroll;
+}


### PR DESCRIPTION
With too many open prizes (more than ~4 short ones) the prizes section of the donate form wouldn't limit its height. Now it's arbitrarily limited to extend a little bit past the default square height given the text next to it.

This could probably be done a little nicer with some fades on the edges, but I don't think that's worth doing atm.