### PR TITLE
remove misc deprecation warnings for 2.x

### DIFF
--- a/feeds/runs_calendar.py
+++ b/feeds/runs_calendar.py
@@ -1,14 +1,14 @@
-from django.core.urlresolvers import reverse
 from django.http import Http404
-
+from django.urls import reverse
 from django_ical.views import ICalFeed
 
-from tracker.models.event import SpeedRun
 from tracker import viewutil
-
+from tracker.models.event import SpeedRun
 
 # Reference the properties used by django-ical:
 # https://django-ical.readthedocs.io/en/latest/usage.html#property-reference-and-extensions
+
+
 class RunsCalendar(ICalFeed):
     """A calendar feed for an event's runs. """
 

--- a/lookups.py
+++ b/lookups.py
@@ -1,8 +1,8 @@
 from ajax_select import LookupChannel
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.db.models import Q
+from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 

--- a/models/donation.py
+++ b/models/donation.py
@@ -4,11 +4,11 @@ from functools import reduce
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Count, Sum, Max, Avg
 from django.db.models import signals
 from django.dispatch import receiver
+from django.urls import reverse
 from django.utils import timezone
 
 from .fields import OneToOneOrNoneField

--- a/models/prize.py
+++ b/models/prize.py
@@ -5,11 +5,11 @@ import pytz
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Sum, Q
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
+from django.urls import reverse
 
 from tracker import util
 from tracker.models import Event, Donation, SpeedRun

--- a/prizemail.py
+++ b/prizemail.py
@@ -5,8 +5,8 @@ import os
 import post_office.mail
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
 from django.db.models import Q, F
+from django.urls import reverse
 
 import tracker.viewutil as viewutil
 from tracker.models import Prize, PrizeWinner

--- a/templates/tracker/partials/language.html
+++ b/templates/tracker/partials/language.html
@@ -2,7 +2,7 @@
 
 
 <div class="footer">
-<!--<form action="{% url 'tracker:i18n:set_language' %}" method="post">
+<!--<form action="{% url 'tracker:set_language' %}" method="post">
 <div>
 <input name="next" type="hidden" value="{{ next }}" />
 <label for="language">{% trans "Choose Language" %}</label>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,8 +2,8 @@ import random
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.urls import reverse
 
 from tracker import randgen, models
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -622,9 +622,7 @@ class TestRunner(APITestCase):
         )
         request.user = self.add_user
         data = self.parseJSON(tracker.views.api.add(request), status_code=400)
