### PR TITLE
remove unnecessary permissions from donation processing [#174781856]

### DIFF
--- a/tracker/admin/donation.py
+++ b/tracker/admin/donation.py
@@ -205,7 +205,7 @@ class DonationAdmin(CustomModelAdmin):
         ]
 
     @staticmethod
-    @permission_required(('tracker.change_donor', 'tracker.change_donation'))
+    @permission_required(('tracker.change_donation',))
     def process_donations(request):
         current_event = viewutil.get_selected_event(request)
         user_can_approve = (
@@ -222,7 +222,7 @@ class DonationAdmin(CustomModelAdmin):
         )
 
     @staticmethod
-    @permission_required(('tracker.change_donor', 'tracker.change_donation'))
+    @permission_required(('tracker.change_donation',))
     def read_donations(request):
         currentEvent = viewutil.get_selected_event(request)
         return render(


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174781856

### Description of the Change

This was hacked out on the server ages ago and somehow never made it back to mainline.

### Verification Process

Donation processing pages still load. If you try to click a Donor link without `change_donor` permissions you get a 404, but that's expected. COULD make the processing pages smart enough to detect lack of permission and not make them links, but this suite is long overdue for a rewrite anyway.