### PR TITLE
add Admin tool to send volunteer emails [#171347289]

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -42,6 +42,7 @@ __all__ = [
     'PrizeSearchForm',
     'MergeObjectsForm',
     'EventFilterForm',
+    'SendVolunteerEmailsForm',
     'PrizeSubmissionForm',
     'AutomailPrizeContributorsForm',
     'DrawPrizeWinnersForm',
@@ -348,6 +349,14 @@ class EventFilterForm(forms.Form):
             initial=event,
             required=not allow_empty,
         )
+
+
+class SendVolunteerEmailsForm(forms.Form):
+    template = forms.ModelChoiceField(
+        post_office.models.EmailTemplate.objects.all(), empty_label=None
+    )
+    sender = forms.EmailField()
+    volunteers = forms.FileField()
 
 
 class PrizeSubmissionForm(forms.Form):

--- a/templates/admin/generic_form.html
+++ b/templates/admin/generic_form.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content %}
-    <form method="post" action="{{ request.path }}">
+    <form method="post" action="{{ request.path }}" enctype="multipart/form-data">
         <table>
             {% csrf_token %}
             {{ form }}


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/171347289

### Description of the Change

Right now GDQ uses a command line... well, command... to send out volunteer emails via a CSV. This replicates that as an Admin view (under events). The intent is to remove the command, but want to put this one through the motions first in a real environment before doing that.

### Verification Process

Ran it locally with several different CSVs to check that it queues up emails as expected, and either creates or modifies users as needed. The error handling isn't super robust, just spitting back very generic errors if there's a problem, but it's intended as a power user button so I'm not that worried about it.