### PR TITLE
clean up extraneous list [#171302185]

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -534,9 +534,9 @@ class AutomailPrizeContributorsForm(forms.Form):
     def clean(self):
         if not self.cleaned_data['replyaddress']:
             self.cleaned_data['replyaddress'] = self.cleaned_data['fromaddress']
-        self.cleaned_data['prizes'] = list(
-            [models.Prize.objects.get(id=x) for x in self.cleaned_data['prizes']]
-        )
+        self.cleaned_data['prizes'] = [
+            models.Prize.objects.get(id=x) for x in self.cleaned_data['prizes']
+        ]
         return self.cleaned_data
 
 
@@ -570,9 +570,9 @@ class DrawPrizeWinnersForm(forms.Form):
         )
 
     def clean(self):
-        self.cleaned_data['prizes'] = list(
-            [models.Prize.objects.get(id=x) for x in self.cleaned_data['prizes']]
-        )
+        self.cleaned_data['prizes'] = [
+            models.Prize.objects.get(id=x) for x in self.cleaned_data['prizes']
+        ]
         return self.cleaned_data
 
 
@@ -702,12 +702,10 @@ class AutomailPrizeAcceptNotifyForm(forms.Form):
     def clean(self):
         if not self.cleaned_data['replyaddress']:
             self.cleaned_data['replyaddress'] = self.cleaned_data['fromaddress']
-        self.cleaned_data['prizewinners'] = list(
-            [
-                models.PrizeWinner.objects.get(id=x)
-                for x in self.cleaned_data['prizewinners']
-            ]
-        )
+        self.cleaned_data['prizewinners'] = [
+            models.PrizeWinner.objects.get(id=x)
+            for x in self.cleaned_data['prizewinners']
+        ]
         return self.cleaned_data
 
 
@@ -767,12 +765,10 @@ class AutomailPrizeShippingNotifyForm(forms.Form):
     def clean(self):
         if not self.cleaned_data['replyaddress']:
             self.cleaned_data['replyaddress'] = self.cleaned_data['fromaddress']
-        self.cleaned_data['prizewinners'] = list(
-            [
-                models.PrizeWinner.objects.get(id=x)
-                for x in self.cleaned_data['prizewinners']
-            ]
-        )
+        self.cleaned_data['prizewinners'] = [
+            models.PrizeWinner.objects.get(id=x)
+            for x in self.cleaned_data['prizewinners']
+        ]
         return self.cleaned_data
 
 
@@ -936,7 +932,7 @@ class PrizeAcceptanceForm(forms.ModelForm):
 
         self.fields['count'] = forms.ChoiceField(
             initial=self.instance.pendingcount,
-            choices=list([(x, x) for x in range(1, self.instance.pendingcount + 1)]),
+            choices=[(x, x) for x in range(1, self.instance.pendingcount + 1)],
             label='Count',
             help_text='You were selected to win more than one copy of this prize, please select how many you would like to take, or press Deny All if you do not want any of them.',
         )

--- a/management/commands/cache_giantbomb_info.py
+++ b/management/commands/cache_giantbomb_info.py
@@ -131,9 +131,7 @@ class Command(commandutil.TrackerCommand):
             name=str(searchResult['name']),
             giantbomb_id=searchResult['id'],
             release_year=parsedReleaseDate,
-            platforms=list(
-                [x['abbreviation'] for x in searchResult['platforms'] or []]
-            ),
+            platforms=[x['abbreviation'] for x in searchResult['platforms'] or []],
         )
 
     def process_query(self, run, searchResult):
@@ -248,13 +246,11 @@ class Command(commandutil.TrackerCommand):
         run.save()
 
     def filter_none_dates(self, entries):
-        return list(
-            [
-                entry
-                for entry in entries
-                if self.parse_query_results(entry)['release_year'] is not None
-            ]
-        )
+        return [
+            entry
+            for entry in entries
+            if self.parse_query_results(entry)['release_year'] is not None
+        ]
 
     def process_search(self, run, cleanedRunName, searchResults):
         exactMatches = []

--- a/management/commands/default_email_templates.py
+++ b/management/commands/default_email_templates.py
@@ -83,7 +83,7 @@ class Command(commandutil.TrackerCommand):
         self.prefix = options['prefix']
 
         if options['list']:
-            for option in list(_defaultTemplates.keys()):
+            for option in _defaultTemplates.keys():
                 self.message(option, 0)
             return
 
@@ -91,13 +91,11 @@ class Command(commandutil.TrackerCommand):
             self.templates = options['create']
 
         if options['create_all']:
