### PR TITLE
prize key winners show in aggregate on the prize list

### DIFF
--- a/randgen.py
+++ b/randgen.py
@@ -250,6 +250,17 @@ def generate_prize_key(rand, *, prize=None, key=None, prize_winner=None, winner=
     return prize_key
 
 
+def generate_prize_keys(rand, num_keys, *, prize=None):
+    if prize is None:
+        prize = pick_random_instance(rand, Prize)
+    prize_keys = []
+    for _ in range(num_keys):
+        prize_key = generate_prize_key(rand, prize=prize)
+        prize_key.save()
+        prize_keys.append(prize_key)
+    return prize_keys
+
+
 def generate_bid(
     rand,
     *,

--- a/templates/tracker/prizeindex.html
+++ b/templates/tracker/prizeindex.html
@@ -89,14 +89,16 @@
                     {% endif %}
                 </td>
                 <td>
-                    {% if prize.get_winners %}
-                        {% for winner in prize.get_winners %}
-                            {% if not forloop.first %} - {% endif %}
-                            {% donor_link winner prize.event %}
-                        {% endfor %}
-                    {% else %}
-                        {% trans "None" %}
-                    {% endif %}
+                  {% if prize.key_code %}
+                    {{ prize.get_winners|length }} winner(s)
+                  {% else %}
+                    {% for winner in prize.get_winners %}
+                      {% if not forloop.first %} - {% endif %}
+                      {% donor_link winner prize.event %}
+                    {% empty %}
+                      {% trans "None" %}
+                    {% endfor %}
+                  {% endif %}
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170785857

### Description of the Change

The static prize list layout could get extremely broken by a key prize trying to list potentially hundreds of winners in the same table cell. This aggregates them so it only prints a number on the index page, but still shows the full list on the detail page.

### Verification Process

This was live on the GDQ server during AGDQ2020.

![image](https://user-images.githubusercontent.com/419927/72674193-1e09f900-3a31-11ea-849d-9fc2ccffed54.png)
