### PR TITLE
legal links are configurable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
           PYTHON_VERSION: '3.7'
 
     variables:
-      TOPLEVEL_REVISION: 947450932a0f68cb79222f5964aad319f99d9abf
+      TOPLEVEL_REVISION: 91f438427815cad88d88f9f64aba1d7d72af263e
 
     steps:
       - task: UsePythonVersion@0

--- a/bundles/@types/global.d.ts
+++ b/bundles/@types/global.d.ts
@@ -1,7 +1,10 @@
 export {};
 
 declare global {
+  // TODO: use a constants context instead of window globals
   interface Window {
+    PRIVACY_POLICY_URL: string;
+    SWEEPSTAKES_URL: string;
     ROOT_PATH: string;
     STATIC_URL: string;
     APP_NAME: string;

--- a/bundles/tracker/donation/__tests__/validateDonation.spec.ts
+++ b/bundles/tracker/donation/__tests__/validateDonation.spec.ts
@@ -6,7 +6,6 @@ const eventDetails = {
   csrfToken: 'testing',
   receiverName: 'a beneficiary',
   prizesUrl: 'https://example.com/prizes',
-  rulesUrl: 'https://example.com/rules',
   donateUrl: 'https://example.com/donate',
   minimumDonation: 2.0,
   maximumDonation: 100.0,

--- a/bundles/tracker/donation/components/Donate.tsx
+++ b/bundles/tracker/donation/components/Donate.tsx
@@ -85,9 +85,11 @@ const Donate = (props: DonateProps) => {
           value={email}
           label="Email Address"
           hint={
-            <React.Fragment>
-              Click <Anchor href="https://gamesdonequick.com/privacy/">here</Anchor> for our privacy policy
-            </React.Fragment>
+            window.PRIVACY_POLICY_URL && (
+              <>
+                Click <Anchor href={window.PRIVACY_POLICY_URL}>here</Anchor> for our privacy policy
+              </>
+            )
           }
           size={TextInput.Sizes.LARGE}
           type={TextInput.Types.EMAIL}

--- a/bundles/tracker/donation/components/DonateInitializer.tsx
+++ b/bundles/tracker/donation/components/DonateInitializer.tsx
@@ -62,7 +62,6 @@ type DonateInitializerProps = {
   donateUrl: string;
   prizes: Array<Prize>;
   prizesUrl: string;
-  rulesUrl?: string;
   csrfToken: string;
 };
 
@@ -73,7 +72,6 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     prizes,
     event: { receivername: receiverName },
     prizesUrl,
-    rulesUrl,
     donateUrl,
     minimumDonation = 1,
     maximumDonation = Infinity,
@@ -126,7 +124,6 @@ const DonateInitializer = (props: DonateInitializerProps) => {
         csrfToken,
         receiverName,
         prizesUrl,
-        rulesUrl,
         donateUrl,
         minimumDonation,
         maximumDonation,
@@ -135,7 +132,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
         prizes,
       }),
     );
-  }, [dispatch, event, prizesUrl, rulesUrl, donateUrl, minimumDonation, maximumDonation, step, incentives, prizes]);
+  }, [dispatch, event, prizesUrl, donateUrl, minimumDonation, maximumDonation, step, incentives, prizes]);
 
   React.useEffect(() => {
     const presetAmount = CurrencyUtils.parseCurrency(urlHash);

--- a/bundles/tracker/donation/components/DonationPrizes.tsx
+++ b/bundles/tracker/donation/components/DonationPrizes.tsx
@@ -39,7 +39,7 @@ type PrizesProps = {
 
 const Prizes = (props: PrizesProps) => {
   const { eventId } = props;
-  const { prizes, rulesUrl } = useSelector(EventDetailsStore.getEventDetails);
+  const { prizes } = useSelector(EventDetailsStore.getEventDetails);
 
   return (
     <React.Fragment>
@@ -50,16 +50,16 @@ const Prizes = (props: PrizesProps) => {
           <Text size={Text.Sizes.SIZE_16}>
             <Anchor href={Routes.EVENT_PRIZES(eventId)}>Full prize list</Anchor>
           </Text>
-          {rulesUrl ? (
+          {window.SWEEPSTAKES_URL && (
             <React.Fragment>
               <Text size={Text.Sizes.SIZE_16}>
-                <Anchor href={rulesUrl}>Official Rules</Anchor>
+                <Anchor href={window.SWEEPSTAKES_URL}>Official Rules</Anchor>
               </Text>
               <Text size={Text.Sizes.SIZE_16}>
                 No donation necessary for a chance to win. See sweepstakes rules for details and instructions.
               </Text>
             </React.Fragment>
-          ) : null}
+          )}
         </div>
         <div className={styles.prizeList}>
           <div className={styles.prizes}>

--- a/bundles/tracker/event_details/EventDetailsReducer.ts
+++ b/bundles/tracker/event_details/EventDetailsReducer.ts
@@ -9,7 +9,6 @@ const initialState: EventDetailsState = {
   csrfToken: '',
   receiverName: '',
   prizesUrl: '',
-  rulesUrl: '',
   donateUrl: '',
   minimumDonation: 1,
   maximumDonation: Infinity,

--- a/bundles/tracker/event_details/EventDetailsTypes.ts
+++ b/bundles/tracker/event_details/EventDetailsTypes.ts
@@ -31,7 +31,6 @@ export type EventDetails = {
   csrfToken: string;
   receiverName: string;
   prizesUrl: string;
-  rulesUrl?: string;
   donateUrl: string;
   minimumDonation: number;
   maximumDonation: number;

--- a/bundles/tracker/events/EventConstants.ts
+++ b/bundles/tracker/events/EventConstants.ts
@@ -1,2 +1,0 @@
-// TODO: Have this be set per-event
-export const SWEEPSTAKES_URL = 'https://gamesdonequick.com/sweepstakes';

--- a/bundles/tracker/prizes/components/Prize.tsx
+++ b/bundles/tracker/prizes/components/Prize.tsx
@@ -12,7 +12,6 @@ import Markdown from '../../../uikit/Markdown';
 import Text from '../../../uikit/Text';
 import useDispatch from '../../hooks/useDispatch';
 import * as EventActions from '../../events/EventActions';
-import { SWEEPSTAKES_URL } from '../../events/EventConstants';
 import * as EventStore from '../../events/EventStore';
 import RouterUtils, { Routes } from '../../router/RouterUtils';
 import { StoreState } from '../../Store';
@@ -199,12 +198,14 @@ const Prize = (props: PrizeProps) => {
         </div>
       </div>
 
-      <div className={styles.disclaimers}>
-        <Text>
-          No donation necessary for a chance to win. See <Anchor href={SWEEPSTAKES_URL}>sweepstakes rules</Anchor> for
-          details and instructions.
-        </Text>
-      </div>
+      {window.SWEEPSTAKES_URL && (
+        <div className={styles.disclaimers}>
+          <Text>
+            No donation necessary for a chance to win. See{' '}
+            <Anchor href={window.SWEEPSTAKES_URL}>sweepstakes rules</Anchor> for details and instructions.
+          </Text>
+        </div>
+      )}
     </Container>
   );
 };

--- a/bundles/tracker/prizes/components/Prizes.tsx
+++ b/bundles/tracker/prizes/components/Prizes.tsx
@@ -15,6 +15,8 @@ import PrizeCard from './PrizeCard';
 import { Prize } from '../PrizeTypes';
 
 import styles from './Prizes.mod.css';
+import Text from '../../../uikit/Text';
+import Anchor from '../../../uikit/Anchor';
 
 // The limit of how many prizes should be included in sections that appear
 // above the All Prizes section. This generally avoids showing prizes multiple
@@ -88,6 +90,14 @@ const Prizes = (props: PrizesProps) => {
       <Header size={Header.Sizes.H1} className={styles.pageHeader}>
         Prizes for <span className={styles.eventName}>{event.name}</span>
       </Header>
+      {window.SWEEPSTAKES_URL && (
+        <div style={{ textAlign: 'center' }}>
+          <Text size={Text.Sizes.SIZE_12}>
+            No donation necessary for a chance to win. See{' '}
+            <Anchor href={window.SWEEPSTAKES_URL}>sweepstakes rules</Anchor> for details and instructions.
+          </Text>
+        </div>
+      )}
       {!loadingPrizes ? (
         <React.Fragment>
           {closingPrizes.length > 0 && (

--- a/ci/local.py
+++ b/ci/local.py
@@ -49,6 +49,15 @@ HAS_GOOGLE_APP_ID = False
 HAS_GIANTBOMB_API_KEY = False
 # GIANTBOMB_API_KEY = 'Itsreallynicetohaveanditsfreetomakeanaccountbutnotneccessary'
 
+HAS_FILE_STORAGE = False
+# DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+
+HAS_AWS_FILE_STORAGE = False
+# AWS_ACCESS_KEY_ID = 'deadbeefdeadbeef'
+# AWS_SECRET_ACCESS_KEY = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+# AWS_STORAGE_BUCKET_NAME = 'some-image-bucket'
+# AWS_DEFAULT_ACL = 'public-read'
+
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
 ADDITIONAL_APPS = [

--- a/templates/base.html
+++ b/templates/base.html
@@ -96,14 +96,16 @@
     {% endif %}
 {% endblock %}
 {% block rendertime %}{% endblock %}
+{% if settings.GOOGLE_ANALYTICS %}
 <script type="application/javascript">
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-36823056-1', 'gamesdonequick.com');
+    ga('create', '{{ settings.GOOGLE_ANALYTICS.0 }}', '{{ settings.GOOGLE_ANALYTICS.1}}');
     ga('send', 'pageview');
 </script>
+{% endif %}
 </body>
 </html>

--- a/templates/tracker/donate.html
+++ b/templates/tracker/donate.html
@@ -192,9 +192,12 @@
             {% endfor %}
         </table>
         <br/>
-        <p>No donation necessary for a chance to win. See <a target="_blank"
-                                                             href="https://gamesdonequick.com/sweepstakes">sweepstakes
-            rules</a> for details and instructions.</p>
+        {% if settings.SWEEPSTAKES_URL %}
+          <p>No donation necessary for a chance to win.
+            See <a href="{{ settings.SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a>
+            for details and instructions.
+          </p>
+        {% endif %}
     {% endif %}
     <br/>
 

--- a/templates/tracker/prize.html
+++ b/templates/tracker/prize.html
@@ -5,6 +5,13 @@
 {% block title %}{% trans "Prize Detail" %} -- {{ event.name|title }}{% endblock %}
 
 {% block content %}
+    {% if settings.SWEEPSTAKES_URL %}
+      <div>No donation necessary for a chance to win.
+        See <a href="{{ settings.SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
+        details and instructions.
+      </div>
+    {% endif %}
+
     <div class="title">
         <b>
             {% trans "Prize" %}:

--- a/templates/tracker/prizeindex.html
+++ b/templates/tracker/prizeindex.html
@@ -18,6 +18,14 @@
 
 
     </h2>
+
+    {% if settings.SWEEPSTAKES_URL %}
+      <div class="text-center">No donation necessary for a chance to win.
+        See <a href="{{ settings.SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
+        details and instructions.
+      </div>
+    {% endif %}
+
     <table class="table table-condensed table-striped small">
         <thead>
         <tr>

--- a/templates/ui/index.html
+++ b/templates/ui/index.html
@@ -10,10 +10,9 @@
     {{ bundle.css|safe }}
     <script type="text/javascript">
       <!--
-      window.API_ROOT = '{% url 'tracker:api_v1:root' %}';
-      window.ROOT_PATH = '{{ root_path }}';
-      window.STATIC_URL = '{% static '' %}';
-      window.APP_NAME = 'tracker';
+      // TODO: use json_script filter once we've upgraded Django
+      Object.assign(window, {{ CONSTANTS }});
+      window.ROOT_PATH = '{{ ROOT_PATH }}';
       -->
     </script>
     <link rel="stylesheet" type="text/css" href="{% static 'main.css' %}"/>

--- a/ui/views.py
+++ b/ui/views.py
@@ -16,6 +16,16 @@ from tracker.models import Event
 from tracker.views.donateviews import process_form
 
 
+def constants():
+    return {
+        'PRIVACY_POLICY_URL': settings.PRIVACY_POLICY_URL,
+        'SWEEPSTAKES_URL': settings.SWEEPSTAKES_URL,
+        'API_ROOT': reverse('tracker:api_v1:root'),
+        'APP_NAME': 'tracker',
+        'STATIC_URL': settings.STATIC_URL,
+    }
+
+
 @csrf_protect
 def index(request, **kwargs):
     bundle = webpack_manifest.load(
@@ -35,7 +45,8 @@ def index(request, **kwargs):
             'event': Event.objects.latest(),
             'events': Event.objects.all(),
             'bundle': bundle.tracker,
-            'root_path': reverse('tracker:ui:index'),
+            'CONSTANTS': mark_safe(json.dumps(constants())),
+            'ROOT_PATH': reverse('tracker:ui:index'),
             'app': 'TrackerApp',
             'form_errors': {},
             'props': '{}',
@@ -62,7 +73,8 @@ def admin(request):
             'event': Event.objects.latest(),
             'events': Event.objects.all(),
             'bundle': bundle.admin,
-            'root_path': reverse('tracker:ui:admin'),
+            'CONSTANTS': mark_safe(json.dumps(constants())),
+            'ROOT_PATH': reverse('tracker:ui:admin'),
             'app': 'AdminApp',
             'form_errors': {},
             'props': mark_safe(
@@ -181,7 +193,8 @@ def donate(request, event):
             'event': event,
             'events': Event.objects.all(),
             'bundle': bundle.tracker,
-            'root_path': reverse('tracker:ui:index'),
+            'CONSTANTS': mark_safe(json.dumps(constants())),
+            'ROOT_PATH': reverse('tracker:ui:index'),
             'app': 'TrackerApp',
             'title': 'Donation Tracker',
             'forms': {'bidsform': bidsform},
@@ -208,7 +221,6 @@ def donate(request, event):
                         'prizesUrl': request.build_absolute_uri(
                             reverse('tracker:prizeindex', args=(event.id,))
                         ),
-                        'rulesUrl': 'https://gamesdonequick.com/sweepstakes',  # TODO: put in settings?
                     },
                     ensure_ascii=False,
                     cls=serializers.json.DjangoJSONEncoder,

--- a/views/common.py
+++ b/views/common.py
@@ -60,6 +60,7 @@ def tracker_context(request, qdict=None):
             'next': request.POST.get('next', request.GET.get('next', request.path)),
             'starttime': starttime,
             'events': tracker.models.Event.objects.all(),
+            'settings': settings,
         }
     )
     qdict.setdefault('event', viewutil.get_event(None))


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170785863

### Description of the Change

There were lingering instances of hard-coded URLs and other keys specific to GDQ in the code. This eliminates:

- sweepstakes url
- privacy policy url
- Google Analytics keys

And makes them configurable in Django settings.

### Verification Process

Loaded up the tracker with different settings to make sure they applied.