### PR TITLE
bids now paginate their targeted donations [#174782477]

### DIFF
--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -392,6 +392,10 @@ class DonationBid(models.Model):
         return self.donation.donor_cache
 
     @property
+    def timereceived(self):
+        return self.donation.timereceived
+
+    @property
     def fullname(self):
         return self.bid.fullname()
 

--- a/tracker/templates/tracker/bid.html
+++ b/tracker/templates/tracker/bid.html
@@ -6,28 +6,26 @@
 {% block title %}{% trans "Bid Detail" %} -- {{ event.name }}{% endblock %}
 
 {% block content %}
-    {% block bid_header %}
-      <h2>
-          {% if bid.speedrun %}
-              {% trans "Game" %}:
-              {{ bid.speedrun }}
-          {% else %}
-              {% trans "Event" %}:
-              {{ bid.event }}
-          {% endif %}
-          <br>
-          <small>
-              {% trans "Bid" %}:
-              {{ bid.name }}
-              {% trans "Total" %}:
-              {{ bid.total|money }}
-              {% if bid.goal %}
-                  {% trans "Goal" %}:
-                  {{ bid.goal|money }}
-              {% endif %}
-          </small>
-      </h2>
-    {% endblock %}
+    <h2>
+        {% if bid.speedrun %}
+            {% trans "Game" %}:
+            {{ bid.speedrun }}
+        {% else %}
+            {% trans "Event" %}:
+            {{ bid.event }}
+        {% endif %}
+        <br>
+        <small>
+            {% trans "Bid" %}:
+            {{ bid.name }}
+            {% trans "Total" %}:
+            {{ bid.total|money }}
+            {% if bid.goal %}
+                {% trans "Goal" %}:
+                {{ bid.goal|money }}
+            {% endif %}
+        </small>
+    </h2>
 
     {% if bid.ancestors %}
         <table class="table table-condensed table-striped small">

--- a/tracker/templates/tracker/bid.html
+++ b/tracker/templates/tracker/bid.html
@@ -3,29 +3,31 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Bid Detail" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Bid Detail" %} -- {{ event.name }}{% endblock %}
 
 {% block content %}
-    <h2>
-        {% if bid.speedrun %}
-            {% trans "Game" %}:
-            {{ bid.speedrun|title }}
-        {% else %}
-            {% trans "Event" %}:
-            {{ bid.event|title }}
-        {% endif %}
-        <br>
-        <small>
-            {% trans "Bid" %}:
-            {{ bid.name|title }}
-            {% trans "Total" %}:
-            {{ bid.total|money }}
-            {% if bid.goal %}
-                {% trans "Goal" %}:
-                {{ bid.goal|money }}
-            {% endif %}
-        </small>
-    </h2>
+    {% block bid_header %}
+      <h2>
+          {% if bid.speedrun %}
+              {% trans "Game" %}:
+              {{ bid.speedrun }}
+          {% else %}
+              {% trans "Event" %}:
+              {{ bid.event }}
+          {% endif %}
+          <br>
+          <small>
+              {% trans "Bid" %}:
+              {{ bid.name }}
+              {% trans "Total" %}:
+              {{ bid.total|money }}
+              {% if bid.goal %}
+                  {% trans "Goal" %}:
+                  {{ bid.goal|money }}
+              {% endif %}
+          </small>
+      </h2>
+    {% endblock %}
 
     {% if bid.ancestors %}
         <table class="table table-condensed table-striped small">
@@ -48,6 +50,7 @@
             {% endfor %}
             </thead>
         </table>
+
     {% endif %}
 
     {% if bid.description|length > 0 %}
@@ -70,46 +73,48 @@
     {% endif %}
 
     {% if bid.istarget %}
-        <table class="table table-condensed table-striped small">
-            <thead>
-            <tr>
-                <th>
-                    {% trans "Name" %}{% sort "name" %}
-                </th>
-                <th>
-                    {% trans "Time Received" %}{% sort "time" %}
-                </th>
-                <th>
-                    {% trans "Amount" %}{% sort "amount" %}
-                </th>
-            </tr>
-            </thead>
-            {% for donation_bid in donation_bids %}
-                <tr class="small">
-                    <td>
-                        {% include "tracker/partials/donor_link.html" with donor=donation_bid.donor_cache only %}
-                    </td>
-                    <td class="datetime">
-                        {{ donation_bid.donation.timereceived|date:"c" }}
-                    </td>
-                    <td>
-                        <a href="{% url 'tracker:donation' pk=donation_bid.donation.id %}">{{ donation_bid.amount|money }}</a>
-                    </td>
-                </tr>
-            {% empty %}
-                <tr class="small">
-                    <td colspan="3">
-                        No bids for this option yet!
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
+      <table class="table table-condensed table-striped small">
+          <thead>
+          <tr>
+              <th>
+                  {% trans "Name" %}{% sort "name" %}
+              </th>
+              <th>
+                  {% trans "Time Received" %}{% sort "time" %}
+              </th>
+              <th>
+                  {% trans "Amount" %}{% sort "amount" %}
+              </th>
+          </tr>
+          </thead>
+          {% for donation in donations %}
+              <tr class="small">
+                  <td>
+                      {% include "tracker/partials/donor_link.html" with donor=donation.donor_cache only %}
+                  </td>
+                  <td class="datetime">
+                      {{ donation.timereceived|date:"c" }}
+                  </td>
+                  <td>
+                      <a href="{% url 'tracker:donation' pk=donation.donation_id %}">{{ donation.amount|money }}</a>
+                  </td>
+              </tr>
+          {% empty %}
+              <tr class="small">
+                  <td colspan="3">
+                      No bids for this option yet!
+                  </td>
+              </tr>
+          {% endfor %}
+      </table>
+
+      {% include "tracker/partials/pagefooter.html" %}
     {% else %}
