### PR TITLE
negative limit on search returns a 400 instead of throwing [#174583704]

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,6 +61,11 @@ class TestGeneric(APITestCase):
         # bad request if limit is set above server config
         self.parseJSON(tracker.views.api.search(request), status_code=400)
 
+        request = self.factory.get('/api/v1/search', dict(type='donation', limit=-1),)
+        request.user = self.anonymous_user
+        # bad request if limit is negative
+        self.parseJSON(tracker.views.api.search(request), status_code=400)
+
     def test_add_log(self):
         request = self.factory.post(
             '/api/v1/add',

--- a/views/api.py
+++ b/views/api.py
@@ -359,6 +359,8 @@ def search(request):
     limit_param = int(single(search_params, 'limit', limit))
     if limit_param > limit:
         raise ValueError('limit can not be above %d' % limit)
+    if limit_param < 1:
+        raise ValueError('limit must be at least 1')
     limit = min(limit, limit_param)
 
     qs = search_filters.run_model_query(search_type, search_params, request.user,)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174583704

### Description of the Change

When the `limit` param was added in before, it would check the max, but not the min. Turns out Django will complain about trying to use a negative limit. This showed up in the error logs a few times during the last event.

### Verification Process

Sent `/tracker/api/v1/search/?type=run&limit=-1` and got back `{"error": "Malformed Parameters", "exception": "limit must be at least 1"}` instead of a 500.