### PR TITLE
fix invalid variable site_header

### DIFF
--- a/admin/event.py
+++ b/admin/event.py
@@ -511,7 +511,20 @@ class SpeedRunAdmin(CustomModelAdmin):
         return render(
             request,
             'admin/generic_form.html',
-            dict(title='Set start time for %s' % run, form=form, action=request.path,),
+            {
+                'site_header': 'Donation Tracker',
+                'title': 'Set start time for %s' % run,
+                'breadcrumbs': (
+                    (
+                        reverse('admin:app_list', kwargs=dict(app_label='tracker')),
+                        'Tracker',
+                    ),
+                    (reverse('admin:tracker_speedrun_changelist'), 'Speedruns'),
+                    (None, 'Start Run'),
+                ),
+                'form': form,
+                'action': request.path,
+            },
         )
 
     def get_queryset(self, request):

--- a/admin/prize.py
+++ b/admin/prize.py
@@ -375,6 +375,7 @@ class PrizeAdmin(CustomModelAdmin):
             request,
             'admin/generic_form.html',
             {
+                'site_header': 'Donation Tracker',
                 'title': 'Import keys for %s' % prize,
                 'breadcrumbs': (
                     (


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/169941607

### Description of the Change

Two admin helper pages would show `invalid variable: site_header` when you viewed them. This is just a missing template variable, so I fixed the places I was able to find the issue.

### Verification Process

Opened the pages and made sure they showed a real value.