### PR TITLE
read and process donations send correct parameters

### DIFF
--- a/templates/admin/process_donations.html
+++ b/templates/admin/process_donations.html
@@ -74,8 +74,8 @@ function addRow(donation) {
 
 function runSearch() {
 
-  searchParams = {
-
+  var searchParams = {
+    all_comments: "",
   };
 
   {% if user_can_approve and not currentEvent.use_one_step_screening %}
@@ -97,7 +97,7 @@ function runSearch() {
   $("#id_loading").html("Loading...");
 
   trackerAPI.searchObjects("donation", searchParams, function(status, responseText) {
-    if (status == 200) {
+    if (status === 200) {
       partition = partitioner.getPartition();
 
       var resultsTable = $("#id_result_set");
@@ -115,7 +115,7 @@ function runSearch() {
       var language = $(partitionLanguageElem).val();
 
       for (var i in donations) {
-        if (donations[i]["pk"] % partition[1] == (partition[0] - 1) && (language == 'all' || donations[i]['fields']["commentlanguage"] == language))
+        if (donations[i]["pk"] % partition[1] === (partition[0] - 1) && (language === 'all' || donations[i]['fields']["commentlanguage"] === language))
         {
           addRow(donations[i]);
         }

--- a/templates/admin/read_donations.html
+++ b/templates/admin/read_donations.html
@@ -80,9 +80,9 @@ function addRow(donation) {
 }
 
 function runSearch() {
-
-  searchParams = {
-    feed : "toread",
+  var searchParams = {
+    feed: "toread",
+    all_comments: "",
   };
 
   {% if currentEvent %}


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/171428558

### Description of the Change

"Process donations" was getting nothing but `undefined` for donation comments, and read donations would get the same if you pinned a donation (because the pin is still a hack). I changed the API recently to require an explicit parameter to get all comments but forgot to add it to these pages. This fixes that.

### Verification Process

Took a donation, marked it pending, made sure it was showing `undefined` without the fix, but working correctly with the fix. Did the same for pinning a comment.