### PR TITLE
restore donor.contact_name because it is used by email templates

### DIFF
--- a/models/donation.py
+++ b/models/donation.py
@@ -357,6 +357,13 @@ class Donor(models.Model):
         if not self.paypalemail:
             self.paypalemail = None
 
+    def contact_name(self):
+        if self.firstname:
+            return self.firstname + ' ' + self.lastname
+        if self.alias:
+            return self.alias
+        return self.email
+
     ANONYMOUS = '(Anonymous)'
 
     def cache_for(self, event_id=None):

--- a/tests/test_prizemail.py
+++ b/tests/test_prizemail.py
@@ -18,6 +18,7 @@ class TestAutomailPrizeWinners(TransactionTestCase):
     emailTemplate = """
   EVENT:{{ event.id }}
   WINNER:{{ winner.id }}
+  WINNER_CONTACT_NAME:{{ winner.contact_name }}
   {% for prize_winner in prize_wins %}
     PRIZE: {{ prize_winner.prize.id }}
   {% endfor %}
@@ -25,31 +26,35 @@ class TestAutomailPrizeWinners(TransactionTestCase):
 
     def setUp(self):
         self.rand = random.Random(None)
-        self.numDonors = 60
-        self.numPrizes = 40
+        self.num_donors = 60
+        self.num_prizes = 40
         self.event = randgen.build_random_event(
-            self.rand, num_runs=20, num_prizes=self.numPrizes, num_donors=self.numDonors
+            self.rand,
+            num_runs=20,
+            num_prizes=self.num_prizes,
+            num_donors=self.num_donors,
         )
-        self.templateEmail = post_office.models.EmailTemplate.objects.create(
+        self.template_email = post_office.models.EmailTemplate.objects.create(
             name='testing_prize_winner_notification',
             description='',
             subject='You Win!',
             content=self.emailTemplate,
         )
 
-    def _parseMail(self, mail):
+    def _parse_mail(self, mail):
         contents = test_util.parse_test_mail(mail)
         event = int(contents['event'][0])
         winner = int(contents['winner'][0])
+        contact_name = contents['winner_contact_name'][0]
         prizes = [int(p) for p in contents.get('prize', [])]
-        return event, winner, prizes
+        return event, winner, contact_name, prizes
 
     def testAutoMail(self):
         models.Prize.objects.update(state='ACCEPTED')
         donors = list(models.Donor.objects.all())
         prizes = list(models.Prize.objects.all())
-        fullWinnerList = []
-        donorWins = {}
+        full_winner_list = []
+        donor_wins = {}
         for prize in prizes:
             if self.rand.getrandbits(1) == 0:
                 winners = []
@@ -58,40 +63,46 @@ class TestAutomailPrizeWinners(TransactionTestCase):
                     if d not in winners:
                         winners.append(d)
                 for winner in winners:
-                    fullWinnerList.append(
+                    full_winner_list.append(
                         models.PrizeWinner.objects.create(
                             winner=winner, prize=prize, pendingcount=1
                         )
                     )
-                    donorPrizeList = donorWins.get(winner.id, None)
-                    if donorPrizeList is None:
-                        donorPrizeList = []
-                    donorWins[winner.id] = donorPrizeList
-                    donorPrizeList.append(prize)
+                    donor_prize_list = donor_wins.get(winner.id, None)
+                    if donor_prize_list is None:
+                        donor_prize_list = []
+                    donor_wins[winner.id] = donor_prize_list
+                    donor_prize_list.append(prize)
 
         self.assertSetEqual(
             {pw.id for pw in prizemail.prize_winners_with_email_pending(self.event)},
-            {pw.id for pw in fullWinnerList},
+            {pw.id for pw in full_winner_list},
         )
         prizemail.automail_prize_winners(
-            self.event, fullWinnerList, self.templateEmail, sender='nobody@nowhere.com'
+            self.event,
+            full_winner_list,
+            self.template_email,
+            sender='nobody@nowhere.com',
         )
 
-        for prizeWinner in fullWinnerList:
+        for prizeWinner in full_winner_list:
             self.assertTrue(prizeWinner.emailsent)
         for donor in donors:
-            wonPrizes = donorWins.get(donor.id, [])
-            donorMail = post_office.models.Email.objects.filter(to=donor.email)
-            if len(wonPrizes) == 0:
-                self.assertEqual(0, donorMail.count())
+            won_prizes = donor_wins.get(donor.id, [])
+            donor_mail = post_office.models.Email.objects.filter(to=donor.email)
+            if len(won_prizes) == 0:
+                self.assertEqual(0, donor_mail.count())
             else:
-                self.assertEqual(1, donorMail.count())
-                eventId, winnerId, prizeIds = self._parseMail(donorMail[0])
-                self.assertEqual(self.event.id, eventId)
-                self.assertEqual(donor.id, winnerId)
-                self.assertEqual(len(wonPrizes), len(prizeIds))
-                for prize in wonPrizes:
-                    self.assertTrue(prize.id in prizeIds)
+                self.assertEqual(1, donor_mail.count())
+                event_id, winner_id, contact_name, prize_ids = self._parse_mail(
+                    donor_mail[0]
+                )
+                self.assertEqual(self.event.id, event_id)
+                self.assertEqual(donor.id, winner_id)
+                self.assertEqual(donor.contact_name(), contact_name)
+                self.assertEqual(len(won_prizes), len(prize_ids))
+                for prize in won_prizes:
+                    self.assertTrue(prize.id in prize_ids)
 
 
 class TestAutomailPrizeContributors(TransactionTestCase):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/171169650

### Description of the Change

Part of the great api/security purge caught this up because it wasn't referenced in the code or tests anywhere, but it IS used by the default email templates and sadly PyCharm is not an infallible oracle and didn't pick up on that.

This just puts it back and adds a test so it'll be harder to do it by accident next time.

### Verification Process

https://twitter.com/0xabad1dea/status/1225448597023580160

We had to send out prize emails this week and sadly a bunch of them went out with mangled slugs.

I cherry-picked this into the live server and sent one email to make sure it was fixed.