### PR TITLE
cleanup pass on templates [#174781770]

### DIFF
--- a/tracker/templates/admin/automail_prize_contributors.html
+++ b/tracker/templates/admin/automail_prize_contributors.html
@@ -7,8 +7,8 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_contributors_post.html
+++ b/tracker/templates/admin/automail_prize_contributors_post.html
@@ -7,10 +7,10 @@
 
 {% block head %}
 
-<link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
-<script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'css/ajax_select.css' %}" type="text/css" media="ajax" rel="stylesheet" />
+<script src="{% static 'js/ajax_select.js' %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_winners.html
+++ b/tracker/templates/admin/automail_prize_winners.html
@@ -7,8 +7,8 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_winners_accept_notifications.html
+++ b/tracker/templates/admin/automail_prize_winners_accept_notifications.html
@@ -7,8 +7,8 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_winners_accept_notifications_post.html
+++ b/tracker/templates/admin/automail_prize_winners_accept_notifications_post.html
@@ -7,10 +7,10 @@
 
 {% block head %}
 
-<link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
-<script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'css/ajax_select.css' %}" type="text/css" media="ajax" rel="stylesheet" />
+<script src="{% static 'js/ajax_select.js' %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_winners_post.html
+++ b/tracker/templates/admin/automail_prize_winners_post.html
@@ -7,10 +7,10 @@
 
 {% block head %}
 
-<link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
-<script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'css/ajax_select.css' %}" type="text/css" media="ajax" rel="stylesheet" />
+<script src="{% static 'js/ajax_select.js' %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_winners_shipping_notifications.html
+++ b/tracker/templates/admin/automail_prize_winners_shipping_notifications.html
@@ -7,8 +7,8 @@
 
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/automail_prize_winners_shipping_notifications_post.html
+++ b/tracker/templates/admin/automail_prize_winners_shipping_notifications_post.html
@@ -7,10 +7,10 @@
 
 {% block head %}
 
-<link href="{% static "css/ajax_select.css" %}" type="text/css" media="ajax" rel="stylesheet" />
-<script src="{% static "js/ajax_select.js" %}"></script>
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'css/ajax_select.css' %}" type="text/css" media="ajax" rel="stylesheet" />
+<script src="{% static 'js/ajax_select.js' %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 {% endblock %}
 

--- a/tracker/templates/admin/process_donations.html
+++ b/tracker/templates/admin/process_donations.html
@@ -7,8 +7,8 @@
 {% block nav %}{% endblock %}
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 
 <script>

--- a/tracker/templates/admin/process_pending_bids.html
+++ b/tracker/templates/admin/process_pending_bids.html
@@ -12,8 +12,8 @@ td {
 }
 </style>
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 <script>
 

--- a/tracker/templates/admin/process_prize_submissions.html
+++ b/tracker/templates/admin/process_prize_submissions.html
@@ -12,8 +12,8 @@ td {
 }
 </style>
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.css' %}"></script>
 
 <script>
 

--- a/tracker/templates/admin/read_donations.html
+++ b/tracker/templates/admin/read_donations.html
@@ -7,8 +7,8 @@
 {% block nav %}{% endblock %}
 {% block head %}
 
-<link href="{% static "adminprocessing.css" %}" type="text/css" rel="stylesheet" />
-<script src="{% static "adminprocessing.js" %}"></script>
+<link href="{% static 'adminprocessing.css' %}" type="text/css" rel="stylesheet" />
+<script src="{% static 'adminprocessing.js' %}"></script>
 
 <script>
 

--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -6,14 +6,14 @@
 <head>
     <title>{% block title %}Base Title{% endblock %}</title>
 
-    <link rel="stylesheet" type="text/css" href="{% static "jquery.datetimepicker.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'jquery.datetimepicker.css' %}" />
     <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.1/themes/smoothness/jquery-ui.css" />
 
     <script type="application/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 
     <script type="application/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.1/jquery-ui.min.js"></script>
-    <script type="application/javascript" src="{% static "jquery.datetimepicker.js" %}"></script>
-    <script type="application/javascript" src="{% static "jquery.cookie.js" %}"></script>
+    <script type="application/javascript" src="{% static 'jquery.datetimepicker.js' %}"></script>
+    <script type="application/javascript" src="{% static 'jquery.cookie.js' %}"></script>
     <script type="application/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript">
@@ -21,7 +21,7 @@
         django.jQuery = jQuery;
     </script>
 
