### PR TITLE
replace some inlines with filtered list links [#167961889]

### DIFF
--- a/admin/donation.py
+++ b/admin/donation.py
@@ -7,12 +7,13 @@ from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from tracker import search_filters, forms, logutil, viewutil, models
 from .filters import DonationListFilter
 from .forms import DonationForm, DonorForm
-from .inlines import DonationBidInline, DonationInline
+from .inlines import DonationBidInline
 from .util import (
     CustomModelAdmin,
     mass_assign_action,
@@ -257,7 +258,7 @@ class DonorAdmin(CustomModelAdmin):
     form = DonorForm
     search_fields = ('email', 'paypalemail', 'alias', 'firstname', 'lastname')
     list_filter = ('donation__event', 'visibility')
-    readonly_fields = ('visible_name',)
+    readonly_fields = ('visible_name', 'donations')
     list_display = ('__str__', 'visible_name', 'alias', 'visibility')
     fieldsets = [
         (
@@ -272,6 +273,7 @@ class DonorAdmin(CustomModelAdmin):
                     'visible_name',
                     'user',
                     'solicitemail',
+                    'donations',
                 ]
             },
         ),
@@ -290,9 +292,16 @@ class DonorAdmin(CustomModelAdmin):
             },
         ),
     ]
-    inlines = [
-        DonationInline,
-    ]
+
+    def donations(self, instance):
+        if instance.id is not None:
+            return format_html(
+                '<a href="{u}?donor={id}">View</a>',
+                u=(reverse('admin:tracker_donation_changelist')),
+                id=instance.id,
+            )
+        else:
+            return 'Not Saved Yet'
 
     def visible_name(self, obj):
         return obj.visible_name()

--- a/admin/inlines.py
+++ b/admin/inlines.py
@@ -5,7 +5,6 @@ from django.utils.safestring import mark_safe
 from tracker import models
 from .forms import (
     DonationBidForm,
-    DonationForm,
     PrizeWinnerForm,
     DonorPrizeEntryForm,
     PrizeForm,
@@ -72,13 +71,6 @@ class BidDependentsInline(BidInline):
     verbose_name_plural = 'Dependent Bids'
     verbose_name = 'Dependent Bid'
     fk_name = 'biddependency'
-
-
-class DonationInline(CustomStackedInline):
-    form = DonationForm
-    model = models.Donation
-    extra = 0
-    readonly_fields = ('edit_link',)
 
 
 class EventBidInline(BidInline):


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/167961889

### Description of the Change

Some of the Admin inlines (for editing related objects) can grow to a pretty stupidly long list and hit a soft cap within Django about how many form fields you can have in a request, making an object unable to be edited via the admin.

This replaces some of the more egregious ones with links that go to a list of those related objects instead.

### Verification Process

Since this is MOSTLY display logic, the tests didn't really need to change since right now they're just smoke tests to make sure the page loads at all. I did verify by hand that the links were correct and gave the expected results, e.g. `/admin/tracker/bid/?speedrun=3`