### PR TITLE
add Donation Transaction State filter to Donation Bid Admin [#170535368]

### DIFF
--- a/admin/bid.py
+++ b/admin/bid.py
@@ -252,6 +252,7 @@ class BidAdmin(CustomModelAdmin):
 class DonationBidAdmin(CustomModelAdmin):
     form = DonationBidForm
     list_display = ('bid', 'donation', 'amount')
+    list_filter = ('donation__transactionstate',)
 
     def get_queryset(self, request):
         event = viewutil.get_selected_event(request)


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/170535368

### Description of the Change

Donation Bids currently show ALL bids, even ones that are attached to donations that are not cleared (and thus not contributing to the total). This adds a filter to the admin page so you can filter on the donations' transaction state.

### Verification Process

It was a one line change (more of a config change than a code change), so I just opened the admin page and checked that the filters were filtering as expected.