### PR TITLE
remove availableNow section from prize page

### DIFF
--- a/bundles/tracker/prizes/components/Prizes.tsx
+++ b/bundles/tracker/prizes/components/Prizes.tsx
@@ -58,8 +58,7 @@ const Prizes = (props: PrizesProps) => {
 
   const [loadingPrizes, setLoadingPrizes] = React.useState(false);
 
-  const { availableNow, closingPrizes, allPrizes, event } = useSelector((state: StoreState) => ({
-    availableNow: PrizeStore.getPrizesOpeningSoon(state, { targetTime: now }).slice(0, FEATURED_SECTION_LIMIT),
+  const { closingPrizes, allPrizes, event } = useSelector((state: StoreState) => ({
     closingPrizes: PrizeStore.getPrizesClosingSoon(state, { targetTime: now }).slice(0, FEATURED_SECTION_LIMIT),
     allPrizes: PrizeStore.getSortedPrizes(state),
     event: EventStore.getEvent(state, { eventId }),
@@ -103,12 +102,6 @@ const Prizes = (props: PrizesProps) => {
           {closingPrizes.length > 0 && (
             <React.Fragment>
               <PrizeGrid prizes={closingPrizes} name="Closing Soon!" />
-              <hr className={styles.divider} />
-            </React.Fragment>
-          )}
-          {availableNow.length > 0 && (
-            <React.Fragment>
-              <PrizeGrid prizes={availableNow} name="Available Now" />
               <hr className={styles.divider} />
             </React.Fragment>
           )}


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170888472

### Description of the Change

Removed the 'available now' section from the prize page. After seeing it live at the event, we came to decision it wasn't actually all that helpful compared to the much more interesting "closing soon". Maybe we can bring it back in another form later.

### Verification Process

Live during AGDQ2020.