### PR TITLE
remove prize imageurl/file restriction

### DIFF
--- a/models/prize.py
+++ b/models/prize.py
@@ -248,10 +248,6 @@ class Prize(models.Model):
             raise ValidationError(
                 {'starttime': 'Cannot have both Start/End Run and Start/End Time set'}
             )
-        if self.image and self.imagefile:
-            raise ValidationError(
-                {'image': 'Cannot have both an Image URL and an Image File'}
-            )
 
     def save(self, *args, **kwargs):
         using = kwargs.get('using', None)


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
~~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170785851

### Description of the Change

I forget why this restriction was in place originally, but it seems unnecessary, the places that use the data prefer `imagefile` over `image` anyway.

### Verification Process

Opened it and made sure I could add both.