### PR TITLE
add an endpoint for donation websocket [#174736894]

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -41,8 +41,9 @@ if __name__ == '__main__':
         help='Tells Django to stop running the test suite after first failed test.',
     )
     # TODO: the fetches for the ui endpoints blow up if the manifest doesn't exist so we have to build the webpack bundles first
-    check_call(['yarn', '--frozen-lockfile', '--production'])
-    check_call(['yarn', 'build'])
+    if not os.access('tracker/ui-tracker.manifest.json', os.R_OK):
+        check_call(['yarn', '--frozen-lockfile', '--production'])
+        check_call(['yarn', 'build'])
     TestRunner = get_runner(settings, 'xmlrunner.extra.djangotestrunner.XMLTestRunner')
     TestRunner.add_arguments(parser)
     test_runner = TestRunner(**parser.parse_args(sys.argv[1:]).__dict__)

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,12 +1,16 @@
 import datetime
+import json
+from decimal import Decimal
 
 import dateutil
 import pytz
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, sync_to_async
 from channels.testing import WebsocketCommunicator
-from django.test import SimpleTestCase
+from django.test import TransactionTestCase, SimpleTestCase
+from tracker import models, eventutil
+from tracker.consumers import PingConsumer, DonationConsumer
 
-from tracker.consumers import PingConsumer
+from .util import today_noon
 
 
 class TestPingConsumer(SimpleTestCase):
@@ -25,3 +29,50 @@ class TestPingConsumer(SimpleTestCase):
             msg=f'{date} and {now} differed by more than five seconds',
         )
         await communicator.disconnect()
+
+
+class TestDonationConsumer(TransactionTestCase):
+    # since the async part means THREADS, means that this transaction has to be treated differently
+    def setUp(self):
+        self.donor = models.Donor.objects.create()
+        self.event = models.Event.objects.create(
+            receivername='Médecins Sans Frontières',
+            targetamount=1,
+            paypalemail='msf@example.com',
+            paypalcurrency='USD',
+            datetime=today_noon,
+        )
+        self.donation = models.Donation.objects.create(
+            timereceived=today_noon,
+            comment='',
+            amount=Decimal(1.5),
+            domain='LOCAL',
+            donor=self.donor,
+            event=self.event,
+            transactionstate='COMPLETED',
+        )
+
+    def tearDown(self):
+        self.donation.delete()
+        self.donor.delete()
+        self.event.delete()
+
+    @async_to_sync
+    async def test_donation_consumer(self):
+        communicator = WebsocketCommunicator(DonationConsumer, '/tracker/ws/donation/')
+        connected, subprotocol = await communicator.connect()
+        self.assertTrue(connected, 'Could not connect')
+        await sync_to_async(eventutil.post_donation_to_postbacks)(self.donation)
+        result = json.loads(await communicator.receive_from())
+        expected = {
+            'type': 'donation',
+            'id': self.donation.id,
+            'timereceived': str(self.donation.timereceived),
+            'comment': self.donation.comment,
+            'amount': self.donation.amount,
+            'donor__visibility': self.donor.visibility,
+            'donor__visiblename': self.donor.visible_name(),
+            'new_total': self.donation.amount,
+            'domain': self.donation.domain,
+        }
+        self.assertEqual(result, expected)

--- a/tracker/consumers/__init__.py
+++ b/tracker/consumers/__init__.py
@@ -1,3 +1,4 @@
+from .donation import DonationConsumer
 from .ping import PingConsumer
 
-__all__ = ['PingConsumer']
+__all__ = ['PingConsumer', 'DonationConsumer']

--- a/tracker/consumers/donation.py
+++ b/tracker/consumers/donation.py
@@ -1,0 +1,14 @@
+from channels.generic.websocket import AsyncWebsocketConsumer
+import json
+
+
+class DonationConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        await self.channel_layer.group_add('donations', self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard('donations', self.channel_name)
+
+    async def donation(self, event):
+        await self.send(text_data=json.dumps(event))

--- a/tracker/routing.py
+++ b/tracker/routing.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import consumers
 
 websocket_urlpatterns = [
+    path('ws/donations/', consumers.DonationConsumer),
     path('ws/ping/', consumers.PingConsumer),
 ]


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174736894

### Description of the Change

Adds an endpoint for WebSocket connections to receive incoming Donations, in the same format as the postbacks. The postback function now sends to all connected sockets in addition to sending postbacks.

### Verification Process

Called the postback function from the shell, with a test socket open, and verified that the socket got the expected data.