-            self.templates = list(
-                map(email_template_name, list(_defaultTemplates.keys()))
-            )
+            self.templates = map(email_template_name, _defaultTemplates.keys())
 
-        self.templates = list(
-            [(x[0], x[1] or (options['prefix'] + x[0].name)) for x in self.templates]
-        )
+        self.templates = [
+            (x[0], x[1] or (options['prefix'] + x[0].name)) for x in self.templates
+        ]
 
         self.check_validity(self.templates, options['force'])
 

--- a/migrations/0001_squashed_0039_upgrade_to_19.py
+++ b/migrations/0001_squashed_0039_upgrade_to_19.py
@@ -38,7 +38,7 @@ def f0013_collect_prize_contributor_names(Prize, AuthUser):
     contributorNames = {}
     for prize in Prize.objects.all():
         if prize.provideremail:
-            if prize.provideremail not in list(contributorNames.keys()):
+            if prize.provideremail not in contributorNames.keys():
                 contributorNames[prize.provideremail] = collections.Counter()
             if prize.provided:
                 contributorNames[prize.provideremail][prize.provided.strip()] += 1
@@ -51,7 +51,7 @@ def f0013_guess_user_id(AuthUser, contributorEmail, contributorNameCounter):
 
     potentialTags = []
 
-    for name, count in list(contributorNameCounter.items()):
+    for name, count in contributorNameCounter.items():
         potentialTags.append((count, name))
 
     potentialTags.sort(reverse=True)
@@ -68,7 +68,7 @@ def f0013_guess_user_id(AuthUser, contributorEmail, contributorNameCounter):
 def f0013_ensure_existing_users(Prize, AuthUser):
     prizeContribCounts = f0013_collect_prize_contributor_names(Prize, AuthUser)
 
-    for contributorEmail, counterDict in list(prizeContribCounts.items()):
+    for contributorEmail, counterDict in prizeContribCounts.items():
         users = AuthUser.objects.filter(email=contributorEmail)
         if users.exists():
             user = users[0]

--- a/models/event.py
+++ b/models/event.py
@@ -25,7 +25,7 @@ __all__ = [
     'Submission',
 ]
 
-_timezoneChoices = list([(x, x) for x in pytz.common_timezones])
+_timezoneChoices = [(x, x) for x in pytz.common_timezones]
 _currencyChoices = (('USD', 'US Dollars'), ('CAD', 'Canadian Dollars'))
 
 

--- a/models/prize.py
+++ b/models/prize.py
@@ -342,14 +342,14 @@ class Prize(models.Model):
                         'amount': d[1],
                         'weight': weight(self.minimumbid, self.maximumbid, d[1]),
                     }
-                    for d in list(donors.items())
+                    for d in donors.items()
                     if self.minimumbid <= d[1]
                 ],
                 key=lambda d: d['donor'],
             )
 
         else:
-            m = max(list(donors.items()), key=lambda d: d[1])
+            m = max(donors.items(), key=lambda d: d[1])
             return [{'donor': m[0].id, 'amount': m[1], 'weight': 1.0}]
 
     def is_donor_allowed_to_receive(self, donor):
@@ -437,11 +437,9 @@ class Prize(models.Model):
         return sum(
             [
                 x
-                for x in list(
-                    self.get_prize_winners()
-                    .aggregate(Sum('pendingcount'), Sum('acceptcount'))
-                    .values()
-                )
+                for x in self.get_prize_winners()
+                .aggregate(Sum('pendingcount'), Sum('acceptcount'))
+                .values()
                 if x is not None
             ]
         )

