### PR TITLE
bump django-paypal to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.27
 django-ajax-selects==1.9.0
 django-betterforms==1.1.4
 django-ical==1.7.0
-django-paypal==0.5.0
+django-paypal==1.0.0
 django-mptt==0.10.0
 django-post-office==3.2.1
 django-timezone-field==3.1


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170958143

### Description of the Change

Dependency bump. This one is important enough that I tested it by hand.

### Verification Process

Booted up the dev server, started a donation with multiple bids (and bid types), then when I got to the sandbox, I instead loaded up the IPN Simulator and sent a notification to clear the donation. All worked as I expected once I got the values right. IPNs have a lot of fields, sheesh.