### PR TITLE
add prize winner mail preview

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.core import validators
 from django.forms import formset_factory, modelformset_factory
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -613,11 +614,15 @@ class AutomailPrizeWinnersForm(forms.Form):
                     prizewinner.id,
                     mark_safe(
                         format_html(
-                            '<a href="{0}">{1}</a>: <a href="{2}">{3}</a>',
+                            '<a href="{0}">{1}</a>: <a href="{2}">{3}</a> <a href="{4}">Preview</a>',
                             viewutil.admin_url(prize),
                             prize,
                             viewutil.admin_url(winner),
                             winner,
+                            reverse(
+                                'admin:preview_prize_winner_mail',
+                                args=(prizewinner.id,),
+                            ),
                         )
                     ),
                 )
@@ -632,11 +637,11 @@ class AutomailPrizeWinnersForm(forms.Form):
         )
 
     def clean(self):
-        if not self.cleaned_data['replyaddress']:
+        if not self.cleaned_data.get('replyaddress', ''):
             self.cleaned_data['replyaddress'] = self.cleaned_data['fromaddress']
         self.cleaned_data['prizewinners'] = [
             models.PrizeWinner.objects.get(id=pw)
-            for pw in self.cleaned_data['prizewinners']
+            for pw in self.cleaned_data.get('prizewinners', [])
         ]
         return self.cleaned_data
 

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -1616,6 +1616,13 @@ class TestPrizeAdmin(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_prize_mail_preview(self):
+        self.client.login(username='admin', password='password')
+        response = self.client.get(
+            reverse('admin:preview_prize_winner_mail', args=(self.prize_winner.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 class TestPrizeList(TestCase):
     def setUp(self):

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -2,6 +2,7 @@ import datetime
 import random
 from decimal import Decimal
 
+import post_office.models
 import pytz
 from dateutil.parser import parse as parse_date
 from django.contrib.admin import ACTION_CHECKBOX_NAME
@@ -1622,6 +1623,7 @@ class TestPrizeAdmin(TestCase):
             reverse('admin:preview_prize_winner_mail', args=(self.prize_winner.id,))
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(post_office.models.Email.objects.count(), 0)
 
 
 class TestPrizeList(TestCase):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/162806081

### Description of the Change

There's no good way to preview certain emails that get sent out from the admin panel. This fixes one of them.

### Verification Process

Made a test prize, assigned a winner, made sure the preview link worked and didn't actually send an email.