### PR TITLE
prize link on donate page works, and works for shortnames

### DIFF
--- a/bundles/tracker/Endpoints.ts
+++ b/bundles/tracker/Endpoints.ts
@@ -1,5 +1,9 @@
-export const API_ROOT = window.API_ROOT;
+function root() {
+  return window.API_ROOT || 'http://testserver/';
+}
 
 export default {
-  SEARCH: API_ROOT + 'search/',
+  get SEARCH() {
+    return `${root()}search/`;
+  },
 };

--- a/bundles/tracker/events/EventActions.ts
+++ b/bundles/tracker/events/EventActions.ts
@@ -51,11 +51,16 @@ export function selectEvent(eventId: string) {
   };
 }
 
-export function fetchEvents(filters: EventSearchFilter = {}) {
+export function fetchEvents(filter: EventSearchFilter = {}) {
   return (dispatch: SafeDispatch) => {
     dispatch({ type: ActionTypes.FETCH_EVENTS_STARTED });
 
-    return HTTPUtils.get(Endpoints.SEARCH, { ...filters, type: 'event' })
+    if (filter.id && /\D/.test(filter.id)) {
+      filter.short = filter.id;
+      delete filter.id;
+    }
+
+    return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'event' })
       .then((data: Array<any>) => {
         const events = data.map(eventFromAPIEvent);
 

--- a/bundles/tracker/events/EventActionsSpec.ts
+++ b/bundles/tracker/events/EventActionsSpec.ts
@@ -1,0 +1,33 @@
+import fetchMock from 'fetch-mock';
+import { fetchEvents } from './EventActions';
+import { AnyAction } from 'redux';
+import thunk, { ThunkDispatch } from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import Endpoints from '../Endpoints';
+import { StoreState } from '../Store';
+
+type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
+
+const mockStore = configureMockStore<StoreState, DispatchExts>([thunk]);
+
+describe('EventActions', () => {
+  let store: ReturnType<typeof mockStore>;
+
+  beforeEach(() => {
+    store = mockStore();
+  });
+
+  describe('#fetchEvents', () => {
+    it('works with a numeric id', () => {
+      fetchMock.once(`${Endpoints.SEARCH}?id=1&type=event`, 200);
+      store.dispatch(fetchEvents({ id: '1' }));
+      expect(fetchMock.called()).toBe(true);
+    });
+
+    it('works with a shortname', () => {
+      fetchMock.once(`${Endpoints.SEARCH}?short=test&type=event`, 200);
+      store.dispatch(fetchEvents({ id: 'test' }));
+      expect(fetchMock.called()).toBe(true);
+    });
+  });
+});

--- a/bundles/tracker/events/EventStore.ts
+++ b/bundles/tracker/events/EventStore.ts
@@ -1,11 +1,17 @@
 import { createSelector } from 'reselect';
 import createCachedSelector from 're-reselect';
-import _ from 'lodash';
 
 import { StoreState } from '../Store';
 
 const getEventsState = (state: StoreState) => state.events;
-const getEventId = (_state: StoreState, { eventId }: { eventId: string }) => eventId;
+const getEventId = (state: StoreState, { eventId }: { eventId: string }) => {
+  const events = state.events && state.events.events;
+  let event;
+  if (/\D/.test(eventId)) {
+    event = Object.values(events).find(event => event.short === eventId);
+  }
+  return event ? event.id : eventId;
+};
 export const getSelectedEventId = (state: StoreState) => state.events.selectedEventId;
 
 export const getSelectedEvent = createSelector(

--- a/bundles/tracker/events/EventStoreSpec.ts
+++ b/bundles/tracker/events/EventStoreSpec.ts
@@ -1,0 +1,34 @@
+import { getEvent } from './EventStore';
+import { combinedReducer, StoreState } from '../Store';
+import { getFixtureEvent } from '../../../spec/fixtures/event';
+
+describe('EventStore', () => {
+  const event = getFixtureEvent();
+  let state: StoreState;
+
+  beforeEach(() => {
+    state = { ...combinedReducer(undefined, { type: 'INIT' }), events: { loading: false, events: { '1': event } } };
+  });
+
+  describe('#getEvent', () => {
+    describe('numeric id', () => {
+      it('works for events that exist', () => {
+        expect(getEvent(state, { eventId: '1' })).toBe(event);
+      });
+
+      it('returns nothing for events that do not exist', () => {
+        expect(getEvent(state, { eventId: '2' })).toBeFalsy();
+      });
+    });
+
+    describe('short name', () => {
+      it('works for events that exist', () => {
+        expect(getEvent(state, { eventId: 'test' })).toBe(event);
+      });
+
+      it('returns nothing for events that do not exist', () => {
+        expect(getEvent(state, { eventId: 'nonsense' })).toBeFalsy();
+      });
+    });
+  });
+});

--- a/bundles/tracker/events/components/EventRouter.tsx
+++ b/bundles/tracker/events/components/EventRouter.tsx
@@ -25,7 +25,7 @@ const EventRouter = (props: any) => {
         {({ match }: RouteComponentProps<{ eventId: string }>) => (
           <React.Fragment>
             <DonateInitializer {...props} />
-            <Donate eventId={match.params.eventId} />
+            <Donate eventId={eventId} />
           </React.Fragment>
         )}
       </Route>

--- a/bundles/tracker/prizes/PrizeActions.ts
+++ b/bundles/tracker/prizes/PrizeActions.ts
@@ -100,6 +100,11 @@ export function fetchPrizes(filter: PrizeSearchFilter = {}) {
   return (dispatch: SafeDispatch) => {
     dispatch({ type: ActionTypes.FETCH_PRIZES_STARTED });
 
+    if (filter.event && /\D/.test(filter.event)) {
+      filter.eventshort = filter.event;
+      delete filter.event;
+    }
+
     return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'prize' })
       .then((data: Array<any>) => {
         const prizes = data.map(prizeFromAPIPrize);

--- a/bundles/tracker/prizes/PrizeActionsSpec.ts
+++ b/bundles/tracker/prizes/PrizeActionsSpec.ts
@@ -1,0 +1,33 @@
+import fetchMock from 'fetch-mock';
+import thunk, { ThunkDispatch } from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import Endpoints from '../Endpoints';
+import { fetchPrizes } from './PrizeActions';
+import { AnyAction } from 'redux';
+import { StoreState } from '../Store';
+
+type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
+
+const mockStore = configureMockStore<StoreState, DispatchExts>([thunk]);
+
+describe('PrizeActions', () => {
+  let store: ReturnType<typeof mockStore>;
+
+  beforeEach(() => {
+    store = mockStore();
+  });
+
+  describe('#fetchPrizes', () => {
+    it('works with a numeric event id', () => {
+      fetchMock.once(`${Endpoints.SEARCH}?event=1&type=prize`, 200);
+      store.dispatch(fetchPrizes({ event: '1' }));
+      expect(fetchMock.called()).toBe(true);
+    });
+
+    it('works with an event shortname', () => {
+      fetchMock.once(`${Endpoints.SEARCH}?eventshort=test&type=prize`, 200);
+      store.dispatch(fetchPrizes({ event: 'test' }));
+      expect(fetchMock.called()).toBe(true);
+    });
+  });
+});

--- a/bundles/tracker/prizes/PrizeTypes.ts
+++ b/bundles/tracker/prizes/PrizeTypes.ts
@@ -62,6 +62,7 @@ export type PrizeSearchFilter = {
   name?: string;
   // maps to `prize.eventId`
   event?: string;
+  eventshort?: string;
 };
 
 export type PrizeAction =

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,7 @@ module.exports = function(config) {
     },
     files: [
       'bundles/**/*Spec.js',
+      'bundles/**/*Spec.ts',
       'bundles/**/*Spec.tsx',
       'bundles/**/*.spec.tsx',
       'bundles/**/*.spec.ts',
@@ -20,6 +21,7 @@ module.exports = function(config) {
     ],
     preprocessors: {
       'bundles/**/*Spec.js': ['webpack'],
+      'bundles/**/*Spec.ts': ['webpack'],
       'bundles/**/*Spec.tsx': ['webpack'],
       'bundles/**/*.spec.tsx': ['webpack'],
       'bundles/**/*.spec.ts': ['webpack'],

--- a/spec/fixtures/event.ts
+++ b/spec/fixtures/event.ts
@@ -1,0 +1,28 @@
+import { Event } from '../../bundles/tracker/events/EventTypes';
+
+export function getFixtureEvent(overrides?: Partial<Event>): Event {
+  return {
+    id: '1',
+    short: 'test',
+    name: 'Test Event',
+    canonicalUrl: '/testserver/tracker/events/1',
+    public: 'Test Event',
+    useOneStepScreening: false,
+    timezone: 'America/New_York',
+    locked: false,
+    paypalEmail: 'paypal@example.com',
+    paypalCurrency: 'USB',
+    paypalImgurl: '',
+    targetAmount: 5000,
+    allowDonations: true,
+    minimumDonation: 5,
+    allowedPrizeCountries: [],
+    disallowedPrizeRegions: [],
+    prizeAcceptDeadlineDelta: 30,
+    amount: 0,
+    count: 0,
+    max: 0,
+    avg: 0,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170536322
https://www.pivotaltracker.com/story/show/170559076

### Description of the Change

Two bugs were here and compounding each other. Firstly, for some reason the prize link on the donate page was using the wrong variable, so it was using `/undefined/` instead of `/1/`, but also the donate page supports using the event short name, e.g. `/test/` instead of `/1/`, which was producing a link to the prizes page that was also using the short name, but various pieces of the prize code did not know how to deal with a short name.

e.g.

`http://localhost:8080/tracker/ui/events/test/prizes`

should work just as well as

`http://localhost:8080/tracker/ui/events/1/prizes`

### Verification Process

Verified that opening the new prize url worked with either the numeric id or the short name.