### PR TITLE
check_migrations can run without toplevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.mo
 *.pyc
 *.swp
+*.sqlite
 build
 *.egg-info
 .webpack_build_cache/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,10 +72,8 @@ jobs:
         displayName: 'Install node prerequisites'
 
       - script: |
-          pushd '$(projectRoot)'
-          mkdir db
-          python manage.py migrate tracker
-          python manage.py makemigrations --check --dry-run tracker
+          cd tracker
+          python check_migrations.py
         displayName: 'Check for bad or missing migrations'
 
       - script: |

--- a/check_migrations.py
+++ b/check_migrations.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+
+if __name__ == '__main__':
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
+    # TODO: need to move tracker into a subfolder so this isn't necessary
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    django.setup()
+
+    from django.core import management
+    from django.core.management.commands import migrate
+    from django.core.management.commands import makemigrations
+
+    management.call_command(migrate.Command())
+    management.call_command(makemigrations.Command(), check=True, dry_run=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,7 +19,7 @@ INSTALLED_APPS = [
     'mptt',
 ]
 DATABASES = {
-    'default': {'ENGINE': 'django.db.backends.sqlite3',},
+    'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'testdb.sqlite',},
 }
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(os.path.dirname(__file__), 'static')


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
~~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~~

It's a CI change.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170943298

### Description of the Change

The "check migrations" step currently relies on an external environment to be able to work. This fixes that by providing a script that does a similar setup to `runtests`.

### Verification Process

Checked it out into its own repo without top level and ran the script, both with the normal migrations and with a deliberately busted migration, saw failures. Pushed a deliberately broken branch to CI, waited for it to fail.