### PR TITLE
send correct email for password reset requests

### DIFF
--- a/templates/tracker/email/password_reset.html
+++ b/templates/tracker/email/password_reset.html
@@ -1,11 +1,9 @@
-Hello {{ user }},
-<p>
-  You (or something pretending to be you) has requested a password reset for your account on {{ domain }}. Please follow
-  this <a href="{{ protocol }}://{{ domain }}{% url 'tracker:password_reset_confirm' uidb64=uid token=token %}">link</a> to reset your password.
-</p>
+<p>Hello {{ user }},</p>
 
-<p>
-  This login link will expire after you reset your password.
-</p>
+<p>You (or something pretending to be you) has requested a password reset for your account on {{ domain }}. Please
+  follow this <a href="{{ protocol }}://{{ domain }}{% url 'tracker:password_reset_confirm' uidb64=uid token=token %}">
+    link</a> to reset your password.</p>
 
-- The Staff
+<p>This login link will expire after you reset your password.</p>
+
+<p>- The Staff</p>

--- a/templates/tracker/email/password_reset.txt
+++ b/templates/tracker/email/password_reset.txt
@@ -1,0 +1,9 @@
+Hello {{ user }},
+
+You (or something pretending to be you) has requested a password reset for
+your account on {{ domain }}. Please follow the link below to reset your
+password.
+
+{{ protocol }}://{{ domain }}{% url 'tracker:password_reset_confirm' uidb64=uid token=token %}
+
+- The Staff

--- a/urls.py
+++ b/urls.py
@@ -72,7 +72,8 @@ urlpatterns = [
         'user/password_reset/',
         PasswordResetView.as_view(
             template_name='tracker/password_reset.html',
-            email_template_name='tracker/email/password_reset.html',
+            email_template_name='tracker/email/password_reset.txt',
+            html_email_template_name='tracker/email/password_reset.html',
             success_url=reverse_lazy('tracker:password_reset_done'),
         ),
         name='password_reset',


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [*] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/173863543

### Description of the Change

The way the email template for a password reset was specified incorrectly back in January. It appears that sendgrid's url protection parses the email incorrectly as a result, making clicking the link not work correctly. This adds a plain-text version of the email and correctly specifies the html version.

### Verification Process

Checked locally using the console output email backend, both versions of the email look good. Tried it on the GDQ server and the link in the resulting email is no longer getting mangled.