### PR TITLE
disable certain Prize functionality if SWEEPSTAKES_URL is not set [#174763941]

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Type: `str`
 
 Default: `''`
 
-If present, shown in several prize-related pages. In the future this will be REQUIRED if you offer any prizes from
-your events. You should DEFINITELY have one of these if you are giving away prizes, but, again, this README is not
-legal advice.
+If present, shown in several prize-related pages. This is REQUIRED if you offer any prizes from your events, and will
+disable a lot of prize functionality if it's not set. This is for legal reasons because it's very easy to run afoul of
+local sweepstakes laws. This README is not legal advice, however, so you should contact a lawyer before you give away
+prizes.
 
 #### TRACKER_PAGINATION_LIMIT
 

--- a/bundles/tracker/events/components/EventRouter.tsx
+++ b/bundles/tracker/events/components/EventRouter.tsx
@@ -6,6 +6,7 @@ import DonateInitializer from '../../donation/components/DonateInitializer';
 import Prize from '../../prizes/components/Prize';
 import Prizes from '../../prizes/components/Prizes';
 import { Routes } from '../../router/RouterUtils';
+import NotFound from '../../router/components/NotFound';
 
 const EventRouter = (props: any) => {
   // TODO: type this better when DonateInitializer doesn't need page-load props
@@ -13,14 +14,18 @@ const EventRouter = (props: any) => {
 
   return (
     <Switch>
-      <Route exact path={Routes.EVENT_PRIZES(eventId)}>
-        <Prizes eventId={eventId} />
-      </Route>
-      <Route exact path={Routes.EVENT_PRIZE(eventId, ':prizeId')}>
-        {({ match }: RouteComponentProps<{ eventId: string; prizeId: string }>) => (
-          <Prize prizeId={match.params.prizeId} />
-        )}
-      </Route>
+      {window.SWEEPSTAKES_URL && (
+        <Route exact path={Routes.EVENT_PRIZES(eventId)}>
+          <Prizes eventId={eventId} />
+        </Route>
+      )}
+      {window.SWEEPSTAKES_URL && (
+        <Route exact path={Routes.EVENT_PRIZE(eventId, ':prizeId')}>
+          {({ match }: RouteComponentProps<{ eventId: string; prizeId: string }>) => (
+            <Prize prizeId={match.params.prizeId} />
+          )}
+        </Route>
+      )}
       <Route exact path={Routes.EVENT_DONATE(eventId)}>
         {({ match }: RouteComponentProps<{ eventId: string }>) => (
           <React.Fragment>
@@ -29,6 +34,7 @@ const EventRouter = (props: any) => {
           </React.Fragment>
         )}
       </Route>
+      <NotFound />
     </Switch>
   );
 };

--- a/bundles/tracker/index.tsx
+++ b/bundles/tracker/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import _ from 'lodash';
 
 import ErrorBoundary from '../public/errorBoundary';
 import ThemeProvider from '../uikit/ThemeProvider';

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -7,8 +7,12 @@ import pytz
 from dateutil.parser import parse as parse_date
 from django.contrib.admin import ACTION_CHECKBOX_NAME
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
-from django.test import TestCase
+from django.core.exceptions import (
+    ValidationError,
+    ObjectDoesNotExist,
+    ImproperlyConfigured,
+)
+from django.test import TestCase, override_settings
 from django.test import TransactionTestCase
 from django.urls import reverse
 from tracker import models, prizeutil
@@ -1690,3 +1694,34 @@ class TestPrizeWinner(TestCase):
             self.donation_prize.get_prize_winner().donor_cache,
             self.donation_donor.cache_for(self.event.id),
         )
+
+
+@override_settings(SWEEPSTAKES_URL='')
+class TestPrizeNoSweepstakes(TestCase):
+    def setUp(self):
+        self.rand = random.Random(None)
+        self.event = randgen.generate_event(self.rand, start_time=today_noon)
+        self.event.save()
+        with override_settings(SWEEPSTAKES_URL='temp'):  # create a worst case scenario
+            self.prize = randgen.generate_prize(self.rand, event=self.event)
+            self.prize.save()
+
+    def test_prize_index_generic_404(self):
+        response = self.client.get(reverse('tracker:prizeindex', args=(self.event.id,)))
+        self.assertContains(response, 'Bad page', status_code=404)
+
+    def test_prize_detail_generic_404(self):
+        response = self.client.get(reverse('tracker:prize', args=(1,)))
+        self.assertContains(response, 'Bad page', status_code=404)
+
+    def test_donate_raises(self):
+        with self.assertRaisesRegex(ImproperlyConfigured, 'SWEEPSTAKES_URL'):
+            self.client.get(reverse('tracker:ui:donate', args=(self.event.id,)))
+
+    def test_model_invalid(self):
+        with self.assertRaisesRegex(ValidationError, 'SWEEPSTAKES_URL'):
+            models.Prize(event=self.event).clean()
+
+    def test_model_save_raises(self):
+        with self.assertRaisesRegex(ImproperlyConfigured, 'SWEEPSTAKES_URL'):
+            models.Prize.objects.create(event=self.event)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -60,3 +60,4 @@ AJAX_LOOKUP_CHANNELS = ajax_lookup_channels.AJAX_LOOKUP_CHANNELS
 CACHES = {'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache',}}
 ASGI_APPLICATION = 'tests.routing.application'
 CHANNEL_LAYERS = {'default': {'BACKEND': 'channels.layers.InMemoryChannelLayer'}}
+SWEEPSTAKES_URL = 'https://example.com/'

--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -49,14 +49,18 @@
                     {% if event.short %}
                         <li><a href="{% url 'tracker:index' event=event.short %}">{% trans "Home" %}</a></li>
                         <li><a href="{% url 'tracker:runindex' event=event.short %}">{% trans "Runs" %}</a></li>
-                        <li><a href="{% url 'tracker:prizeindex' event=event.short %}">{% trans "Prizes" %}</a></li>
+                        {% if settings.SWEEPSTAKES_URL %}
+                            <li><a href="{% url 'tracker:prizeindex' event=event.short %}">{% trans "Prizes" %}</a></li>
+                        {% endif %}
                         <li><a href="{% url 'tracker:bidindex' event=event.short %}">{% trans "Bids" %}</a></li>
                         <li><a href="{% url 'tracker:donorindex' event=event.short %}">{% trans "Donors" %}</a></li>
                         <li><a href="{% url 'tracker:donationindex' event=event.short %}">{% trans "Donations" %}</a></li>
                     {% else %}
                         <li><a href="{% url 'tracker:index_all' %}">{% trans "Home" %}</a></li>
                         <li><a href="{% url 'tracker:runindex' %}">{% trans "Runs" %}</a></li>
-                        <li><a href="{% url 'tracker:prizeindex' %}">{% trans "Prizes" %}</a></li>
+                        {% if settings.SWEEPSTAKES_URL %}
+                            <li><a href="{% url 'tracker:prizeindex' %}">{% trans "Prizes" %}</a></li>
+                        {% endif %}
                         <li><a href="{% url 'tracker:bidindex' %}">{% trans "Bids" %}</a></li>
                         <li><a href="{% url 'tracker:donorindex' %}">{% trans "Donors" %}</a></li>
                         <li><a href="{% url 'tracker:donationindex' %}">{% trans "Donations" %}</a></li>

--- a/tracker/templates/tracker/index.html
+++ b/tracker/templates/tracker/index.html
@@ -26,13 +26,17 @@
         <p class="center-block"><br /></p>
         {% if event.short %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:runindex' event=event.short %}">{% trans "View Runs" %} ({{ count.runs }})</a></p>
-            <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:prizeindex' event=event.short %}">{% trans "View Prizes" %} ({{ count.prizes }})</a></p>
+            {% if settings.SWEEPSTAKES_URL %}
+                <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:prizeindex' event=event.short %}">{% trans "View Prizes" %} ({{ count.prizes }})</a></p>
+            {% endif %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:bidindex' event=event.short %}">{% trans "View Bids" %} ({{ count.bids }})</a></p>
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:donorindex' event=event.short %}">{% trans "View Donors" %} ({{ count.donors }})</a></p>
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:donationindex' event=event.short %}">{% trans "View Donations" %} ({{ agg.count }})</a></p>
         {% else %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:runindex' %}">{% trans "View Runs" %} ({{ count.runs }})</a></p>
-            <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:prizeindex' %}">{% trans "View Prizes" %} ({{ count.prizes }})</a></p>
+            {% if settings.SWEEPSTAKES_URL %}
+                <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:prizeindex' %}">{% trans "View Prizes" %} ({{ count.prizes }})</a></p>
+            {% endif %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:bidindex' %}">{% trans "View Bids" %} ({{ count.bids }})</a></p>
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:donorindex' %}">{% trans "View Donors" %} ({{ count.donors }})</a></p>
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:donationindex' %}">{% trans "View Donations" %} ({{ agg.count }})</a></p>

--- a/tracker/ui/views.py
+++ b/tracker/ui/views.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.core import serializers
+from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
 from django.shortcuts import render
 from django.urls import reverse
@@ -155,6 +156,12 @@ def donate(request, event):
     prizes = search_filters.run_model_query(
         'prize', {'feed': 'current', 'event': event.id}
     )
+
+    # You have to try really hard to get into this state so it's reasonable to blow up spectacularly when it happens
+    if prizes and not getattr(settings, 'SWEEPSTAKES_URL', None):
+        raise ImproperlyConfigured(
+            'There are prizes available but no SWEEPSTAKES_URL is set'
+        )
 
     bidsArray = [bid_info(o) for o in bids]
 

--- a/tracker/views/public.py
+++ b/tracker/views/public.py
@@ -429,6 +429,9 @@ def run_detail(request, pk):
 
 @cache_page(1800)
 def prizeindex(request, event=None):
+    if not getattr(settings, 'SWEEPSTAKES_URL', None):
+        raise Http404
+
     event = viewutil.get_event(event)
 
     if not event.id:
@@ -450,6 +453,8 @@ def prizeindex(request, event=None):
 
 @cache_page(1800)
 def prize_detail(request, pk):
+    if not getattr(settings, 'SWEEPSTAKES_URL', None):
+        raise Http404
     try:
         prize = Prize.objects.get(pk=pk)
         event = prize.event


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174763941

### Description of the Change

When I added the ability to configure these values before, there was some code that would just hide the relevant blurbs if the setting was missing. After further consideration it's better to go a step further and just disable the prize functionality altogether if the setting is missing or blank. This does several things:

- removes the Prize links from all pages
- makes the Django Prize index/details 404 even if prizes exist
- makes the React Prize view 404
- makes all prizes fail validation (so cannot be created or edited in the admin)
- makes `Prize.save()` throw if you somehow call it directly (e.g. from the terminal)
- causes the donate page to throw if you somehow end up with available prizes but no sweepstakes url (degenerate, especially for new deploys, but possible)

Note that this doesn't prevent direct DB access if you're truly dedicated to messing things up, but what python code could possibly prevent that?

### Verification Process

First, I created prizes on a branch without this code active. Then switched back to this branch.

Links to the prize page don't show up in the nav bar or in the index page. Direct links 404 (or similar, for the React views) even if the prize exists. Could not edit the existing prize, or create a new prize. Trying to save a prize from the shell threw as expected. Trying to visit the donate page while inside the prize window threw as expected. Then set `SWEEPSTAKES_URL` and everything started working correctly again.