-    <script type="application/javascript" src="{% static "date.format.js" %}"></script>
+    <script type="application/javascript" src="{% static 'date.format.js' %}"></script>
 
     <script type="application/javascript">
         $(document).ready(function() {

--- a/tracker/templates/tracker/bid.html
+++ b/tracker/templates/tracker/bid.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Bid Detail" %} -- {{ event.name }}{% endblock %}
+{% block title %}{% trans "Bid Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
     <h2>

--- a/tracker/templates/tracker/bidindex.html
+++ b/tracker/templates/tracker/bidindex.html
@@ -2,7 +2,7 @@
 {% load donation_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Bid Index" %} &mdash; {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Bid Index" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
     <div class="fa-stack center-block medium-icon-blue fa-5x">
@@ -10,7 +10,7 @@
     </div>
 
     <h2 class="text-center">
-        {% trans "Bid Index" %} &mdash; {{ event.name|title }}
+        {% trans "Bid Index" %} &mdash; {{ event.name }}
         <br/>
         <small>
             {% trans "Total" %}:

--- a/tracker/templates/tracker/bidtitle.html
+++ b/tracker/templates/tracker/bidtitle.html
@@ -4,21 +4,21 @@
     <b>
       {% trans "Game" %}:
     </b>
-    {{ bid.speedrun|title }}
+    {{ bid.speedrun }}
   {% else %}
     <b>
       {% trans "Event" %}:
     </b>
-    {{ bid.event|title }}
+    {{ bid.event }}
   {% endif %}
-  
+
   <b>
     {% trans "Bid" %}:
-    {{ bid.name|title }}
+    {{ bid.name }}
   </b>
   <b>
     {% trans "Total" %}:
   </b>
   {{ agg.amount|money }}
-  
+
 </div>

--- a/tracker/templates/tracker/donation.html
+++ b/tracker/templates/tracker/donation.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Donation Detail" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Donation Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
 
@@ -59,7 +59,7 @@
                 <tr class="small">
                     <td>
                         {% if donation_bid.speedrun_id %}
-                            <a href="{% url 'tracker:run' pk=donation_bid.speedrun_id %}">{{ donation_bid.speedrun.name_with_category|title }}</a>
+                            <a href="{% url 'tracker:run' pk=donation_bid.speedrun_id %}">{{ donation_bid.speedrun.name_with_category }}</a>
                         {% endif %}
                     </td>
                     <td>

--- a/tracker/templates/tracker/donationindex.html
+++ b/tracker/templates/tracker/donationindex.html
@@ -4,7 +4,7 @@
 
 {% load tz %}
 
-{% block title %}{% trans "Donation Index" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Donation Index" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
 
@@ -14,7 +14,7 @@
 
 
     <h2 class="text-center">
-        {% trans "Donation Index" %} &mdash; {{ event.name|title }}
+        {% trans "Donation Index" %} &mdash; {{ event.name }}
         <br />
         <small>
             {% trans "Total" %} ({% trans "Count" %}):

--- a/tracker/templates/tracker/donor.html
+++ b/tracker/templates/tracker/donor.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Donor Detail" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Donor Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
   <h2 class="text-center">

--- a/tracker/templates/tracker/donorindex.html
+++ b/tracker/templates/tracker/donorindex.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Donor Index" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Donor Index" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
 
@@ -14,7 +14,7 @@
     <h2 class="text-center">
         {% trans "Donor Index" %}
         &mdash;
-        {{ event.name|title }}
+        {{ event.name }}
     </h2>
     <table class="table table-condensed table-striped small">
         <thead>

--- a/tracker/templates/tracker/index.html
+++ b/tracker/templates/tracker/index.html
@@ -4,16 +4,16 @@
 {% load static %}
 
 {% block title %}
-    {{ event.name|title }} -- {% trans "Index" %}
+    {{ event.name }} &mdash; {% trans "Index" %}
 {% endblock %}
 
 {% block head %}
-    <link rel="stylesheet" type="text/css" href="{% static "main.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'main.css' %}" />
 {% endblock %}
 
 {% block content %}
     <h2 class="text-center">
-        {{ event.name|title }}
+        {{ event.name }}
         <br />
         <small>
             {% trans "Donation Total" %}:

--- a/tracker/templates/tracker/paypal_cancel.html
+++ b/tracker/templates/tracker/paypal_cancel.html
@@ -2,11 +2,11 @@
 {% load static %}
 
 {% block title %}
-    {{ event.name|title }} -- Cancelled
+    {{ event.name }} &mdash; Cancelled
 {% endblock %}
 
 {% block head %}
-    <link rel="stylesheet" type="text/css" href="{% static "queueindex.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'queueindex.css' %}" />
 {% endblock %}
 
 {% block content %}

--- a/tracker/templates/tracker/paypal_return.html
+++ b/tracker/templates/tracker/paypal_return.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}
-    {{ event.name|title }} -- Donation Complete
-{% endblock %}
+{% block title %}{{ event.name }} &mdash; Donation Complete{% endblock %}
 
 {% block head %}
-    <link rel="stylesheet" type="text/css" href="{% static "queueindex.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'queueindex.css' %}" />
 {% endblock %}
 
 {% block nav %}

--- a/tracker/templates/tracker/prize.html
+++ b/tracker/templates/tracker/prize.html
@@ -2,7 +2,7 @@
 {% load donation_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Prize Detail" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Prize Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
     {% if settings.SWEEPSTAKES_URL %}
@@ -16,7 +16,7 @@
         <b>
             {% trans "Prize" %}:
         </b>
-        {{ prize.name|title }}
+        {{ prize.name }}
         <b>
             {% trans "Minimum Bid" %}:
         </b>
@@ -74,7 +74,7 @@
                 <tr>
                     <td>
                         <a href="{% url 'tracker:run' pk=game.pk %}">
-                            {{ game.name|title }}
+                            {{ game.name }}
                         </a>
                     </td>
                 </tr>

--- a/tracker/templates/tracker/prizeindex.html
+++ b/tracker/templates/tracker/prizeindex.html
@@ -2,7 +2,7 @@
 {% load donation_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Prize Index" %} -- {{ event.name|title }}{% endblock %}
+{% block title %}{% trans "Prize Index" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
     <div class="fa-stack center-block medium-icon-blue fa-5x">
@@ -10,13 +10,7 @@
     </div>
 
     <h2 class="text-center">
-
-        {% trans "Prize Index" %}
-        &mdash;
-
-        {{ event.name|title }}
-
-
+      {% trans "Prize Index" %} &mdash; {{ event.name }}
     </h2>
 
     {% if settings.SWEEPSTAKES_URL %}
@@ -57,7 +51,7 @@
             <tr class="small">
                 <td>
                     <a href="{% url 'tracker:prize' pk=prize.pk %}">
-                        {{ prize.name|title }}
+                        {{ prize.name }}
                     </a>
                 </td>
                 <td>
@@ -74,13 +68,13 @@
                 <td>
                     {% if prize.startrun %}
                         <a href="{% url 'tracker:run' pk=prize.startrun.pk %}">
-                            {{ prize.startrun.name_with_category|title }}
+                            {{ prize.startrun.name_with_category }}
                         </a>
                     {% endif %}
                     {% if prize.startrun != prize.endrun %}
                         <i class="fa fa-arrows-h"></i>
                         <a href="{% url 'tracker:run' pk=prize.endrun.pk %}">
-                            {{ prize.endrun.name_with_category|title }}
+                            {{ prize.endrun.name_with_category }}
                         </a>
                     {% endif %}
                     {% if prize.starttime %}

--- a/tracker/templates/tracker/run.html
+++ b/tracker/templates/tracker/run.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Run Detail" %} -- {{ event.name }}{% endblock %}
+{% block title %}{% trans "Run Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
 	<h2 class="text-center">

--- a/tracker/templates/tracker/runindex.html
+++ b/tracker/templates/tracker/runindex.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 
-{% block title %}{% trans "Run Index" %} -- {{ event.name }}{% endblock %}
+{% block title %}{% trans "Run Index" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
 <div class="fa-stack center-block medium-icon-blue fa-5x">
@@ -40,7 +40,7 @@
 	{% for run in runs %}
 		<tr class="small">
 			<td>
-				<a href="{% url 'tracker:run' pk=run.pk %}">{{ run.name_with_category|title }}</a>
+				<a href="{% url 'tracker:run' pk=run.pk %}">{{ run.name_with_category }}</a>
 			</td>
 			<td>
 				{{ run.deprecated_runners }}

--- a/tracker/templates/tracker/submit_prize.html
+++ b/tracker/templates/tracker/submit_prize.html
@@ -2,19 +2,17 @@
 {% load donation_tags %}
 {% load static %}
 
-{% block title %}
-        {{ event.name|title }} -- Submit Prize
-{% endblock %}
+{% block title %}{{ event.name }} &mdash; Submit Prize{% endblock %}
 
 {% block nav %}
 {% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" type="text/css" href="{% static "donate.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static 'donate.css' %}" />
 
   <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700' rel='stylesheet' type='text/css'>
 
-  <script src="{% static "donationbids.js" %}"></script>
+  <script src="{% static 'donationbids.js' %}"></script>
 
   <script type="text/javascript">
 

--- a/tracker/templates/tracker/submit_prize_success.html
+++ b/tracker/templates/tracker/submit_prize_success.html
@@ -2,11 +2,11 @@
 {% load static %}
 
 {% block title %}
-    {{ event.name|title }} -- Submit Prize
+    {{ event.name }} &mdash; Submit Prize
 {% endblock %}
 
 {% block head %}
-    <link rel="stylesheet" type="text/css" href="{% static "main.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'main.css' %}" />
 {% endblock %}
 
 {% block content %}

--- a/tracker/templates/ui/index.html
+++ b/tracker/templates/ui/index.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-    {{ event.name|title }}{% if title %} -- {{ title }}{% endif %}
+    {{ event.name }}{% if title %} &mdash; {{ title }}{% endif %}
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
# Contributing to the Donation Tracker

~~- [ ] I've added tests or modified existing tests for the change.~~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174781770

### Description of the Change

Just a text/style pass on some things I noticed in the templates. 

- The `title` filter isn't helpful because it makes getting precise capitalization impossible ("Mega Man III" comes to mind)
- Use `&mdash;` where appropriate
- Improve syntax highlighting by using single quotes for template tags, especially when the tag itself is embedded inside a double-quoted HTML attribute

### Verification Process

Tests all pass (none of the templates have parsing issues), and I did a quick visual pass on any view that used one of the affected templates to make sure they didn't change in unexpected ways.