### PR TITLE
HIDDEN bid state propagates again [#174781797]

### DIFF
--- a/tests/test_bid.py
+++ b/tests/test_bid.py
@@ -34,17 +34,14 @@ class TestBidBase(TestCase):
         self.opened_parent_bid = models.Bid.objects.create(
             name='Opened Parent Test', speedrun=self.run, state='OPENED'
         )
-        self.opened_parent_bid.clean()
         self.opened_parent_bid.save()
         self.closed_parent_bid = models.Bid.objects.create(
             name='Closed Parent Test', speedrun=self.run, state='CLOSED'
         )
-        self.closed_parent_bid.clean()
         self.closed_parent_bid.save()
         self.hidden_parent_bid = models.Bid.objects.create(
             name='Hidden Parent Test', speedrun=self.run, state='HIDDEN'
         )
-        self.hidden_parent_bid.clean()
         self.hidden_parent_bid.save()
         self.opened_bid = models.Bid.objects.create(
             name='Opened Test',
@@ -52,7 +49,6 @@ class TestBidBase(TestCase):
             parent=self.opened_parent_bid,
             state='OPENED',
         )
-        self.opened_bid.clean()
         self.opened_bid.save()
         # this one needs a different parent because of the way opened/closed interacts through the tree
         self.closed_bid = models.Bid.objects.create(
@@ -61,7 +57,6 @@ class TestBidBase(TestCase):
             parent=self.closed_parent_bid,
             state='CLOSED',
         )
-        self.closed_bid.clean()
         self.closed_bid.save()
         self.hidden_bid = models.Bid.objects.create(
             name='Hidden Test',
@@ -69,7 +64,6 @@ class TestBidBase(TestCase):
             parent=self.hidden_parent_bid,
             state='HIDDEN',
         )
-        self.hidden_bid.clean()
         self.hidden_bid.save()
         self.denied_bid = models.Bid.objects.create(
             name='Denied Test',
@@ -77,7 +71,6 @@ class TestBidBase(TestCase):
             parent=self.opened_parent_bid,
             state='DENIED',
         )
-        self.denied_bid.clean()
         self.denied_bid.save()
         self.pending_bid = models.Bid.objects.create(
             name='Pending Test',
@@ -85,7 +78,6 @@ class TestBidBase(TestCase):
             parent=self.opened_parent_bid,
             state='PENDING',
         )
-        self.pending_bid.clean()
         self.pending_bid.save()
 
 

--- a/tests/test_bid.py
+++ b/tests/test_bid.py
@@ -160,18 +160,14 @@ class TestBid(TestBidBase):
                 state,
                 msg=f'Child state `{state}` did not propagate from parent during parent save',
             )
-            self.pending_bid.refresh_from_db()
-            self.assertEqual(
-                self.pending_bid.state,
-                'PENDING',
-                msg='Child state `PENDING` should not have changed during parent save',
-            )
-            self.denied_bid.refresh_from_db()
-            self.assertEqual(
-                self.denied_bid.state,
-                'DENIED',
-                msg='Child state `PENDING` should not have changed during parent save',
-            )
+            for bid in [self.pending_bid, self.denied_bid]:
+                old_state = bid.state
+                bid.refresh_from_db()
+                self.assertEqual(
+                    bid.state,
+                    old_state,
+                    msg=f'Child state `{old_state}` should not have changed during parent save',
+                )
         for state in ['CLOSED', 'HIDDEN']:
             self.opened_bid.state = state
             self.opened_bid.save()

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -30,8 +30,16 @@ class FiltersFeedsTestCase(TransactionTestCase):
         self.closed_bids = closed_bids[0] + closed_bids[1]
         hidden_bids = randgen.generate_bids(self.rand, self.event, 5, state='HIDDEN')
         self.hidden_bids = hidden_bids[0] + hidden_bids[1]
-        pending_bids = randgen.generate_bids(self.rand, self.event, 5, state='PENDING')
-        self.pending_bids = pending_bids[0] + pending_bids[1]
+        pending_bids = randgen.generate_bids(
+            self.rand, self.event, 5, parent_state='OPENED', state='PENDING'
+        )
+        self.opened_bids += pending_bids[0]
+        self.pending_bids = pending_bids[1]
+        denied_bids = randgen.generate_bids(
+            self.rand, self.event, 5, parent_state='OPENED', state='DENIED'
+        )
+        self.opened_bids += denied_bids[0]
+        self.denied_bids = denied_bids[1]
         self.accepted_prizes = randgen.generate_prizes(self.rand, self.event, 5)
         self.pending_prizes = randgen.generate_prizes(
             self.rand, self.event, 5, state='PENDING'

--- a/tracker/admin/bid.py
+++ b/tracker/admin/bid.py
@@ -176,7 +176,6 @@ class BidAdmin(CustomModelAdmin):
         total = queryset.count()
         for b in queryset:
             b.state = value
-            b.clean()
             b.save()  # can't use queryset.update because that doesn't send the post_save signals
             logutil.change(request, b, ['state'])
         if total and not recursive:


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174781797

### Description of the Change

At some point (buried in an unrelated commit) children could be made `HIDDEN` separately from their parents, but this meant that setting the parent to `OPENED` no longer opened up the hidden children as well, which is how we normally do things. This puts that back.

It also cleans up some of the logic around keeping parent/child state in sync, moving it to `save` instead of `clean`.

And also prevents non-child bids from being set as `PENDING` or `DENIED` because that makes no sense.

### Verification Process

Tried to set various combinations of parent/child bid states and verified they changed (or did not change) as expected. The admin dropdown actions still work as expected.