-        self.assertRegexpMatches(
-            data['messages'][0], 'case-insensitive.*already exists'
-        )
+        self.assertRegex(data['messages'][0], 'case-insensitive.*already exists')
 
     def test_search_by_event(self):
         request = self.factory.get(

--- a/tests/test_bid.py
+++ b/tests/test_bid.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
+from django.urls import reverse
 
 from tracker import models
 from .util import today_noon

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -5,12 +5,12 @@ from decimal import Decimal
 import pytz
 from django import template
 from django.contrib.auth.models import AnonymousUser, User
-from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 from django.test import TransactionTestCase
+from django.urls import reverse
 
-from .util import today_noon
 from tracker import models, views, randgen, viewutil
+from .util import today_noon
 from ..templatetags.donation_tags import donor_link
 
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -3,12 +3,13 @@ import io
 import random
 
 import pytz
+from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.urls import reverse
 
-from .util import today_noon, tomorrow_noon, long_ago_noon
 from tracker import models
+from .util import today_noon, tomorrow_noon, long_ago_noon
 from .. import randgen
 
 
@@ -40,10 +41,10 @@ class TestEventAdmin(TestCase):
         self.super_user = User.objects.create_superuser(
             'admin', 'admin@example.com', 'password'
         )
-        timezone = pytz.timezone('America/New_York')
+        timezone = pytz.timezone(settings.TIME_ZONE)
         self.event = models.Event.objects.create(
             targetamount=5,
-            datetime=timezone.localize(today_noon),
+            datetime=today_noon,
             timezone=timezone,
             name='test event',
             short='test',

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -7,12 +7,12 @@ from dateutil.parser import parse as parse_date
 from django.contrib.admin import ACTION_CHECKBOX_NAME
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test import TransactionTestCase
+from django.urls import reverse
 
-from .util import today_noon, MigrationsTestCase
 from tracker import models, prizeutil, randgen
+from .util import today_noon, MigrationsTestCase
 
 
 class TestPrizeGameRange(TransactionTestCase):

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,7 +2,9 @@ import datetime
 import json
 import random
 
+import pytz
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User, Permission
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection
@@ -32,11 +34,17 @@ def parse_test_mail(mail):
 
 noon = datetime.time(12, 0)
 today = datetime.date.today()
-today_noon = datetime.datetime.combine(today, noon)
+today_noon = datetime.datetime.combine(today, noon).astimezone(
+    pytz.timezone(settings.TIME_ZONE)
+)
 tomorrow = today + datetime.timedelta(days=1)
-tomorrow_noon = datetime.datetime.combine(tomorrow, noon)
+tomorrow_noon = datetime.datetime.combine(tomorrow, noon).astimezone(
+    pytz.timezone(settings.TIME_ZONE)
+)
 long_ago = today - datetime.timedelta(days=180)
-long_ago_noon = datetime.datetime.combine(long_ago, noon)
+long_ago_noon = datetime.datetime.combine(long_ago, noon).astimezone(
+    pytz.timezone(settings.TIME_ZONE)
+)
 
 
 class MigrationsTestCase(TestCase):

--- a/ui/views.py
+++ b/ui/views.py
@@ -4,9 +4,9 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.core import serializers
-from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.shortcuts import render
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_protect

--- a/urls.py
+++ b/urls.py
@@ -19,7 +19,7 @@ from tracker.views import public, api, donateviews, user, auth
 app_name = 'tracker'
 urlpatterns = [
     url(r'^ui/', include(ui_urls, namespace='ui')),
-    url(r'^i18n/', include('django.conf.urls.i18n', namespace='i18n')),
+    url(r'^i18n/', include('django.conf.urls.i18n')),
     url(r'^bids/(?P<event>\w+|)$', public.bidindex, name='bidindex'),
     url(r'^bid/(?P<id>-?\d+)$', public.bid, name='bid'),
     url(r'^donors/(?P<event>\w+|)$', public.donorindex, name='donorindex'),
@@ -68,9 +68,7 @@ urlpatterns = [
         name='login',
     ),
     url(
-        r'^user/logout/$',
-        LogoutView.as_view(next_page='tracker:login'),
-        name='logout',
+        r'^user/logout/$', LogoutView.as_view(next_page='tracker:login'), name='logout',
     ),
     url(
         r'^user/password_reset/$',
@@ -103,7 +101,10 @@ urlpatterns = [
     ),
     url(
         r'^user/password_change/$',
-        PasswordChangeView.as_view(template_name='tracker/password_change.html', success_url=reverse_lazy('tracker:password_change_done')),
+        PasswordChangeView.as_view(
+            template_name='tracker/password_change.html',
+            success_url=reverse_lazy('tracker:password_change_done'),
+        ),
         name='password_change',
     ),
     url(

--- a/views/donateviews.py
+++ b/views/donateviews.py
@@ -8,9 +8,9 @@ from decimal import Decimal
 import post_office.mail
 import pytz
 from django.core import serializers
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import HttpResponse, Http404
+from django.urls import reverse
 from django.views.decorators.cache import never_cache, cache_page
 from django.views.decorators.csrf import csrf_exempt
 from paypal.standard.forms import PayPalPaymentsForm

--- a/views/public.py
+++ b/views/public.py
@@ -2,12 +2,12 @@ import json
 
 import django.core.paginator as paginator
 from django.core import serializers
-from django.core.urlresolvers import reverse
 from django.db.models import Count, Sum, Max, Avg, F
 from django.http import (
     HttpResponse,
     HttpResponseRedirect,
 )
+from django.urls import reverse
 from django.views.decorators.cache import cache_page
 
 import tracker.search_filters as filters

--- a/viewutil.py
+++ b/viewutil.py
@@ -4,10 +4,10 @@ from functools import reduce
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404
+from django.urls import reverse
 
 from tracker import search_filters
 from tracker.models import Donor, Event, Log

--- a/volunteer.py
+++ b/volunteer.py
@@ -1,13 +1,13 @@
 import csv
 
-from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
+from django.urls import reverse
 
-from tracker import viewutil
 from tracker import auth
+from tracker import viewutil
 
 AuthUser = get_user_model()
 

--- a/widgets.py
+++ b/widgets.py
@@ -13,7 +13,7 @@ class MegaFilterWidget(forms.widgets.Widget):
         else:
             return None
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         return format_html(
             """
     <div class="mf_widget mf_model_{0}">


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170941062

### Description of the Change

This one fixes the remaining 2.x runtime warnings that I could find.

The only behavior change is for how add/edit sets M2M relationships, and how the `set_lang` url is generated (though it's currently commented out, maybe I should have just deleted it).

### Verification Process

The only "user" facing behavior change is how runners are set on a run via the api, so I used a `fetch` in the console to make sure you could still write M2M this way.

```
formData = new FormData();
formData.append('type', 'run');
formData.append('id', 'nnn');
formData.append('runners', 'x,y');
fetch('/tracker/api/v1/edit/', {method: 'POST', credentials: 'same-origin', body: formData}).then(response => response.json()).then(json => console.log(json));
```