### PR TITLE
stop server errors if you forget to attach to a bid

### DIFF
--- a/models/bid.py
+++ b/models/bid.py
@@ -350,6 +350,8 @@ class DonationBid(models.Model):
         unique_together = (('bid', 'donation'),)
 
     def clean(self):
+        if not self.bid_id:
+            return
         if not self.bid.istarget:
             raise ValidationError('Target bid must be a leaf node')
         self.donation.clean(self)


### PR DESCRIPTION
[#125271291]

# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/125271291

### Description of the Change

There were a couple of times when trying to save a donation it would blow up rather than giving a sensible error if you forgot to actually attach the amount to a bid. This fixes that.

### Verification Process

Tried to save a donation with a bid amount but no bid, and got a sensible `field cannot be blank` error.

![image](https://user-images.githubusercontent.com/419927/91750149-d7ac7900-eb7f-11ea-8101-342a04e22fad.png)
