### PR TITLE
fix/clean up search annotations

### DIFF
--- a/search_filters.py
+++ b/search_filters.py
@@ -37,8 +37,6 @@ _ModelMap = {
 _ModelDefaultQuery = {
     'bidtarget': Q(allowuseroptions=True) | Q(options__isnull=True, istarget=True),
     'bid': Q(level=0),
-    # TODO: where is this used? it causes an event to not show up if there's only pending donations and that is pretty weird
-    'event': Q(donation=None) | Q(donation__transactionstate='COMPLETED'),
 }
 
 _ModelReverseMap = {v: k for k, v in _ModelMap.items()}
@@ -432,7 +430,7 @@ _1ToManyDonationAggregateFilter = Q(donation__transactionstate='COMPLETED')
 DonationBidAggregateFilter = _1ToManyDonationAggregateFilter
 DonorAggregateFilter = _1ToManyDonationAggregateFilter
 EventAggregateFilter = _1ToManyDonationAggregateFilter
-PrizeWinnersFilter = Q(prizewinner__acceptcount_gt=0) | Q(
+PrizeWinnersFilter = Q(prizewinner__acceptcount__gt=0) | Q(
     prizewinner__pendingcount__gt=0
 )
 _1ToManyBidsAggregateFilter = Q(bids__donation__transactionstate='COMPLETED')

--- a/tests/util.py
+++ b/tests/util.py
@@ -122,7 +122,7 @@ class APITestCase(TransactionTestCase):
                 'Could not parse json: %s\n"""%s"""' % (e, response.content)
             )
 
-    def assertModelPresent(self, expected_model, data):
+    def assertModelPresent(self, expected_model, data, partial=False):
         found_model = None
         for model in data:
             if (
@@ -136,9 +136,12 @@ class APITestCase(TransactionTestCase):
                 'Could not find model "%s:%s" in data'
                 % (expected_model['model'], expected_model['pk'])
             )
-        extra_keys = set(found_model['fields'].keys()) - set(
-            expected_model['fields'].keys()
-        )
+        if partial:
+            extra_keys = []
+        else:
+            extra_keys = set(found_model['fields'].keys()) - set(
+                expected_model['fields'].keys()
+            )
         missing_keys = set(expected_model['fields'].keys()) - set(
             found_model['fields'].keys()
         )


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170960443

### Description of the Change

A few layered changes here.

Firstly, it's fixing a bug where events that had donations, but no cleared donations, would not show up in an event search.

Secondly, the `numwinners` field on prize searches wasn't accurate, as it was included people who had declined a prize, when it shouldn't.

Thirdly, the annotations were all coming back as strings when it should be numbers. This was also true of hitting `/event/n?json`

### Verification Process

Hit the search endpoints and the `?json` endpoint and made sure they were returning correct, numeric values.