--- a/prizemail.py
+++ b/prizemail.py
@@ -84,7 +84,7 @@ def automail_prize_winners(
 
     winnerDict = {}
     for prizeWinner in prizeWinners:
-        if prizeWinner.winner.id in list(winnerDict.keys()):
+        if prizeWinner.winner.id in winnerDict.keys():
             winList = winnerDict[prizeWinner.winner.id]
         else:
             winList = []
@@ -126,7 +126,7 @@ def automail_prize_winners(
             )
 
         message = 'Mailed donor {0} for prize wins {1}'.format(
-            winner.id, list([pw.id for pw in prizesWon])
+            winner.id, [pw.id for pw in prizesWon]
         )
 
         if verbosity > 0:
@@ -182,15 +182,15 @@ def automail_inactive_prize_handlers(
 ):
     sender, replyTo = event_sender_replyto_defaults(event, sender, replyTo)
     for inactiveUser in inactiveUsers:
-        eventPrizes = list(
-            Prize.objects.filter(handler=inactiveUser, event=event, state='ACCEPTED')
+        eventPrizes = Prize.objects.filter(
+            handler=inactiveUser, event=event, state='ACCEPTED'
         )
         formatContext = {
             'event': event,
             'handler': inactiveUser,
             'register_url': domain + reverse('tracker:register'),
             'prize_set': eventPrizes,
-            'prize_count': len(eventPrizes),
+            'prize_count': eventPrizes.count(),
             'reply_address': replyTo,
         }
         if not dry_run:
@@ -264,12 +264,10 @@ def automail_prize_contributors(
             'user_index_url': domain + reverse('tracker:user_index'),
             'event': event,
             'handler': handler,
-            'accepted_prizes': list(
-                [prize for prize in prizeList if prize.state == 'ACCEPTED']
-            ),
-            'denied_prizes': list(
-                [prize for prize in prizeList if prize.state == 'DENIED']
-            ),
+            'accepted_prizes': [
+                prize for prize in prizeList if prize.state == 'ACCEPTED'
+            ],
+            'denied_prizes': [prize for prize in prizeList if prize.state == 'DENIED'],
             'reply_address': replyTo,
         }
         if not dry_run:
@@ -281,7 +279,7 @@ def automail_prize_contributors(
                 headers={'Reply-to': replyTo},
             )
         message = 'Mailed prize handler {0} for prizes {1}'.format(
-            handler.id, list([p.id for p in prizeList])
+            handler.id, [p.id for p in prizeList]
         )
         if verbosity > 0:
             print(message)
@@ -361,7 +359,7 @@ def automail_winner_accepted_prize(
                 headers={'Reply-to': replyTo},
             )
         message = 'Mailed handler {0} for prize accepts {1}'.format(
-            handler.id, list([pw.id for pw in prizeList])
+            handler.id, [pw.id for pw in prizeList]
         )
         if verbosity > 0:
             print(message)
@@ -434,7 +432,7 @@ def automail_shipping_email_notifications(
                 headers={'Reply-to': replyTo},
             )
         message = 'Mailed donor {0} for prizes shipped {1}'.format(
-            winner.id, list([pw.id for pw in prizeList])
+            winner.id, [pw.id for pw in prizeList]
         )
         if verbosity > 0:
             print(message)

--- a/runtests.py
+++ b/runtests.py
@@ -8,8 +8,7 @@ from django.test.utils import get_runner
 from argparse import ArgumentParser
 
 # needs additional dependencies
-# tblib is needed for printing tracebacks on parallel runs
-# pip install unittest-xml-reporting tblib
+# pip install -r tests/requirements.txt
 # must be run from the tracker root folder, for now
 
 if __name__ == '__main__':

--- a/templatetags/donation_tags.py
+++ b/templatetags/donation_tags.py
@@ -21,7 +21,7 @@ def tryresolve(var, context, default=None):
 def sortlink(style, contents, **args):
     return format_html(
         '<a href="?{args}"{style}><span style="display:none;">{contents}</span></a>',
-        args=urllib.parse.urlencode([a for a in list(args.items()) if a[1]]),
+        args=urllib.parse.urlencode([a for a in args.items() if a[1]]),
         style=format_html(' class="{style}"', style=style) if style else '',
         contents=contents,
     )

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -271,7 +271,7 @@ class TestDonorMerge(TestCase):
         rootDonor = donorList[0]
         donationList = []
         for donor in donorList:
-            donationList.extend(list(donor.donation_set.all()))
+            donationList.extend(donor.donation_set.all())
         viewutil.merge_donors(rootDonor, donorList)
         for donor in donorList[1:]:
             self.assertFalse(models.Donor.objects.filter(id=donor.id).exists())
@@ -295,7 +295,7 @@ class TestDonorView(TestCase):
             firstname=firstname, lastname=lastname, defaults=kwargs
         )
         if not created:
-            for k, v in list(kwargs.items()):
+            for k, v in kwargs.items():
                 setattr(self.donor, k, v)
             if kwargs:
                 self.donor.save()

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -216,7 +216,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
             )
             donation3.save()
         eligibleDonors = prize.eligible_donors()
-        self.assertEqual(len(list(donationDonors.keys())), len(eligibleDonors))
+        self.assertEqual(len(donationDonors), len(eligibleDonors))
         for eligibleDonor in eligibleDonors:
             found = False
             if eligibleDonor['donor'] in donationDonors:
@@ -302,7 +302,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
             if donationDonors[donor.id]['amount'] < prize.minimumbid:
                 del donationDonors[donor.id]
         eligibleDonors = prize.eligible_donors()
