### PR TITLE
bids are ordered explicitly on new donate page

### DIFF
--- a/bundles/tracker/donation/__tests__/Donate.spec.tsx
+++ b/bundles/tracker/donation/__tests__/Donate.spec.tsx
@@ -94,10 +94,24 @@ describe('Donate', () => {
       const store = createStore();
       store.dispatch(
         EventDetailsActions.loadIncentives([
-          { id: 1, name: 'an incentive', amount: 0, runname: 'some run' },
-          { id: 2, name: 'an incentive with children', amount: 0, runname: 'some run', custom: true },
-          { id: 3, name: 'child 1', parent: { id: 2, name: 'parent', custom: true }, amount: 0, runname: 'some run' },
-          { id: 4, name: 'child 2', parent: { id: 2, name: 'parent', custom: true }, amount: 0, runname: 'some run' },
+          { id: 1, name: 'an incentive', amount: 0, runname: 'some run', order: 1 },
+          { id: 2, name: 'an incentive with children', amount: 0, runname: 'some run', custom: true, order: 1 },
+          {
+            id: 3,
+            name: 'child 1',
+            parent: { id: 2, name: 'parent', custom: true },
+            amount: 0,
+            runname: 'some run',
+            order: 1,
+          },
+          {
+            id: 4,
+            name: 'child 2',
+            parent: { id: 2, name: 'parent', custom: true },
+            amount: 0,
+            runname: 'some run',
+            order: 1,
+          },
         ]),
       );
 

--- a/bundles/tracker/donation/__tests__/validateBid.spec.ts
+++ b/bundles/tracker/donation/__tests__/validateBid.spec.ts
@@ -10,6 +10,7 @@ const basicIncentive: Incentive = {
   parent: undefined,
   runname: 'the run',
   custom: false,
+  order: 1,
 };
 
 const incentiveWithOptions: Incentive = {
@@ -21,6 +22,7 @@ const incentiveWithOptions: Incentive = {
   maxlength: 12,
   custom: false,
   description: 'idk i need an incentive',
+  order: 2,
 };
 
 const incentiveWithOptionsAsParent = {
@@ -37,6 +39,7 @@ const incentiveOption1: Incentive = {
   parent: incentiveWithOptionsAsParent,
   amount: 50.0,
   runname: 'idk',
+  order: 3,
 };
 
 const donation: Donation = {

--- a/bundles/tracker/donation/components/DonateInitializer.tsx
+++ b/bundles/tracker/donation/components/DonateInitializer.tsx
@@ -29,6 +29,7 @@ type DonateInitializerProps = {
     };
     name: string;
     runname: string;
+    order: number;
     amount: string; // TODO: this and goal should be numbers but django seems to be serializing them as strings?
     count: number;
     goal?: string;

--- a/bundles/tracker/event_details/EventDetailsStore.ts
+++ b/bundles/tracker/event_details/EventDetailsStore.ts
@@ -21,7 +21,7 @@ export const getIncentive = createSelector(
 
 export const getTopLevelIncentives = createSelector(
   [getIncentives],
-  incentives => incentives.filter(incentive => !incentive.parent),
+  incentives => incentives.filter(incentive => !incentive.parent).sort((a, b) => a.order - b.order),
 );
 
 export const getChildIncentives = createSelector(

--- a/bundles/tracker/event_details/EventDetailsStoreSpec.ts
+++ b/bundles/tracker/event_details/EventDetailsStoreSpec.ts
@@ -1,0 +1,23 @@
+import { getTopLevelIncentives } from './EventDetailsStore';
+import { combinedReducer, StoreState } from '../Store';
+import { getFixtureBid } from '../../../spec/fixtures/bid';
+
+describe('EventDetailsStore', () => {
+  const bid1 = getFixtureBid({ id: 1, order: 50 });
+  const bid2 = getFixtureBid({ id: 2, order: 3 });
+  let state: StoreState;
+
+  beforeEach(() => {
+    state = combinedReducer(undefined, { type: 'INIT' });
+    state = {
+      ...state,
+      eventDetails: { ...state.eventDetails, availableIncentives: { '1': bid1, '2': bid2 } },
+    };
+  });
+
+  describe('#getTopLevelIncentives', () => {
+    it('returns top-level incentives in order', () => {
+      expect(getTopLevelIncentives(state)).toEqual([bid2, bid1]);
+    });
+  });
+});

--- a/bundles/tracker/event_details/EventDetailsTypes.ts
+++ b/bundles/tracker/event_details/EventDetailsTypes.ts
@@ -11,6 +11,7 @@ export type Incentive = {
     description?: string;
   };
   runname: string;
+  order: number;
   count?: number;
   goal?: number;
   description?: string;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,7 @@ module.exports = function(config) {
     },
     files: [
       'bundles/**/*Spec.js',
+      'bundles/**/*Spec.ts',
       'bundles/**/*Spec.tsx',
       'bundles/**/*.spec.tsx',
       'bundles/**/*.spec.ts',
@@ -20,6 +21,7 @@ module.exports = function(config) {
     ],
     preprocessors: {
       'bundles/**/*Spec.js': ['webpack'],
+      'bundles/**/*Spec.ts': ['webpack'],
       'bundles/**/*Spec.tsx': ['webpack'],
       'bundles/**/*.spec.tsx': ['webpack'],
       'bundles/**/*.spec.ts': ['webpack'],

--- a/spec/fixtures/bid.ts
+++ b/spec/fixtures/bid.ts
@@ -1,0 +1,12 @@
+import { Incentive } from '../../bundles/tracker/event_details/EventDetailsTypes';
+
+export function getFixtureBid(overrides?: Partial<Incentive>): Incentive {
+  return {
+    id: 1,
+    name: 'Test Incentive',
+    amount: 0,
+    runname: 'Test Run',
+    order: 1,
+    ...overrides,
+  };
+}

--- a/ui/views.py
+++ b/ui/views.py
@@ -120,8 +120,10 @@ def donate(request, event):
         }
         if bid.speedrun:
             result['runname'] = bid.speedrun.name
+            result['order'] = bid.speedrun.order
         else:
             result['runname'] = 'Event Wide'
+            result['order'] = 0
         if bid.allowuseroptions:
             result['custom'] = True
             result['maxlength'] = bid.option_max_length

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const packageJSON = require('./package');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const PROD = process.env.NODE_ENV === 'production';
+const SOURCE_MAPS = +(process.env.SOURCE_MAPS || 0);
 
 console.log(PROD ? 'PRODUCTION BUILD' : 'DEVELOPMENT BUILD');
 
@@ -126,5 +127,5 @@ module.exports = {
       NODE_ENV: 'development',
     }),
   ],
-  devtool: PROD ? 'source-map' : 'eval-source-map',
+  devtool: SOURCE_MAPS ? (PROD ? 'source-map' : 'eval-source-map') : false,
 };


### PR DESCRIPTION
- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170811124

### Description of the Change

The older donate form used the implicit ordering from the server to show incentives in the "right" order, but with the change to the data shape that got lost. This puts it back.

### Verification Process

It was live on the GDQ site during AGDQ2020.