-        {% include 'tracker/partials/optionstable.html' with bid=bid only %}
+      {% include 'tracker/partials/optionstable.html' with bid=bid only %}
     {% endif %}
 
-    <p align="center">
-        <a href="{% url 'tracker:bidindex' event=event.short %}">
+    <p class="text-center">
+        <a href="{% url 'tracker:bidindex' event=event.short %}" class="btn btn-default">
             {% trans "Back to Bid Index" %}
         </a>
     </p>

--- a/tracker/templates/tracker/bid.html
+++ b/tracker/templates/tracker/bid.html
@@ -48,7 +48,6 @@
             {% endfor %}
             </thead>
         </table>
-
     {% endif %}
 
     {% if bid.description|length > 0 %}
@@ -71,44 +70,44 @@
     {% endif %}
 
     {% if bid.istarget %}
-      <table class="table table-condensed table-striped small">
-          <thead>
-          <tr>
-              <th>
-                  {% trans "Name" %}{% sort "name" %}
-              </th>
-              <th>
-                  {% trans "Time Received" %}{% sort "time" %}
-              </th>
-              <th>
-                  {% trans "Amount" %}{% sort "amount" %}
-              </th>
-          </tr>
-          </thead>
-          {% for donation in donations %}
-              <tr class="small">
-                  <td>
-                      {% include "tracker/partials/donor_link.html" with donor=donation.donor_cache only %}
-                  </td>
-                  <td class="datetime">
-                      {{ donation.timereceived|date:"c" }}
-                  </td>
-                  <td>
-                      <a href="{% url 'tracker:donation' pk=donation.donation_id %}">{{ donation.amount|money }}</a>
-                  </td>
-              </tr>
-          {% empty %}
-              <tr class="small">
-                  <td colspan="3">
-                      No bids for this option yet!
-                  </td>
-              </tr>
-          {% endfor %}
-      </table>
+        <table class="table table-condensed table-striped small">
+            <thead>
+            <tr>
+                <th>
+                    {% trans "Name" %}{% sort "name" %}
+                </th>
+                <th>
+                    {% trans "Time Received" %}{% sort "time" %}
+                </th>
+                <th>
+                    {% trans "Amount" %}{% sort "amount" %}
+                </th>
+            </tr>
+            </thead>
+            {% for donation in donations %}
+                <tr class="small">
+                    <td>
+                        {% include "tracker/partials/donor_link.html" with donor=donation.donor_cache only %}
+                    </td>
+                    <td class="datetime">
+                        {{ donation.timereceived|date:"c" }}
+                    </td>
+                    <td>
+                        <a href="{% url 'tracker:donation' pk=donation.donation_id %}">{{ donation.amount|money }}</a>
+                    </td>
+                </tr>
+            {% empty %}
+                <tr class="small">
+                    <td colspan="3">
+                        No bids for this option yet!
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
 
-      {% include "tracker/partials/pagefooter.html" %}
+        {% include "tracker/partials/pagefooter.html" %}
     {% else %}
-      {% include 'tracker/partials/optionstable.html' with bid=bid only %}
+        {% include 'tracker/partials/optionstable.html' with bid=bid only %}
     {% endif %}
 
     <p class="text-center">

--- a/tracker/templates/tracker/partials/optionstable.html
+++ b/tracker/templates/tracker/partials/optionstable.html
@@ -1,42 +1,40 @@
 {% load donation_tags %}
 {% load i18n %}
 
-{% if bid.children %}
-    <table class="table table-condensed table-striped small">
-        <thead>
+<table class="table table-condensed table-striped small">
+    <thead>
+    <tr>
+        <th>
+            {% trans "Name" %}
+        </th>
+        <th>
+            {% if bid.speedrun %}
+                {% trans "Run" %}
+            {% endif %}
+        </th>
+        <th>
+            {% if bid.event %}
+                {% trans "Event" %}
+            {% endif %}
+        </th>
+        <th>
+            {% trans "Description" %}
+        </th>
+        <th>
+            {% trans "Amount" %}
+        </th>
+        <th>
+            {% trans "Goal" %}
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for option in bid.children %}
+        {% include 'tracker/partials/option.html' with bid=option only %}
+    {% empty %}
         <tr>
-            <th>
-                {% trans "Name" %}
-            </th>
-            <th>
-                {% if bid.speedrun %}
-                    {% trans "Run" %}
-                {% endif %}
-            </th>
-            <th>
-                {% if bid.event %}
-                    {% trans "Event" %}
-                {% endif %}
-            </th>
-            <th>
-                {% trans "Description" %}
-            </th>
-            <th>
-                {% trans "Amount" %}
-            </th>
-            <th>
-                {% trans "Goal" %}
-            </th>
+            <td colspan="6">No options yet!</td>
         </tr>
-        </thead>
-        <tbody>
-        {% for option in bid.children %}
-            {% include 'tracker/partials/option.html' with bid=option only %}
-        {% empty %}
-            <tr>
-                <td colspan="6">No options yet!</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-{% endif %}
+    {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174782477

### Description of the Change

On the GDQ server listing the donations associated with a bid has been disabled for a while because the volume of some of them (bonus games and save/kill spring to mind) could literally number in the thousands. This adds a pagination view so that people can still view the list in small chunks if they really want to.

### Verification Process

Created a bid with enough donations to be above 50, verified that the page range worked as expected. Checked with `&queries` and made sure there weren't excessive DB fetches.