-        self.assertEqual(len(list(donationDonors.keys())), len(eligibleDonors))
+        self.assertEqual(len(donationDonors), len(eligibleDonors))
         found = False
         for eligibleDonor in eligibleDonors:
             if eligibleDonor['donor'] in donationDonors:
@@ -491,7 +491,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
                         min_time=prize.end_draw_time() + datetime.timedelta(seconds=1),
                     )
                 donation.save()
-        maxDonor = max(list(donationDonors.items()), key=lambda x: x[1]['amount'])[1]
+        maxDonor = max(donationDonors.items(), key=lambda x: x[1]['amount'])[1]
         eligibleDonors = prize.eligible_donors()
         self.assertEqual(1, len(eligibleDonors))
         self.assertEqual(maxDonor['donor'].id, eligibleDonors[0]['donor'])
@@ -505,7 +505,7 @@ class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
             self.assertEqual(maxDonor['donor'].id, prize.get_winner().id)
         oldMaxDonor = maxDonor
         del donationDonors[oldMaxDonor['donor'].id]
-        maxDonor = max(list(donationDonors.items()), key=lambda x: x[1]['amount'])[1]
+        maxDonor = max(donationDonors.items(), key=lambda x: x[1]['amount'])[1]
         diff = oldMaxDonor['amount'] - maxDonor['amount']
         newDonor = maxDonor['donor']
         newDonation = randgen.generate_donation(

--- a/tests/test_prizemail.py
+++ b/tests/test_prizemail.py
@@ -135,8 +135,8 @@ class TestAutomailPrizeContributors(TransactionTestCase):
         contents = test_util.parse_test_mail(mail)
         event = int(contents['event'][0])
         handlerId = int(contents['handlerid'][0])
-        accepted = list([int(x) for x in contents.get('accepted', [])])
-        denied = list([int(x) for x in contents.get('denied', [])])
+        accepted = [int(x) for x in contents.get('accepted', [])]
+        denied = [int(x) for x in contents.get('denied', [])]
         return event, handlerId, accepted, denied
 
     def testAutoMail(self):
@@ -173,7 +173,7 @@ class TestAutomailPrizeContributors(TransactionTestCase):
             prize.save()
 
         pendingPrizes = reduce(
-            lambda x, y: x + y[0] + y[1], list(contributorPrizes.values()), []
+            lambda x, y: x + y[0] + y[1], contributorPrizes.values(), []
         )
         self.assertSetEqual(
             set(prizemail.prizes_with_submission_email_pending(self.event)),
@@ -240,7 +240,7 @@ class TestAutomailPrizeWinnerAcceptNotifications(TransactionTestCase):
         contents = test_util.parse_test_mail(mail)
         event = int(contents['event'][0])
         handlerId = int(contents['handlerid'][0])
-        prizeWins = list([int(x) for x in contents.get('prizewinner', [])])
+        prizeWins = [int(x) for x in contents.get('prizewinner', [])]
         reply = contents['reply'][0]
         return event, handlerId, prizeWins, reply
 
@@ -277,9 +277,7 @@ class TestAutomailPrizeWinnerAcceptNotifications(TransactionTestCase):
             )
             contributorPrizeWinners[prize.handler].append(prizeWinner)
 
-        winnerList = reduce(
-            lambda x, y: x + y, list(contributorPrizeWinners.values()), []
-        )
+        winnerList = reduce(lambda x, y: x + y, contributorPrizeWinners.values(), [])
         self.assertSetEqual(
             set(prizemail.prizes_with_winner_accept_email_pending(self.event)),
             set(winnerList),
@@ -380,7 +378,7 @@ class TestAutomailPrizesShipped(TransactionTestCase):
                     key.save()
                 winningDonors[prizeWinner.winner].append(prizeWinner)
 
-        winnerList = sum(list(winningDonors.values()), [])
+        winnerList = sum(winningDonors.values(), [])
         self.assertSetEqual(
             set(prizemail.prizes_with_shipping_email_pending(self.event)),
             set(winnerList),

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,16 +11,14 @@ from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TransactionTestCase, RequestFactory
 
-import models
+from tracker import models
 
 
 def parse_test_mail(mail):
-    lines = list(
-        [
-            x.partition(':')
-            for x in [x for x in [x.strip() for x in mail.message.split('\n')] if x]
-        ]
-    )
+    lines = [
+        x.partition(':')
+        for x in [x for x in [x.strip() for x in mail.message.split('\n')] if x]
+    ]
     result = {}
     for line in lines:
         if line[2]:
@@ -152,7 +150,7 @@ class APITestCase(TransactionTestCase):
         )
         unequal_keys = [
             k
-            for k in list(expected_model['fields'].keys())
+            for k in expected_model['fields'].keys()
             if k in found_model['fields']
             and found_model['fields'][k] != expected_model['fields'][k]
         ]

--- a/ui/views.py
+++ b/ui/views.py
@@ -179,13 +179,13 @@ def donate(request, event):
 
     initialForm = {
         k: to_json(commentform.cleaned_data[k])
-        for k, v in list(commentform.fields.items())
+        for k, v in commentform.fields.items()
         if commentform.is_bound and k in commentform.cleaned_data
     }
     pickedIncentives = [
         {
             k: to_json(form.cleaned_data[k])
-            for k, v in list(form.fields.items())
+            for k, v in form.fields.items()
             if k in form.cleaned_data
         }
         for form in bidsform.forms

--- a/util.py
+++ b/util.py
@@ -25,7 +25,7 @@ def natural_list_parse(s, symbol_only=False):
                 newtokens.append(before)
                 token = after
         tokens = newtokens
-    return list([x for x in [x.strip() for x in tokens] if len(x) > 0])
+    return [x for x in [x.strip() for x in tokens] if len(x) > 0]
 
 
 def labelify(labels):

--- a/views/api.py
+++ b/views/api.py
@@ -560,7 +560,7 @@ def add(request):
         raise PermissionDenied(
             'You do not have permission to add a model of the requested type'
         )
-    good_fields = filter_fields(list(add_params.keys()), model_admin, request)
+    good_fields = filter_fields(add_params.keys(), model_admin, request)
     bad_fields = set(good_fields) - set(add_params.keys())
     if bad_fields:
         raise PermissionDenied(
@@ -570,13 +570,13 @@ def add(request):
     newobj = Model()
     changed_fields = []
     m2m_collections = []
-    for k, v in list(add_params.items()):
+    for k, v in add_params.items():
         if k in ('type', 'id'):
             continue
         new_value = parse_value(Model, k, v, request.user)
         if type(new_value) == list:  # accounts for m2m relationships
             m2m_collections.append((k, new_value))
-            new_value = list(map(str, new_value))
+            new_value = [str(x) for x in new_value]
         else:
             setattr(newobj, k, new_value)
         changed_fields.append('Set %s to "%s".' % (k, new_value))
@@ -643,7 +643,7 @@ def edit(request):
     obj = Model.objects.get(pk=edit_params['id'])
     if not model_admin.has_change_permission(request, obj):
         raise PermissionDenied('You do not have permission to change that object')
-    good_fields = filter_fields(list(edit_params.keys()), model_admin, request)
+    good_fields = filter_fields(edit_params.keys(), model_admin, request)
     bad_fields = set(good_fields) - set(edit_params.keys())
     if bad_fields:
         raise PermissionDenied(
@@ -651,16 +651,16 @@ def edit(request):
             % ','.join(sorted(bad_fields))
         )
     changed_fields = []
-    for k, v in list(edit_params.items()):
+    for k, v in edit_params.items():
         if k in ('type', 'id'):
             continue
         old_value = getattr(obj, k)
         if hasattr(old_value, 'all'):  # accounts for m2m relationships
-            old_value = list(map(str, old_value.all()))
+            old_value = [str(x) for x in old_value.all()]
         new_value = parse_value(Model, k, v, request.user)
         if type(new_value) == list:  # accounts for m2m relationships
             getattr(obj, k).set(new_value)
-            new_value = list(map(str, new_value))
+            new_value = [str(x) for x in new_value]
         else:
             setattr(obj, k, new_value)
         if str(old_value) != str(new_value):

--- a/views/donateviews.py
+++ b/views/donateviews.py
@@ -185,7 +185,7 @@ def donate(request, event):
         if bid.speedrun:
             result['runname'] = bid.speedrun.name
         if bid.suggestions.exists():
-            result['suggested'] = list([x.name for x in bid.suggestions.all()])
+            result['suggested'] = [x.name for x in bid.suggestions.all()]
         if bid.allowuseroptions:
             result['custom'] = ['custom']
             result['label'] += ' (select and add a name next to "New Option Name")'


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/171302185

### Description of the Change

The `2to3` script is quite paranoid about converting things to `list` objects that used to be that but now return iterators, but a lot of those places only needed iterators to begin with (or were already lists). This swept through all the references to `list` and removed the ones that were superfluous. Shouldn't be any externally facing behavior.

### Verification Process

Tests pass with no changes, couldn't find any page errors when I ran through everything.