### PR TITLE
display more server errors on the donation form

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,6 +75,7 @@
       "rules": {
         "@typescript-eslint/ban-ts-ignore": 0,
         "@typescript-eslint/no-use-before-define": 0,
+        "@typescript-eslint/no-non-null-assertion": 0,
         "no-empty": 0,
         "no-unused-vars": 1,
         "react/no-find-dom-node": 0

--- a/bundles/@types/matchers-types.d.ts
+++ b/bundles/@types/matchers-types.d.ts
@@ -1,0 +1,8 @@
+declare namespace jasmine {
+  interface Matchers<T> {
+    toExist(): boolean;
+  }
+  interface ArrayLikeMatchers<T> {
+    toHaveLength(expected: number): boolean;
+  }
+}

--- a/bundles/tracker/donation/DonationReducerSpec.ts
+++ b/bundles/tracker/donation/DonationReducerSpec.ts
@@ -1,0 +1,48 @@
+import DonationReducer from './DonationReducer';
+import { createBid, deleteBid } from './DonationActions';
+
+describe('DonationReducer', () => {
+  let state: ReturnType<typeof DonationReducer>;
+
+  beforeEach(() => {
+    state = DonationReducer(undefined, {
+      type: 'LOAD_DONATION',
+      donation: { name: '', email: '', amount: 50, comment: '', wantsEmails: 'CURR' },
+      bids: [
+        { amount: 5, customoptionname: '' },
+        { incentiveId: 3, amount: 5, customoptionname: '' },
+        { incentiveId: 4, amount: 5, customoptionname: '' },
+      ],
+      formErrors: { bidsform: [{ bid: ['Does not exist'] }], commentform: {} },
+    });
+  });
+
+  describe('CREATE_BID', () => {
+    it('clears out bid form errors and bids with no incentive ids', () => {
+      state = DonationReducer(state, createBid({ incentiveId: 1, amount: 5, customoptionname: '' }));
+      expect(state.bids).toHaveLength(3);
+      expect(state.formErrors.bidsform).toHaveLength(0);
+    });
+
+    it('joins amounts together', () => {
+      state = DonationReducer(state, createBid({ incentiveId: 1, amount: 5, customoptionname: '' }));
+      state = DonationReducer(state, createBid({ incentiveId: 1, amount: 5, customoptionname: '' }));
+      expect(state.bids).toHaveLength(3);
+      expect(state.bids.find(bid => bid.incentiveId === 1)!.amount).toBe(10);
+    });
+
+    it('can add multiple bids', () => {
+      state = DonationReducer(state, createBid({ incentiveId: 1, amount: 5, customoptionname: '' }));
+      state = DonationReducer(state, createBid({ incentiveId: 2, amount: 5, customoptionname: '' }));
+      expect(state.bids).toHaveLength(4);
+    });
+  });
+
+  describe('DELETE_BID', () => {
+    it('clears out bit form errors and bids with no incentive ids', () => {
+      state = DonationReducer(state, deleteBid(3));
+      expect(state.bids).toHaveLength(1);
+      expect(state.formErrors.bidsform).toHaveLength(0);
+    });
+  });
+});

--- a/bundles/tracker/donation/DonationStore.ts
+++ b/bundles/tracker/donation/DonationStore.ts
@@ -6,8 +6,17 @@ import { StoreState } from '../Store';
 import validateDonationUtil from './validateDonation';
 
 const getDonationState = (state: StoreState) => state.donation.donation;
-const getBidsById = (state: StoreState) => state.donation.bids;
-export const getFormError = (state: StoreState) => state.donation.formError;
+export const getFormErrors = (state: StoreState) => state.donation.formErrors;
+
+export const getCommentFormErrors = createSelector(
+  [getFormErrors],
+  formErrors => formErrors.commentform,
+);
+
+export const getBidsFormErrors = createSelector(
+  [getFormErrors],
+  formErrors => formErrors.bidsform,
+);
 
 export const getDonation = getDonationState;
 
@@ -16,16 +25,13 @@ export const getDonationAmount = createSelector(
   donation => donation.amount,
 );
 
-export const getBids = createSelector(
-  [getBidsById],
-  bidsById => Object.values(bidsById),
-);
+export const getBids = (state: StoreState) => state.donation.bids;
 
 export const getAllocatedBidTotal = createSelector(
   [getBids],
   bids => {
     if (bids.length === 0) return 0;
-    return _.sumBy(bids, 'amount');
+    return _.sumBy(bids.filter(bid => bid.incentiveId), 'amount');
   },
 );
 

--- a/bundles/tracker/donation/DonationTypes.ts
+++ b/bundles/tracker/donation/DonationTypes.ts
@@ -1,25 +1,49 @@
 export type Bid = {
-  incentiveId: number;
+  incentiveId?: number;
   amount: number;
   customoptionname?: string;
 };
 
 export type Donation = {
   name: string;
-  nameVisibility: 'ALIAS' | 'ANON';
   email: string;
   wantsEmails: 'CURR' | 'OPTIN' | 'OPTOUT';
   amount?: number;
   comment: string;
 };
 
+type ValidationError = { field: string; message: string };
+
 export type Validation = {
   valid: boolean;
-  errors: Array<{ field: string; message: string }>;
+  errors: ValidationError[];
+};
+
+export type FormError = { message: string; code?: string } | string;
+
+export type BidFormErrors = {
+  bid?: FormError[];
+  customoptionname?: FormError[];
+  amount?: FormError[];
+};
+
+export type CommentFormErrors = {
+  __all__?: FormError[];
+  requestedalias?: FormError[];
+  requestedemail?: FormError[];
+  requestedsolicitemail?: FormError[];
+  requestedvisibility?: FormError[];
+  amount?: FormError[];
+  comment?: FormError[];
+};
+
+export type DonationFormErrors = {
+  bidsform: BidFormErrors[];
+  commentform: CommentFormErrors;
 };
 
 export type DonationAction =
-  | { type: 'LOAD_DONATION'; donation: Donation; bids: Array<Bid>; formError?: string }
+  | { type: 'LOAD_DONATION'; donation: Donation; bids: Bid[]; formErrors: DonationFormErrors }
   | { type: 'UPDATE_DONATION'; fields: Partial<Donation> }
   | { type: 'CREATE_BID'; bid: Bid }
   | { type: 'DELETE_BID'; incentiveId: number };

--- a/bundles/tracker/donation/__tests__/DonationActions.spec.ts
+++ b/bundles/tracker/donation/__tests__/DonationActions.spec.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { Donation } from '../DonationTypes';
 import { buildDonationPayload } from '../DonationActions';
 
@@ -9,7 +7,6 @@ describe('DonationActions', () => {
 
     const donation: Donation = {
       name: 'someone',
-      nameVisibility: 'ALIAS',
       email: 'email@example.com',
       wantsEmails: 'OPTOUT',
       amount: 20.0,
@@ -24,12 +21,18 @@ describe('DonationActions', () => {
     it('converts donation field names to API fields', () => {
       const payload = buildDonationPayload(csrfToken, donation, []);
 
-      expect(payload.requestedvisibility).toEqual(donation.nameVisibility);
+      expect(payload.requestedvisibility).toEqual('ALIAS');
       expect(payload.requestedalias).toEqual(donation.name);
       expect(payload.requestedemail).toEqual(donation.email);
       expect(payload.requestedsolicitemail).toEqual(donation.wantsEmails);
       expect(payload.amount).toEqual('20.00');
       expect(payload.comment).toEqual(donation.comment);
+    });
+
+    it('sends ANON for visibility when alias is blank', () => {
+      const payload = buildDonationPayload(csrfToken, { ...donation, name: '' }, []);
+
+      expect(payload.requestedvisibility).toEqual('ANON');
     });
 
     it('includes provided csrf token', () => {

--- a/bundles/tracker/donation/__tests__/validateBid.spec.ts
+++ b/bundles/tracker/donation/__tests__/validateBid.spec.ts
@@ -47,7 +47,6 @@ const donation: Donation = {
   email: '',
   amount: 75.0,
   comment: '',
-  nameVisibility: 'ANON',
   wantsEmails: 'CURR',
 };
 

--- a/bundles/tracker/donation/__tests__/validateDonation.spec.ts
+++ b/bundles/tracker/donation/__tests__/validateDonation.spec.ts
@@ -22,7 +22,6 @@ describe('validateDonation', () => {
       email: '',
       amount: 75.0,
       comment: '',
-      nameVisibility: 'ANON',
       wantsEmails: 'CURR',
     };
 
@@ -38,7 +37,6 @@ describe('validateDonation', () => {
         email: '',
         amount: undefined,
         comment: '',
-        nameVisibility: 'ANON',
         wantsEmails: 'CURR',
       };
 
@@ -53,7 +51,6 @@ describe('validateDonation', () => {
         email: '',
         amount: eventDetails.minimumDonation - 1,
         comment: '',
-        nameVisibility: 'ANON',
         wantsEmails: 'CURR',
       };
 
@@ -71,7 +68,6 @@ describe('validateDonation', () => {
         email: '',
         amount: eventDetails.maximumDonation + 1,
         comment: '',
-        nameVisibility: 'ANON',
         wantsEmails: 'CURR',
       };
 
@@ -91,11 +87,10 @@ describe('validateDonation', () => {
         email: '',
         amount: eventDetails.minimumDonation + 1,
         comment: '',
-        nameVisibility: 'ANON',
         wantsEmails: 'CURR',
       };
 
-      const bids: Array<Bid> = Array(MAX_BIDS_PER_DONATION + 1).fill({
+      const bids: Bid[] = Array(MAX_BIDS_PER_DONATION + 1).fill({
         incentiveId: 1,
         amount: 2.0,
       });
@@ -114,11 +109,10 @@ describe('validateDonation', () => {
         email: '',
         amount: 10,
         comment: '',
-        nameVisibility: 'ANON',
         wantsEmails: 'CURR',
       };
 
-      const bids: Array<Bid> = Array(3).fill({
+      const bids: Bid[] = Array(3).fill({
         incentiveId: 1,
         amount: 10,
       });
@@ -139,7 +133,6 @@ describe('validateDonation', () => {
         email: 'notavalidemail',
         amount: 10,
         comment: '',
-        nameVisibility: 'ANON',
         wantsEmails: 'CURR',
       };
 

--- a/bundles/tracker/donation/components/Donate.tsx
+++ b/bundles/tracker/donation/components/Donate.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import _ from 'lodash';
 
 import * as CurrencyUtils from '../../../public/util/currency';
-import Alert from '../../../uikit/Alert';
 import Anchor from '../../../uikit/Anchor';
 import Button from '../../../uikit/Button';
 import Container from '../../../uikit/Container';
 import CurrencyInput from '../../../uikit/CurrencyInput';
+import ErrorAlert from '../../../uikit/ErrorAlert';
 import Header from '../../../uikit/Header';
 import RadioGroup from '../../../uikit/RadioGroup';
 import Text from '../../../uikit/Text';
@@ -21,7 +19,7 @@ import * as DonationStore from '../DonationStore';
 import DonationIncentives from './DonationIncentives';
 import DonationPrizes from './DonationPrizes';
 
-import { EMAIL_OPTIONS, AMOUNT_PRESETS } from '../DonationConstants';
+import { AMOUNT_PRESETS, EMAIL_OPTIONS } from '../DonationConstants';
 import styles from './Donate.mod.css';
 
 type DonateProps = {
@@ -32,14 +30,16 @@ const Donate = (props: DonateProps) => {
   const dispatch = useDispatch();
   const { eventId } = props;
 
-  const { eventDetails, prizes, donation, bids, donationValidity, formError } = useSelector((state: StoreState) => ({
-    eventDetails: EventDetailsStore.getEventDetails(state),
-    prizes: EventDetailsStore.getPrizes(state),
-    donation: DonationStore.getDonation(state),
-    bids: DonationStore.getBids(state),
-    formError: DonationStore.getFormError(state),
-    donationValidity: DonationStore.validateDonation(state),
-  }));
+  const { eventDetails, prizes, donation, bids, donationValidity, commentErrors } = useSelector(
+    (state: StoreState) => ({
+      eventDetails: EventDetailsStore.getEventDetails(state),
+      prizes: EventDetailsStore.getPrizes(state),
+      donation: DonationStore.getDonation(state),
+      bids: DonationStore.getBids(state),
+      commentErrors: DonationStore.getCommentFormErrors(state),
+      donationValidity: DonationStore.validateDonation(state),
+    }),
+  );
 
   const { receiverName, donateUrl, minimumDonation, maximumDonation, step } = eventDetails;
   const { name, email, wantsEmails, amount, comment } = donation;
@@ -59,17 +59,14 @@ const Donate = (props: DonateProps) => {
 
   return (
     <Container>
-      {formError != null ? (
-        <Alert className={styles.alert}>
-          <Text marginless>{formError}</Text>
-        </Alert>
-      ) : null}
+      <ErrorAlert errors={commentErrors.__all__} />
       <Header size={Header.Sizes.H1} marginless>
         Thank You For Your Donation
       </Header>
       <Text size={Text.Sizes.SIZE_16}>100% of your donation goes directly to {receiverName}.</Text>
 
       <section className={styles.section}>
+        <ErrorAlert errors={commentErrors.requestedalias} />
         <TextInput
           name="alias"
           value={name}
@@ -80,6 +77,7 @@ const Donate = (props: DonateProps) => {
           maxLength={32}
           autoFocus
         />
+        <ErrorAlert errors={commentErrors.requestedemail} />
         <TextInput
           name="email"
           value={email}
@@ -95,6 +93,8 @@ const Donate = (props: DonateProps) => {
           maxLength={128}
         />
 
+        <ErrorAlert errors={commentErrors.requestedsolicitemail} />
+
         <Text size={Text.Sizes.SIZE_16} marginless>
           Do you want to receive emails from {receiverName}?
         </Text>
@@ -105,6 +105,8 @@ const Donate = (props: DonateProps) => {
           value={wantsEmails}
           onChange={value => updateDonation({ wantsEmails: value })}
         />
+
+        <ErrorAlert errors={commentErrors.amount} />
 
         <CurrencyInput
           name="amount"
@@ -132,6 +134,8 @@ const Donate = (props: DonateProps) => {
             </Button>
           ))}
         </div>
+
+        <ErrorAlert errors={commentErrors.comment} />
 
         <TextInput
           name="comment"

--- a/bundles/tracker/donation/components/DonateInitializer.tsx
+++ b/bundles/tracker/donation/components/DonateInitializer.tsx
@@ -7,7 +7,7 @@ import { Prize } from '../../event_details/EventDetailsTypes';
 import useDispatch from '../../hooks/useDispatch';
 import RouterUtils from '../../router/RouterUtils';
 import * as DonationActions from '../DonationActions';
-import { Bid } from '../DonationTypes';
+import { Bid, DonationFormErrors } from '../DonationTypes';
 
 /*
   DonateInitializer acts as a proxy for bringing the preloaded props provided
@@ -17,30 +17,33 @@ import { Bid } from '../DonationTypes';
   to a fully-API-powered frontend easier later on.
 */
 
-type DonateInitializerProps = {
-  incentives: Array<{
+type Incentive = {
+  id: number;
+  parent: {
     id: number;
-    parent: {
-      id: number;
-      name: string;
-      custom: boolean;
-      maxlength?: number;
-      description: string;
-    };
     name: string;
-    runname: string;
-    order: number;
-    amount: string; // TODO: this and goal should be numbers but django seems to be serializing them as strings?
-    count: number;
-    goal?: string;
+    custom: boolean;
+    maxlength?: number;
     description: string;
-  }>;
-  formErrors: {
-    bidsform: Array<{
-      bid: Array<string>;
-    }>;
-    commentform: object;
   };
+  name: string;
+  runname: string;
+  order: number;
+  amount: string; // TODO: this and goal should be numbers but django seems to be serializing them as strings?
+  count: number;
+  goal?: string;
+  description: string;
+};
+
+type InitialIncentive = {
+  bid?: number; // ? `bid` will be missing if it was invalid or has closed since the form was opened
+  customoptionname: string;
+  amount: string;
+};
+
+type DonateInitializerProps = {
+  incentives: Incentive[];
+  formErrors: DonationFormErrors;
   initialForm: {
     requestedvisibility?: string;
     requestedalias?: string;
@@ -49,11 +52,7 @@ type DonateInitializerProps = {
     amount?: string;
     comment?: string;
   };
-  initialIncentives: Array<{
-    bid?: number; // ? `bid` will be null if it was closed
-    customoptionname: string;
-    amount: string;
-  }>;
+  initialIncentives: InitialIncentive[];
   event: {
     receivername: string;
   };
@@ -61,7 +60,7 @@ type DonateInitializerProps = {
   minimumDonation: number;
   maximumDonation: number;
   donateUrl: string;
-  prizes: Array<Prize>;
+  prizes: Prize[];
   prizesUrl: string;
   rulesUrl?: string;
   csrfToken: string;
@@ -83,7 +82,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     // Donation
     initialForm,
     initialIncentives,
-    formErrors: { bidsform: bidErrors },
+    formErrors,
   } = props;
 
   const dispatch = useDispatch();
@@ -94,23 +93,18 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     // to have submitted the form in the first place, the bid must have been
     // valid. The server will potentially strip `bid.bid` from invalid bids,
     // but `bid.amount` _should_ always be a valid currency string.
-    const transformedBids = initialIncentives
-      .map(bid => ({
-        incentiveId: bid.bid,
-        customoptionname: bid.customoptionname,
-        amount: CurrencyUtils.parseCurrency(bid.amount)!,
-      }))
-      .filter(bid => bid.incentiveId != null);
+    const transformedBids = initialIncentives.map(bid => ({
+      incentiveId: bid.bid,
+      customoptionname: bid.customoptionname,
+      amount: CurrencyUtils.parseCurrency(bid.amount)!,
+    }));
 
     const transformedDonation = {
       ...initialForm,
       amount: CurrencyUtils.parseCurrency(initialForm.amount),
     };
 
-    const transformedError =
-      bidErrors.length > 0 ? 'One or more of your chosen incentives is no longer available for bids.' : undefined;
-
-    dispatch(DonationActions.loadDonation(transformedDonation, transformedBids as Array<Bid>, transformedError));
+    dispatch(DonationActions.loadDonation(transformedDonation, transformedBids as Bid[], formErrors));
   }, [dispatch, initialForm]);
 
   React.useEffect(() => {

--- a/bundles/tracker/donation/components/DonationBidForm.tsx
+++ b/bundles/tracker/donation/components/DonationBidForm.tsx
@@ -98,7 +98,7 @@ const DonationBidForm = (props: DonationBidFormProps) => {
       <Header size={Header.Sizes.H5}>{incentive.name}</Header>
       <Text size={Text.Sizes.SIZE_14}>{incentive.description}</Text>
 
-      {incentive.goal && (
+      {incentive.goal ? (
         <React.Fragment>
           <ProgressBar className={styles.progressBar} progress={(incentive.amount / incentive.goal) * 100} />
           <Text marginless>
@@ -108,7 +108,7 @@ const DonationBidForm = (props: DonationBidFormProps) => {
             </span>
           </Text>
         </React.Fragment>
-      )}
+      ) : null}
 
       <CurrencyInput
         value={allocatedAmount}

--- a/bundles/tracker/donation/validateBid.ts
+++ b/bundles/tracker/donation/validateBid.ts
@@ -21,12 +21,12 @@ export default function validateBid(
   newBid: Partial<Bid>,
   incentive: Incentive,
   donation: Donation,
-  bids: Array<Bid>,
+  bids: Bid[],
   hasChildIncentives: boolean,
   hasChildSelected: boolean,
   isCustom = false,
 ): Validation {
-  const preAllocatedTotal = _.sumBy(bids, 'amount');
+  const preAllocatedTotal = _.sumBy(bids.filter(bid => bid.incentiveId), 'amount');
   const remainingTotal = donation.amount ? donation.amount - preAllocatedTotal : 0;
 
   const errors = [];

--- a/bundles/tracker/donation/validateDonation.ts
+++ b/bundles/tracker/donation/validateDonation.ts
@@ -18,7 +18,7 @@ export const DonationErrors = {
   INVALID_EMAIL: 'Email is not a valid email address',
 };
 
-export default function validateDonation(eventDetails: EventDetails, donation: Donation, bids: Array<Bid>): Validation {
+export default function validateDonation(eventDetails: EventDetails, donation: Donation, bids: Bid[]): Validation {
   const sumOfBids = _.sumBy(bids, 'amount');
   const errors = [];
 

--- a/bundles/tracker/event_details/EventDetailsActions.ts
+++ b/bundles/tracker/event_details/EventDetailsActions.ts
@@ -8,7 +8,7 @@ export function loadEventDetails(eventDetails: EventDetails) {
   };
 }
 
-export function loadIncentives(incentives: Array<Incentive>) {
+export function loadIncentives(incentives: Incentive[]) {
   return {
     type: ActionTypes.LOAD_INCENTIVES,
     incentives,

--- a/bundles/tracker/event_details/EventDetailsStore.ts
+++ b/bundles/tracker/event_details/EventDetailsStore.ts
@@ -26,7 +26,7 @@ export const getTopLevelIncentives = createSelector(
 
 export const getChildIncentives = createSelector(
   [getIncentives, (_: StoreState, incentiveId: number) => incentiveId],
-  (incentives, parentId): Array<Incentive> => {
+  (incentives, parentId): Incentive[] => {
     if (parentId == null) return [];
     return incentives.filter(incentive => incentive.parent && incentive.parent.id === parentId);
   },

--- a/bundles/tracker/event_details/EventDetailsTypes.ts
+++ b/bundles/tracker/event_details/EventDetailsTypes.ts
@@ -38,9 +38,9 @@ export type EventDetails = {
   maximumDonation: number;
   step: number;
   availableIncentives: { [incentiveId: number]: Incentive };
-  prizes: Array<Prize>;
+  prizes: Prize[];
 };
 
 export type EventDetailsAction =
   | { type: 'LOAD_EVENT_DETAILS'; eventDetails: EventDetails }
-  | { type: 'LOAD_INCENTIVES'; incentives: Array<Incentive> };
+  | { type: 'LOAD_INCENTIVES'; incentives: Incentive[] };

--- a/bundles/tracker/event_details/searchIncentives.ts
+++ b/bundles/tracker/event_details/searchIncentives.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import { Incentive } from './EventDetailsTypes';
 
-export default function searchIncentives(incentives: Array<Incentive>, query: string) {
+export default function searchIncentives(incentives: Incentive[], query: string) {
   if (query === '') {
     return incentives;
   }

--- a/bundles/tracker/events/EventActions.ts
+++ b/bundles/tracker/events/EventActions.ts
@@ -61,7 +61,7 @@ export function fetchEvents(filter: EventSearchFilter = {}) {
     }
 
     return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'event' })
-      .then((data: Array<any>) => {
+      .then((data: any[]) => {
         const events = data.map(eventFromAPIEvent);
 
         dispatch({

--- a/bundles/tracker/events/EventTypes.ts
+++ b/bundles/tracker/events/EventTypes.ts
@@ -22,8 +22,8 @@ export type Event = {
   autoApproveThreshold?: number;
   // Prizes
   prizeCoordinator?: object; // User
-  allowedPrizeCountries: Array<object>; // Array<Country>
-  disallowedPrizeRegions: Array<object>; // Array<CountryRegion>
+  allowedPrizeCountries: object[]; // Country[]
+  disallowedPrizeRegions: object[]; // CountryRegion[]
   prizeAcceptDeadlineDelta: number;
   // Statistics
   amount: number;
@@ -51,6 +51,6 @@ export type EventSearchFilter = {
 
 export type EventAction =
   | { type: 'FETCH_EVENTS_STARTED' }
-  | { type: 'FETCH_EVENTS_SUCCESS'; events: Array<Event> }
+  | { type: 'FETCH_EVENTS_SUCCESS'; events: Event[] }
   | { type: 'FETCH_EVENTS_FAILED' }
   | { type: 'SELECT_EVENT'; eventId: number };

--- a/bundles/tracker/prizes/PrizeActions.ts
+++ b/bundles/tracker/prizes/PrizeActions.ts
@@ -106,7 +106,7 @@ export function fetchPrizes(filter: PrizeSearchFilter = {}) {
     }
 
     return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'prize' })
-      .then((data: Array<any>) => {
+      .then((data: any[]) => {
         const prizes = data.map(prizeFromAPIPrize);
 
         dispatch({

--- a/bundles/tracker/prizes/PrizeTypes.ts
+++ b/bundles/tracker/prizes/PrizeTypes.ts
@@ -50,8 +50,8 @@ export type Prize = {
   handlerId?: string;
   requiresShipping: boolean;
   customCountryFilter: boolean;
-  allowedPrizeCountries: Array<string>;
-  disallowedPrizeRegions: Array<string>;
+  allowedPrizeCountries: string[];
+  disallowedPrizeRegions: string[];
   numWinners: number;
   maxWinners: number;
   maxMultiWin: number;
@@ -67,5 +67,5 @@ export type PrizeSearchFilter = {
 
 export type PrizeAction =
   | { type: 'FETCH_PRIZES_STARTED' }
-  | { type: 'FETCH_PRIZES_SUCCESS'; prizes: Array<Prize> }
+  | { type: 'FETCH_PRIZES_SUCCESS'; prizes: Prize[] }
   | { type: 'FETCH_PRIZES_FAILED' };

--- a/bundles/tracker/prizes/components/Prizes.tsx
+++ b/bundles/tracker/prizes/components/Prizes.tsx
@@ -23,7 +23,7 @@ import styles from './Prizes.mod.css';
 const FEATURED_SECTION_LIMIT = 6;
 
 type PrizeGridProps = {
-  prizes: Array<Prize>;
+  prizes: Prize[];
   name: string;
 };
 

--- a/bundles/tracker/runs/RunTypes.ts
+++ b/bundles/tracker/runs/RunTypes.ts
@@ -19,7 +19,7 @@ export type Run = {
   setupTime: string;
   order?: number;
   coop: boolean;
-  runners: Array<string>; // Array<Runner>
+  runners: string[]; // Runner[]
   techNotes?: string;
   giantbombId?: string;
 };

--- a/bundles/uikit/ErrorAlert.tsx
+++ b/bundles/uikit/ErrorAlert.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Alert from './Alert';
+import Text from './Text';
+
+interface FormError {
+  message: string;
+  code?: string;
+}
+
+export default function ErrorAlert({ errors }: { errors?: (FormError | string)[] }) {
+  return (
+    <>
+      {errors &&
+        errors.map(error => {
+          const message = (error as FormError).message || (error as string);
+          return (
+            <Alert key={message}>
+              <Text>{message}</Text>
+            </Alert>
+          );
+        })}
+    </>
+  );
+}

--- a/bundles/uikit/Markdown.tsx
+++ b/bundles/uikit/Markdown.tsx
@@ -14,7 +14,7 @@ type MarkdownProps = {
 //
 // The types defined here effectively allow users to write paragraphs of text
 // with emphasized inline elements.
-const DEFAULT_ALLOWED_NODE_TYPES: Array<ReactMarkdown.NodeType> = [
+const DEFAULT_ALLOWED_NODE_TYPES: ReactMarkdown.NodeType[] = [
   'text',
   'break',
   'paragraph',

--- a/bundles/uikit/RadioGroup.tsx
+++ b/bundles/uikit/RadioGroup.tsx
@@ -40,7 +40,7 @@ const RadioItem = (props: RadioItemProps) => {
 
 type RadioGroupProps = {
   look?: typeof RadioGroupLooks[keyof typeof RadioGroupLooks];
-  options: Array<any>;
+  options: any[];
   value: any;
   className?: string;
   children?: (props: RadioItemProps) => React.ReactElement;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,21 +11,9 @@ module.exports = function(config) {
         flags: ['--no-sandbox'],
       },
     },
-    files: [
-      'bundles/**/*Spec.js',
-      'bundles/**/*Spec.ts',
-      'bundles/**/*Spec.tsx',
-      'bundles/**/*.spec.tsx',
-      'bundles/**/*.spec.ts',
-      './spec/Suite.tsx',
-    ],
+    files: ['./spec/entry.js'],
     preprocessors: {
-      'bundles/**/*Spec.js': ['webpack'],
-      'bundles/**/*Spec.ts': ['webpack'],
-      'bundles/**/*Spec.tsx': ['webpack'],
-      'bundles/**/*.spec.tsx': ['webpack'],
-      'bundles/**/*.spec.ts': ['webpack'],
-      './spec/Suite.tsx': ['webpack'],
+      './spec/entry.js': ['webpack'],
     },
     webpack: {
       ...webpackConfig,

--- a/spec/entry.js
+++ b/spec/entry.js
@@ -1,0 +1,5 @@
+import './Suite';
+import './matchers';
+
+const modules = require.context('../bundles', true, /(Spec|\.spec).[jt]sx?$/);
+modules.keys().forEach(modules);

--- a/spec/matchers.js
+++ b/spec/matchers.js
@@ -1,0 +1,37 @@
+beforeEach(() => {
+  jasmine.addMatchers({
+    toExist: function() {
+      return {
+        compare: function(actual) {
+          if (!actual.exists) {
+            throw new Error(`Expected ${actual} to have an 'exists' method`);
+          }
+          const passed = actual.exists();
+
+          return {
+            pass: passed,
+            message: `Expected element ${passed ? 'not ' : ' '}to exist`,
+          };
+        },
+      };
+    },
+    toHaveLength: function() {
+      return {
+        compare: function(actual, expected) {
+          if (actual.length == null) {
+            throw new Error(`Expected ${actual} to have a 'length' property`);
+          }
+
+          const passed = actual.length === expected;
+
+          return {
+            pass: passed,
+            message: `Expected ${actual} ${passed ? 'not ' : ' '}to have length ${expected}, but it ${
+              passed ? 'did' : `had length ${actual.length}`
+            }`,
+          };
+        },
+      };
+    },
+  });
+});


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170535381

### Description of the Change

The bug that kicked this off was because of the form not properly initializing some app state and sending a value to the server that made it think it was trying to submit a donation with 'alias' visibility but no alias provided. This manifested as the form punting you back with no indication of what was wrong.

Given the way the form should be sending the value in question to the server I just changed it so that it's derived at submission time instead of storing it in the app state.

I also took the time to make the error handling/display more robust to match what the server might return. The actual display isn't the prettiest, but it'll do for now.

### Verification Process

Forced various error states by either having the client code send garbage values, or have the server complain about valid ones, and made sure the errors showed up as expected.