### PR TITLE
remove remaining references to window-level constants [#175027382]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,6 @@
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended"
   ],
-  "globals": {
-    "API_ROOT": true
-  },
   "parser": "@babel/eslint-parser",
   "plugins": [
     "react",
@@ -34,6 +31,7 @@
     "@typescript-eslint/ban-types": 1,
     "@typescript-eslint/camelcase": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
+    "@typescript-eslint/explicit-module-boundary-types": 0,
     "@typescript-eslint/no-empty-function": 0,
     "eqeqeq": [
       2,

--- a/bundles/@types/global.d.ts
+++ b/bundles/@types/global.d.ts
@@ -1,10 +1,7 @@
 export {};
 
 declare global {
-  // TODO: use a constants context instead of window globals
   interface Window {
-    ROOT_PATH: string;
-    API_ROOT: string;
     AdminApp: any;
     TrackerApp: any;
   }

--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -9,6 +9,8 @@ import Dropdown from '../public/dropdown';
 import { actions } from '../public/api';
 import ScheduleEditor from './scheduleEditor';
 import Loading from '../common/Loading';
+import { useConstants } from '../common/Constants';
+import { setAPIRoot } from '../tracker/Endpoints';
 
 const Interstitials = Loadable({
   loader: () => import('./interstitials' /* webpackChunkName: 'interstitials' */),
@@ -18,79 +20,91 @@ const Interstitials = Loadable({
 const App = () => {
   const match = useRouteMatch();
   const dispatch = useDispatch();
+  const [ready, setReady] = React.useState(false);
 
   const { events, status } = useSelector(state => ({
     events: state.models.event,
     status: state.status,
   }));
 
-  React.useEffect(() => {
-    dispatch(actions.singletons.fetchMe());
-  }, [dispatch]);
+  const { API_ROOT } = useConstants();
 
   React.useEffect(() => {
-    if (status.event !== 'success' && status.event !== 'loading') {
+    setAPIRoot(API_ROOT);
+    setReady(true);
+  }, [API_ROOT]);
+
+  React.useEffect(() => {
+    if (ready) {
+      dispatch(actions.singletons.fetchMe());
+    }
+  }, [dispatch, ready]);
+
+  React.useEffect(() => {
+    if (status.event !== 'success' && status.event !== 'loading' && ready) {
       dispatch(actions.models.loadModels('event'));
     }
-  }, [dispatch, status.event]);
+  }, [dispatch, status.event, ready]);
 
   return (
-    <div style={{ position: 'relative', display: 'flex', height: 'calc(100vh - 51px)', flexDirection: 'column' }}>
-      <div style={{ height: 60, display: 'flex', alignItems: 'center' }}>
-        <Spinner spinning={status.event === 'loading'}>
-          Schedule Editor
-          <Dropdown closeOnClick={true}>
-            <div
-              style={{
-                border: '1px solid',
-                position: 'absolute',
-                backgroundColor: 'white',
-                minWidth: '200px',
-                maxHeight: '120px',
-                overflowY: 'auto',
-              }}>
-              <ul style={{ display: 'block' }}>
-                {events &&
-                  events.map(e => {
-                    return (
-                      <li key={e.pk}>
-                        <Link to={`${match.url}/schedule_editor/${e.pk}`}>{e.short}</Link>
-                      </li>
-                    );
-                  })}
-              </ul>
-            </div>
-          </Dropdown>
-          &mdash; Interstitials
-          <Dropdown closeOnClick={true}>
-            <div
-              style={{
-                border: '1px solid',
-                position: 'absolute',
-                backgroundColor: 'white',
-                minWidth: '200px',
-                maxHeight: '120px',
-                overflowY: 'auto',
-              }}>
-              <ul style={{ display: 'block' }}>
-                {events &&
-                  events.map(e => {
-                    return (
-                      <li key={e.pk}>
-                        <Link to={`${match.url}/interstitials/${e.pk}`}>{e.short}</Link>
-                      </li>
-                    );
-                  })}
-              </ul>
-            </div>
-          </Dropdown>
-        </Spinner>
+    ready && (
+      <div style={{ position: 'relative', display: 'flex', height: 'calc(100vh - 51px)', flexDirection: 'column' }}>
+        <div style={{ height: 60, display: 'flex', alignItems: 'center' }}>
+          <Spinner spinning={status.event === 'loading'}>
+            Schedule Editor
+            <Dropdown closeOnClick={true}>
+              <div
+                style={{
+                  border: '1px solid',
+                  position: 'absolute',
+                  backgroundColor: 'white',
+                  minWidth: '200px',
+                  maxHeight: '120px',
+                  overflowY: 'auto',
+                }}>
+                <ul style={{ display: 'block' }}>
+                  {events &&
+                    events.map(e => {
+                      return (
+                        <li key={e.pk}>
+                          <Link to={`${match.url}/schedule_editor/${e.pk}`}>{e.short}</Link>
+                        </li>
+                      );
+                    })}
+                </ul>
+              </div>
+            </Dropdown>
+            &mdash; Interstitials
+            <Dropdown closeOnClick={true}>
+              <div
+                style={{
+                  border: '1px solid',
+                  position: 'absolute',
+                  backgroundColor: 'white',
+                  minWidth: '200px',
+                  maxHeight: '120px',
+                  overflowY: 'auto',
+                }}>
+                <ul style={{ display: 'block' }}>
+                  {events &&
+                    events.map(e => {
+                      return (
+                        <li key={e.pk}>
+                          <Link to={`${match.url}/interstitials/${e.pk}`}>{e.short}</Link>
+                        </li>
+                      );
+                    })}
+                </ul>
+              </div>
+            </Dropdown>
+          </Spinner>
+        </div>
+        <div style={{ flex: '1 0 1', overflow: 'auto' }}>
+          <Route path={`${match.url}/schedule_editor/:event`} component={ScheduleEditor} />
+          <Route path={`${match.url}/interstitials/:event`} component={Interstitials} />
+        </div>
       </div>
-      <div style={{ flex: '1 0 1', overflow: 'auto' }}>
-        <Route path={`${match.url}/schedule_editor/:event`} component={ScheduleEditor} />
-        <Route path={`${match.url}/interstitials/:event`} component={Interstitials} />
-      </div>
-    </div>
+    )
   );
 };
 

--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -6,7 +6,7 @@ import Loadable from 'react-loadable';
 
 import Spinner from '../public/spinner';
 import Dropdown from '../public/dropdown';
-import { actions, history, store } from '../public/api';
+import { actions } from '../public/api';
 import ScheduleEditor from './scheduleEditor';
 import Loading from '../common/Loading';
 
@@ -93,8 +93,5 @@ const App = () => {
     </div>
   );
 };
-
-App.store = store;
-App.history = history;
 
 export default App;

--- a/bundles/admin/index.js
+++ b/bundles/admin/index.js
@@ -10,18 +10,21 @@ import ErrorBoundary from 'ui/public/errorBoundary';
 
 import App from './app';
 import Constants from '../common/Constants';
+import { createTrackerStore } from '../public/api';
 
 window.AdminApp = function (props) {
   function redirect({ location }) {
     return <Redirect to={location.pathname.replace(/\/\/+/g, '/')} />;
   }
 
+  const store = createTrackerStore({ apiRoot: props.CONSTANTS.API_ROOT });
+
   ReactDOM.render(
     <ErrorBoundary>
       <DndProvider backend={HTML5Backend}>
-        <Provider store={App.store}>
+        <Provider store={store}>
           <Constants.Provider value={props.CONSTANTS}>
-            <ConnectedRouter history={App.history}>
+            <ConnectedRouter history={store.history}>
               <Switch>
                 <Route exact strict path="(.*//+.*)" render={redirect} />
                 <Route path={props.ROOT_PATH} component={App} />

--- a/bundles/admin/index.js
+++ b/bundles/admin/index.js
@@ -17,7 +17,7 @@ window.AdminApp = function (props) {
     return <Redirect to={location.pathname.replace(/\/\/+/g, '/')} />;
   }
 
-  const store = createTrackerStore({ apiRoot: props.CONSTANTS.API_ROOT });
+  const store = createTrackerStore();
 
   ReactDOM.render(
     <ErrorBoundary>

--- a/bundles/public/api/actions/models.js
+++ b/bundles/public/api/actions/models.js
@@ -54,9 +54,9 @@ const modelTypeMap = {
 };
 
 function loadModels(model, params, additive) {
-  return dispatch => {
+  return (dispatch, getState, { apiRoot }) => {
     dispatch(onModelStatusLoad(model));
-    return HTTPUtil.get(`${API_ROOT}search`, {
+    return HTTPUtil.get(`${apiRoot}search/`, {
       ...params,
       type: modelTypeMap[model] || model,
     })
@@ -153,10 +153,10 @@ function onSaveDraftModelError(model, error, fields) {
 }
 
 function saveDraftModels(models) {
-  return dispatch => {
+  return (dispatch, getState, { apiRoot }) => {
     _.each(models, model => {
       dispatch(setInternalModelField(model.type, model.pk, 'saving', true));
-      const url = model.pk < 0 ? `${API_ROOT}add/` : `${API_ROOT}edit/`;
+      const url = model.pk < 0 ? `${apiRoot}add/` : `${apiRoot}edit/`;
 
       HTTPUtil.post(
         url,
@@ -194,14 +194,14 @@ function saveDraftModels(models) {
 }
 
 function saveField(model, field, value) {
-  return dispatch => {
+  return (dispatch, getState, { apiRoot }) => {
     if (model.pk) {
       dispatch(setInternalModelField(model.type, model.pk, 'saving', true));
       if (value === undefined || value === null) {
         value = 'None';
       }
       HTTPUtil.post(
-        `${API_ROOT}edit/`,
+        `${apiRoot}edit/`,
         {
           type: modelTypeMap[model.type] || model.type,
           id: model.pk,
@@ -239,9 +239,9 @@ function saveField(model, field, value) {
 }
 
 function command(command) {
-  return dispatch => {
+  return (dispatch, getState, { apiRoot }) => {
     return HTTPUtil.post(
-      `${API_ROOT}command/`,
+      `${apiRoot}command/`,
       {
         data: JSON.stringify({
           command: command.type,

--- a/bundles/public/api/actions/models.js
+++ b/bundles/public/api/actions/models.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import HTTPUtil from '../../util/http';
+import Endpoints from '../../../tracker/Endpoints';
 
 function onModelStatusLoad(model) {
   return {
@@ -54,9 +55,9 @@ const modelTypeMap = {
 };
 
 function loadModels(model, params, additive) {
-  return (dispatch, getState, { apiRoot }) => {
+  return dispatch => {
     dispatch(onModelStatusLoad(model));
-    return HTTPUtil.get(`${apiRoot}search/`, {
+    return HTTPUtil.get(Endpoints.SEARCH, {
       ...params,
       type: modelTypeMap[model] || model,
     })
@@ -153,10 +154,10 @@ function onSaveDraftModelError(model, error, fields) {
 }
 
 function saveDraftModels(models) {
-  return (dispatch, getState, { apiRoot }) => {
-    _.each(models, model => {
+  return dispatch => {
+    models.forEach(model => {
       dispatch(setInternalModelField(model.type, model.pk, 'saving', true));
-      const url = model.pk < 0 ? `${apiRoot}add/` : `${apiRoot}edit/`;
+      const url = model.pk < 0 ? Endpoints.ADD : Endpoints.EDIT;
 
       HTTPUtil.post(
         url,
@@ -194,14 +195,14 @@ function saveDraftModels(models) {
 }
 
 function saveField(model, field, value) {
-  return (dispatch, getState, { apiRoot }) => {
+  return dispatch => {
     if (model.pk) {
       dispatch(setInternalModelField(model.type, model.pk, 'saving', true));
       if (value === undefined || value === null) {
         value = 'None';
       }
       HTTPUtil.post(
-        `${apiRoot}edit/`,
+        Endpoints.EDIT,
         {
           type: modelTypeMap[model.type] || model.type,
           id: model.pk,
@@ -239,9 +240,9 @@ function saveField(model, field, value) {
 }
 
 function command(command) {
-  return (dispatch, getState, { apiRoot }) => {
+  return dispatch => {
     return HTTPUtil.post(
-      `${apiRoot}command/`,
+      Endpoints.COMMAND,
       {
         data: JSON.stringify({
           command: command.type,

--- a/bundles/public/api/actions/singletons.js
+++ b/bundles/public/api/actions/singletons.js
@@ -1,4 +1,5 @@
 import HTTPUtil from '../../util/http';
+import Endpoints from '../../../tracker/Endpoints';
 
 function onLoadMe(me) {
   return {
@@ -8,14 +9,14 @@ function onLoadMe(me) {
 }
 
 export function fetchMe() {
-  return (dispatch, getState, { apiRoot }) => {
+  return dispatch => {
     dispatch({
       type: 'MODEL_STATUS_LOADING',
       model: {
         type: 'me',
       },
     });
-    return HTTPUtil.get(`${apiRoot}me`)
+    return HTTPUtil.get(Endpoints.ME)
       .then(me => {
         dispatch({
           type: 'MODEL_STATUS_SUCCESS',

--- a/bundles/public/api/actions/singletons.js
+++ b/bundles/public/api/actions/singletons.js
@@ -8,14 +8,14 @@ function onLoadMe(me) {
 }
 
 export function fetchMe() {
-  return dispatch => {
+  return (dispatch, getState, { apiRoot }) => {
     dispatch({
       type: 'MODEL_STATUS_LOADING',
       model: {
         type: 'me',
       },
     });
-    return HTTPUtil.get(`${API_ROOT}me`)
+    return HTTPUtil.get(`${apiRoot}me`)
       .then(me => {
         dispatch({
           type: 'MODEL_STATUS_SUCCESS',

--- a/bundles/public/api/actions/singletonsSpec.js
+++ b/bundles/public/api/actions/singletonsSpec.js
@@ -3,8 +3,9 @@ import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 
 import singletons from './singletons';
+import Endpoints from '../../../tracker/Endpoints';
 
-const mockStore = configureMockStore([thunk.withExtraArgument({ apiRoot: 'http://testserver/' })]);
+const mockStore = configureMockStore([thunk]);
 
 const expectActions = (store, creator, expected = []) => {
   store.dispatch(creator).then(() => {
@@ -32,7 +33,7 @@ describe('singletons actions', () => {
 
     describe('when the thunk is called', () => {
       beforeEach(() => {
-        fetchMock.restore().getOnce('path:/me', {
+        fetchMock.restore().getOnce(Endpoints.ME, {
           body: { todos: ['do something'] },
           headers: { 'content-type': 'application/json' },
         });
@@ -55,7 +56,7 @@ describe('singletons actions', () => {
       describe('when the call succeeds', () => {
         const ME_DATA = { username: 'jazzaboo' };
         beforeEach(() => {
-          fetchMock.restore().getOnce('path:/me', {
+          fetchMock.restore().getOnce(Endpoints.ME, {
             body: ME_DATA,
             headers: { 'content-type': 'application/json' },
           });
@@ -78,7 +79,7 @@ describe('singletons actions', () => {
 
       describe('when the call fails', () => {
         beforeEach(() => {
-          fetchMock.restore().getOnce('path:/me', new Promise((res, reject) => reject()));
+          fetchMock.restore().getOnce(Endpoints.ME, new Promise((res, reject) => reject()));
         });
 
         it('dispatches a model error for "me"', () => {

--- a/bundles/public/api/actions/singletonsSpec.js
+++ b/bundles/public/api/actions/singletonsSpec.js
@@ -4,7 +4,7 @@ import configureMockStore from 'redux-mock-store';
 
 import singletons from './singletons';
 
-const mockStore = configureMockStore([thunk]);
+const mockStore = configureMockStore([thunk.withExtraArgument({ apiRoot: 'http://testserver/' })]);
 
 const expectActions = (store, creator, expected = []) => {
   store.dispatch(creator).then(() => {
@@ -17,7 +17,6 @@ describe('singletons actions', () => {
   let store;
 
   beforeEach(() => {
-    window.API_ROOT = 'http://testserver/';
     fetchMock.restore();
   });
 
@@ -33,7 +32,7 @@ describe('singletons actions', () => {
 
     describe('when the thunk is called', () => {
       beforeEach(() => {
-        fetchMock.restore().getOnce(`${API_ROOT}me`, {
+        fetchMock.restore().getOnce('path:/me', {
           body: { todos: ['do something'] },
           headers: { 'content-type': 'application/json' },
         });
@@ -56,7 +55,7 @@ describe('singletons actions', () => {
       describe('when the call succeeds', () => {
         const ME_DATA = { username: 'jazzaboo' };
         beforeEach(() => {
-          fetchMock.restore().getOnce(`${API_ROOT}me`, {
+          fetchMock.restore().getOnce('path:/me', {
             body: ME_DATA,
             headers: { 'content-type': 'application/json' },
           });
@@ -79,7 +78,7 @@ describe('singletons actions', () => {
 
       describe('when the call fails', () => {
         beforeEach(() => {
-          fetchMock.restore().getOnce(`${API_ROOT}me`, new Promise((res, reject) => reject()));
+          fetchMock.restore().getOnce('path:/me', new Promise((res, reject) => reject()));
         });
 
         it('dispatches a model error for "me"', () => {

--- a/bundles/public/api/actions/singletonsSpec.js
+++ b/bundles/public/api/actions/singletonsSpec.js
@@ -33,7 +33,7 @@ describe('singletons actions', () => {
 
     describe('when the thunk is called', () => {
       beforeEach(() => {
-        fetchMock.restore().getOnce(Endpoints.ME, {
+        fetchMock.getOnce(Endpoints.ME, {
           body: { todos: ['do something'] },
           headers: { 'content-type': 'application/json' },
         });
@@ -49,14 +49,14 @@ describe('singletons actions', () => {
 
       it('sends a request to the ME endpoint', () => {
         store.dispatch(action).then(() => {
-          expect(fetchMock.done());
+          expect(fetchMock.done()).toBe(true);
         });
       });
 
       describe('when the call succeeds', () => {
         const ME_DATA = { username: 'jazzaboo' };
         beforeEach(() => {
-          fetchMock.restore().getOnce(Endpoints.ME, {
+          fetchMock.getOnce(Endpoints.ME, {
             body: ME_DATA,
             headers: { 'content-type': 'application/json' },
           });

--- a/bundles/public/api/actions/singletonsSpec.js
+++ b/bundles/public/api/actions/singletonsSpec.js
@@ -56,7 +56,7 @@ describe('singletons actions', () => {
       describe('when the call succeeds', () => {
         const ME_DATA = { username: 'jazzaboo' };
         beforeEach(() => {
-          fetchMock.getOnce(Endpoints.ME, {
+          fetchMock.restore().getOnce(Endpoints.ME, {
             body: ME_DATA,
             headers: { 'content-type': 'application/json' },
           });

--- a/bundles/public/api/index.js
+++ b/bundles/public/api/index.js
@@ -9,8 +9,6 @@ import freeze from 'ui/public/util/freeze';
 import actions from './actions';
 import createRootReducer from './reducers';
 
-const history = createBrowserHistory();
-
 const freezeReducer = store => next => action => {
   const result = next(action);
   freeze(store.getState());
@@ -22,15 +20,15 @@ const composeEnhancers = composeWithDevTools({
   trace: true,
 });
 
-const store = createStore(
-  createRootReducer(history),
-  composeEnhancers(applyMiddleware(freezeReducer, thunk, routerMiddleware(history))),
-);
+export { actions };
 
-export { actions, store, history };
+export function createTrackerStore({ apiRoot, history }) {
+  history = history || createBrowserHistory();
 
-export default {
-  actions,
-  store,
-  history,
-};
+  const store = createStore(
+    createRootReducer(history),
+    composeEnhancers(applyMiddleware(freezeReducer, thunk.withExtraArgument({ apiRoot }), routerMiddleware(history))),
+  );
+  store.history = history;
+  return store;
+}

--- a/bundles/public/api/index.js
+++ b/bundles/public/api/index.js
@@ -22,12 +22,12 @@ const composeEnhancers = composeWithDevTools({
 
 export { actions };
 
-export function createTrackerStore({ apiRoot, history }) {
+export function createTrackerStore({ history } = {}) {
   history = history || createBrowserHistory();
 
   const store = createStore(
     createRootReducer(history),
-    composeEnhancers(applyMiddleware(freezeReducer, thunk.withExtraArgument({ apiRoot }), routerMiddleware(history))),
+    composeEnhancers(applyMiddleware(freezeReducer, thunk, routerMiddleware(history))),
   );
   store.history = history;
   return store;

--- a/bundles/tracker/App.tsx
+++ b/bundles/tracker/App.tsx
@@ -4,24 +4,38 @@ import { Router, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import DonateInitializer from './donation/components/DonateInitializer';
 import EventRouter from './events/components/EventRouter';
 import NotFound from './router/components/NotFound';
-import { Routes, useRouterUtils } from './router/RouterUtils';
+import { Routes, createTrackerHistory } from './router/RouterUtils';
+import { useConstants } from '../common/Constants';
+import { setAPIRoot } from './Endpoints';
 
 const App = (props: React.ComponentProps<typeof DonateInitializer>) => {
-  const { history } = useRouterUtils();
+  const history = React.useMemo(() => createTrackerHistory(props.ROOT_PATH), [props.ROOT_PATH]);
+  const { API_ROOT } = useConstants();
+  const [ready, setReady] = React.useState(false);
+
+  React.useEffect(() => {
+    setAPIRoot(API_ROOT);
+    setReady(true);
+  }, [API_ROOT]);
+
   return (
-    <Router history={history}>
-      <Switch>
-        {/* TODO: Remove `EVENT_DONATE` from here once it gets normalized */}
-        <Route path={[Routes.EVENT_BASE(':eventId'), Routes.EVENT_DONATE(':eventId')]}>
-          {({ match }: RouteComponentProps<{ eventId: string }>) => {
-            // This has to be done as a custom child to pass through DonateInitializerProps
-            const { eventId } = match.params;
-            return <EventRouter {...props} eventId={eventId} />;
-          }}
-        </Route>
-        <NotFound />
-      </Switch>
-    </Router>
+    <>
+      {ready && (
+        <Router history={history}>
+          <Switch>
+            {/* TODO: Remove `EVENT_DONATE` from here once it gets normalized */}
+            <Route path={[Routes.EVENT_BASE(':eventId'), Routes.EVENT_DONATE(':eventId')]}>
+              {({ match }: RouteComponentProps<{ eventId: string }>) => {
+                // This has to be done as a custom child to pass through DonateInitializerProps
+                const { eventId } = match.params;
+                return <EventRouter {...props} eventId={eventId} />;
+              }}
+            </Route>
+            <NotFound />
+          </Switch>
+        </Router>
+      )}
+    </>
   );
 };
 

--- a/bundles/tracker/App.tsx
+++ b/bundles/tracker/App.tsx
@@ -4,9 +4,10 @@ import { Router, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import DonateInitializer from './donation/components/DonateInitializer';
 import EventRouter from './events/components/EventRouter';
 import NotFound from './router/components/NotFound';
-import { Routes, history } from './router/RouterUtils';
+import { Routes, useRouterUtils } from './router/RouterUtils';
 
 const App = (props: React.ComponentProps<typeof DonateInitializer>) => {
+  const { history } = useRouterUtils();
   return (
     <Router history={history}>
       <Switch>

--- a/bundles/tracker/Endpoints.ts
+++ b/bundles/tracker/Endpoints.ts
@@ -1,0 +1,23 @@
+let apiRoot: string | null = null;
+
+export function setAPIRoot(url: string) {
+  apiRoot = url;
+}
+
+export default {
+  get SEARCH() {
+    return `${apiRoot}search/`;
+  },
+  get ADD() {
+    return `${apiRoot}add/`;
+  },
+  get EDIT() {
+    return `${apiRoot}edit/`;
+  },
+  get COMMAND() {
+    return `${apiRoot}command/`;
+  },
+  get ME() {
+    return `${apiRoot}me/`;
+  },
+};

--- a/bundles/tracker/Endpoints.ts
+++ b/bundles/tracker/Endpoints.ts
@@ -1,9 +1,0 @@
-function root() {
-  return window.API_ROOT || 'http://testserver/';
-}
-
-export default {
-  get SEARCH() {
-    return `${root()}search/`;
-  },
-};

--- a/bundles/tracker/Store.ts
+++ b/bundles/tracker/Store.ts
@@ -16,9 +16,15 @@ export const combinedReducer = combineReducers({
 
 export type StoreState = ReturnType<typeof combinedReducer>;
 
+export interface ExtraArguments {
+  apiRoot: string;
+}
+
 const composeEnhancers = composeWithDevTools({
   // Uncomment to see stacktraces in the devtools for each action fired.
   // trace: true,
 });
 
-export const store = createStore(combinedReducer, composeEnhancers(applyMiddleware(thunk)));
+export function createTrackerStore(extraArguments: ExtraArguments) {
+  return createStore(combinedReducer, composeEnhancers(applyMiddleware(thunk.withExtraArgument(extraArguments))));
+}

--- a/bundles/tracker/Store.ts
+++ b/bundles/tracker/Store.ts
@@ -16,15 +16,11 @@ export const combinedReducer = combineReducers({
 
 export type StoreState = ReturnType<typeof combinedReducer>;
 
-export interface ExtraArguments {
-  apiRoot: string;
-}
-
 const composeEnhancers = composeWithDevTools({
   // Uncomment to see stacktraces in the devtools for each action fired.
   // trace: true,
 });
 
-export function createTrackerStore(extraArguments: ExtraArguments) {
-  return createStore(combinedReducer, composeEnhancers(applyMiddleware(thunk.withExtraArgument(extraArguments))));
+export function createTrackerStore() {
+  return createStore(combinedReducer, composeEnhancers(applyMiddleware(thunk)));
 }

--- a/bundles/tracker/donation/components/DonateInitializer.tsx
+++ b/bundles/tracker/donation/components/DonateInitializer.tsx
@@ -5,9 +5,9 @@ import * as CurrencyUtils from '../../../public/util/currency';
 import * as EventDetailsActions from '../../event_details/EventDetailsActions';
 import { Prize } from '../../event_details/EventDetailsTypes';
 import useDispatch from '../../hooks/useDispatch';
-import RouterUtils from '../../router/RouterUtils';
 import * as DonationActions from '../DonationActions';
 import { Bid, DonationFormErrors } from '../DonationTypes';
+import { useRouterUtils } from '../../router/RouterUtils';
 
 /*
   DonateInitializer acts as a proxy for bringing the preloaded props provided
@@ -70,7 +70,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     // EventDetails
     incentives,
     prizes,
-    event: { receivername: receiverName },
+    event,
     prizesUrl,
     donateUrl,
     minimumDonation = 1,
@@ -84,7 +84,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
   } = props;
 
   const dispatch = useDispatch();
-  const urlHash = RouterUtils.getLocationHash();
+  const urlHash = useRouterUtils().getLocationHash();
 
   React.useEffect(() => {
     // This transform is lossy and a little brittle, making the assumption that
@@ -103,7 +103,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     };
 
     dispatch(DonationActions.loadDonation(transformedDonation, transformedBids as Bid[], formErrors));
-  }, [dispatch, initialForm]);
+  }, [dispatch, formErrors, initialForm, initialIncentives]);
 
   React.useEffect(() => {
     const transformedIncentives = incentives.map(incentive => {
@@ -117,7 +117,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     dispatch(
       EventDetailsActions.loadEventDetails({
         csrfToken,
-        receiverName,
+        receiverName: event.receivername,
         prizesUrl,
         donateUrl,
         minimumDonation,
@@ -127,14 +127,14 @@ const DonateInitializer = (props: DonateInitializerProps) => {
         prizes,
       }),
     );
-  }, [dispatch, event, prizesUrl, donateUrl, minimumDonation, maximumDonation, step, incentives, prizes]);
+  }, [dispatch, event, prizesUrl, donateUrl, minimumDonation, maximumDonation, step, incentives, prizes, csrfToken]);
 
   React.useEffect(() => {
     const presetAmount = CurrencyUtils.parseCurrency(urlHash);
     if (presetAmount != null) {
       dispatch(DonationActions.updateDonation({ amount: presetAmount }));
     }
-  }, []);
+  }, [dispatch, urlHash]);
 
   return null;
 };

--- a/bundles/tracker/donation/components/DonateInitializer.tsx
+++ b/bundles/tracker/donation/components/DonateInitializer.tsx
@@ -7,7 +7,7 @@ import { Prize } from '../../event_details/EventDetailsTypes';
 import useDispatch from '../../hooks/useDispatch';
 import * as DonationActions from '../DonationActions';
 import { Bid, DonationFormErrors } from '../DonationTypes';
-import { useRouterUtils } from '../../router/RouterUtils';
+import RouterUtils from '../../router/RouterUtils';
 
 /*
   DonateInitializer acts as a proxy for bringing the preloaded props provided
@@ -44,6 +44,7 @@ type InitialIncentive = {
 type DonateInitializerProps = {
   incentives: Incentive[];
   formErrors: DonationFormErrors;
+  ROOT_PATH: string;
   initialForm: {
     requestedvisibility?: string;
     requestedalias?: string;
@@ -84,7 +85,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
   } = props;
 
   const dispatch = useDispatch();
-  const urlHash = useRouterUtils().getLocationHash();
+  const urlHash = RouterUtils.getLocationHash();
 
   React.useEffect(() => {
     // This transform is lossy and a little brittle, making the assumption that

--- a/bundles/tracker/events/EventActions.ts
+++ b/bundles/tracker/events/EventActions.ts
@@ -1,10 +1,10 @@
 import { ActionTypes } from '../Action';
-import Endpoints from '../Endpoints';
 import { SafeDispatch } from '../hooks/useDispatch';
 import * as CurrencyUtils from '../../public/util/currency';
 import * as HTTPUtils from '../../public/util/http';
 import TimeUtils from '../../public/util/TimeUtils';
 import { Event, EventSearchFilter } from './EventTypes';
+import { ExtraArguments, StoreState } from '../Store';
 
 function eventFromAPIEvent({ pk, fields }: { pk: number; fields: { [field: string]: any } }): Event {
   return {
@@ -52,7 +52,7 @@ export function selectEvent(eventId: string) {
 }
 
 export function fetchEvents(filter: EventSearchFilter = {}) {
-  return (dispatch: SafeDispatch) => {
+  return (dispatch: SafeDispatch, getState: () => StoreState, { apiRoot }: ExtraArguments) => {
     dispatch({ type: ActionTypes.FETCH_EVENTS_STARTED });
 
     if (filter.id && /\D/.test(filter.id)) {
@@ -60,7 +60,7 @@ export function fetchEvents(filter: EventSearchFilter = {}) {
       delete filter.id;
     }
 
-    return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'event' })
+    return HTTPUtils.get(`${apiRoot}search/`, { ...filter, type: 'event' })
       .then((data: any[]) => {
         const events = data.map(eventFromAPIEvent);
 

--- a/bundles/tracker/events/EventActions.ts
+++ b/bundles/tracker/events/EventActions.ts
@@ -4,7 +4,7 @@ import * as CurrencyUtils from '../../public/util/currency';
 import * as HTTPUtils from '../../public/util/http';
 import TimeUtils from '../../public/util/TimeUtils';
 import { Event, EventSearchFilter } from './EventTypes';
-import { ExtraArguments, StoreState } from '../Store';
+import Endpoints from '../Endpoints';
 
 function eventFromAPIEvent({ pk, fields }: { pk: number; fields: { [field: string]: any } }): Event {
   return {
@@ -52,7 +52,7 @@ export function selectEvent(eventId: string) {
 }
 
 export function fetchEvents(filter: EventSearchFilter = {}) {
-  return (dispatch: SafeDispatch, getState: () => StoreState, { apiRoot }: ExtraArguments) => {
+  return (dispatch: SafeDispatch) => {
     dispatch({ type: ActionTypes.FETCH_EVENTS_STARTED });
 
     if (filter.id && /\D/.test(filter.id)) {
@@ -60,7 +60,7 @@ export function fetchEvents(filter: EventSearchFilter = {}) {
       delete filter.id;
     }
 
-    return HTTPUtils.get(`${apiRoot}search/`, { ...filter, type: 'event' })
+    return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'event' })
       .then((data: any[]) => {
         const events = data.map(eventFromAPIEvent);
 

--- a/bundles/tracker/events/EventActionsSpec.ts
+++ b/bundles/tracker/events/EventActionsSpec.ts
@@ -3,29 +3,31 @@ import { fetchEvents } from './EventActions';
 import { AnyAction } from 'redux';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
-import Endpoints from '../Endpoints';
-import { StoreState } from '../Store';
+import { ExtraArguments, StoreState } from '../Store';
 
-type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
+type DispatchExts = ThunkDispatch<StoreState, ExtraArguments, AnyAction>;
 
-const mockStore = configureMockStore<StoreState, DispatchExts>([thunk]);
+const mockStore = configureMockStore<StoreState, DispatchExts>([
+  thunk.withExtraArgument({ apiRoot: 'http://testserver/' }),
+]);
 
 describe('EventActions', () => {
   let store: ReturnType<typeof mockStore>;
 
   beforeEach(() => {
     store = mockStore();
+    fetchMock.restore();
   });
 
   describe('#fetchEvents', () => {
     it('works with a numeric id', () => {
-      fetchMock.once(`${Endpoints.SEARCH}?id=1&type=event`, 200);
+      fetchMock.getOnce('path:/search/', 200, { query: { id: '1', type: 'event' } });
       store.dispatch(fetchEvents({ id: '1' }));
-      expect(fetchMock.called()).toBe(true);
+      expect(fetchMock.done()).toBe(true);
     });
 
     it('works with a shortname', () => {
-      fetchMock.once(`${Endpoints.SEARCH}?short=test&type=event`, 200);
+      fetchMock.getOnce('path:/search/', 200, { query: { short: 'test', type: 'event' } });
       store.dispatch(fetchEvents({ id: 'test' }));
       expect(fetchMock.called()).toBe(true);
     });

--- a/bundles/tracker/events/EventActionsSpec.ts
+++ b/bundles/tracker/events/EventActionsSpec.ts
@@ -3,13 +3,12 @@ import { fetchEvents } from './EventActions';
 import { AnyAction } from 'redux';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
-import { ExtraArguments, StoreState } from '../Store';
+import { StoreState } from '../Store';
+import Endpoints from '../Endpoints';
 
-type DispatchExts = ThunkDispatch<StoreState, ExtraArguments, AnyAction>;
+type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
 
-const mockStore = configureMockStore<StoreState, DispatchExts>([
-  thunk.withExtraArgument({ apiRoot: 'http://testserver/' }),
-]);
+const mockStore = configureMockStore<StoreState, DispatchExts>([thunk]);
 
 describe('EventActions', () => {
   let store: ReturnType<typeof mockStore>;
@@ -21,13 +20,13 @@ describe('EventActions', () => {
 
   describe('#fetchEvents', () => {
     it('works with a numeric id', () => {
-      fetchMock.getOnce('path:/search/', 200, { query: { id: '1', type: 'event' } });
+      fetchMock.getOnce(Endpoints.SEARCH, 200, { query: { id: '1', type: 'event' } });
       store.dispatch(fetchEvents({ id: '1' }));
       expect(fetchMock.done()).toBe(true);
     });
 
     it('works with a shortname', () => {
-      fetchMock.getOnce('path:/search/', 200, { query: { short: 'test', type: 'event' } });
+      fetchMock.getOnce(Endpoints.SEARCH, 200, { query: { short: 'test', type: 'event' } });
       store.dispatch(fetchEvents({ id: 'test' }));
       expect(fetchMock.called()).toBe(true);
     });

--- a/bundles/tracker/events/EventActionsSpec.ts
+++ b/bundles/tracker/events/EventActionsSpec.ts
@@ -20,15 +20,15 @@ describe('EventActions', () => {
 
   describe('#fetchEvents', () => {
     it('works with a numeric id', () => {
-      fetchMock.getOnce(Endpoints.SEARCH, 200, { query: { id: '1', type: 'event' } });
+      fetchMock.getOnce(`${Endpoints.SEARCH}?id=1&type=event`, 200);
       store.dispatch(fetchEvents({ id: '1' }));
       expect(fetchMock.done()).toBe(true);
     });
 
     it('works with a shortname', () => {
-      fetchMock.getOnce(Endpoints.SEARCH, 200, { query: { short: 'test', type: 'event' } });
+      fetchMock.getOnce(`${Endpoints.SEARCH}?short=test&type=event`, 200);
       store.dispatch(fetchEvents({ id: 'test' }));
-      expect(fetchMock.called()).toBe(true);
+      expect(fetchMock.done()).toBe(true);
     });
   });
 });

--- a/bundles/tracker/index.tsx
+++ b/bundles/tracker/index.tsx
@@ -5,17 +5,23 @@ import { Provider } from 'react-redux';
 import ErrorBoundary from '../public/errorBoundary';
 import ThemeProvider from '../uikit/ThemeProvider';
 import AppWrapper from './App';
-import { store } from './Store';
+import { createTrackerStore } from './Store';
+import { createRouterUtils, RouterUtils } from './router/RouterUtils';
 
 // TODO: Migrate all page-load props to API calls. Currently these props
 // are just being proxied through to `AppWrapper` which decides what props
 // it should expect, and is only used for the `/donate` page.
 window.TrackerApp = (props: any) => {
+  const store = createTrackerStore({ apiRoot: props.CONSTANTS.API_ROOT });
+  const routerUtils = createRouterUtils({ rootPath: props.ROOT_PATH });
+
   ReactDOM.render(
     <Provider store={store}>
       <ThemeProvider>
         <ErrorBoundary>
-          <AppWrapper {...props} />
+          <RouterUtils.Provider value={routerUtils}>
+            <AppWrapper {...props} />
+          </RouterUtils.Provider>
         </ErrorBoundary>
       </ThemeProvider>
     </Provider>,

--- a/bundles/tracker/index.tsx
+++ b/bundles/tracker/index.tsx
@@ -6,22 +6,21 @@ import ErrorBoundary from '../public/errorBoundary';
 import ThemeProvider from '../uikit/ThemeProvider';
 import AppWrapper from './App';
 import { createTrackerStore } from './Store';
-import { createRouterUtils, RouterUtils } from './router/RouterUtils';
+import Constants from '../common/Constants';
 
 // TODO: Migrate all page-load props to API calls. Currently these props
 // are just being proxied through to `AppWrapper` which decides what props
 // it should expect, and is only used for the `/donate` page.
 window.TrackerApp = (props: any) => {
-  const store = createTrackerStore({ apiRoot: props.CONSTANTS.API_ROOT });
-  const routerUtils = createRouterUtils({ rootPath: props.ROOT_PATH });
+  const store = createTrackerStore();
 
   ReactDOM.render(
     <Provider store={store}>
       <ThemeProvider>
         <ErrorBoundary>
-          <RouterUtils.Provider value={routerUtils}>
+          <Constants.Provider value={props.CONSTANTS}>
             <AppWrapper {...props} />
-          </RouterUtils.Provider>
+          </Constants.Provider>
         </ErrorBoundary>
       </ThemeProvider>
     </Provider>,

--- a/bundles/tracker/prizes/PrizeActions.ts
+++ b/bundles/tracker/prizes/PrizeActions.ts
@@ -7,7 +7,7 @@ import * as HTTPUtils from '../../public/util/http';
 import TimeUtils from '../../public/util/TimeUtils';
 import { Run } from '../runs/RunTypes';
 import { Prize, PrizeSearchFilter } from './PrizeTypes';
-import { ExtraArguments, StoreState } from '../Store';
+import Endpoints from '../Endpoints';
 
 function runFromNestedAPIRun(prefix: string, fields: { [field: string]: any }): Run | undefined {
   const runFields: { [field: string]: any } = {};
@@ -97,7 +97,7 @@ function prizeFromAPIPrize({ pk, fields }: { pk: number; fields: { [field: strin
 }
 
 export function fetchPrizes(filter: PrizeSearchFilter = {}) {
-  return (dispatch: SafeDispatch, getState: () => StoreState, { apiRoot }: ExtraArguments) => {
+  return (dispatch: SafeDispatch) => {
     dispatch({ type: ActionTypes.FETCH_PRIZES_STARTED });
 
     if (filter.event && /\D/.test(filter.event)) {
@@ -105,7 +105,7 @@ export function fetchPrizes(filter: PrizeSearchFilter = {}) {
       delete filter.event;
     }
 
-    return HTTPUtils.get(`${apiRoot}search/`, { ...filter, type: 'prize' })
+    return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'prize' })
       .then((data: any[]) => {
         const prizes = data.map(prizeFromAPIPrize);
 

--- a/bundles/tracker/prizes/PrizeActions.ts
+++ b/bundles/tracker/prizes/PrizeActions.ts
@@ -1,13 +1,13 @@
 import _ from 'lodash';
 
 import { ActionTypes } from '../Action';
-import Endpoints from '../Endpoints';
 import { SafeDispatch } from '../hooks/useDispatch';
 import * as CurrencyUtils from '../../public/util/currency';
 import * as HTTPUtils from '../../public/util/http';
 import TimeUtils from '../../public/util/TimeUtils';
 import { Run } from '../runs/RunTypes';
 import { Prize, PrizeSearchFilter } from './PrizeTypes';
+import { ExtraArguments, StoreState } from '../Store';
 
 function runFromNestedAPIRun(prefix: string, fields: { [field: string]: any }): Run | undefined {
   const runFields: { [field: string]: any } = {};
@@ -97,7 +97,7 @@ function prizeFromAPIPrize({ pk, fields }: { pk: number; fields: { [field: strin
 }
 
 export function fetchPrizes(filter: PrizeSearchFilter = {}) {
-  return (dispatch: SafeDispatch) => {
+  return (dispatch: SafeDispatch, getState: () => StoreState, { apiRoot }: ExtraArguments) => {
     dispatch({ type: ActionTypes.FETCH_PRIZES_STARTED });
 
     if (filter.event && /\D/.test(filter.event)) {
@@ -105,7 +105,7 @@ export function fetchPrizes(filter: PrizeSearchFilter = {}) {
       delete filter.event;
     }
 
-    return HTTPUtils.get(Endpoints.SEARCH, { ...filter, type: 'prize' })
+    return HTTPUtils.get(`${apiRoot}search/`, { ...filter, type: 'prize' })
       .then((data: any[]) => {
         const prizes = data.map(prizeFromAPIPrize);
 

--- a/bundles/tracker/prizes/PrizeActionsSpec.ts
+++ b/bundles/tracker/prizes/PrizeActionsSpec.ts
@@ -3,13 +3,11 @@ import thunk, { ThunkDispatch } from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import { fetchPrizes } from './PrizeActions';
 import { AnyAction } from 'redux';
-import { ExtraArguments, StoreState } from '../Store';
+import { StoreState } from '../Store';
 
-type DispatchExts = ThunkDispatch<StoreState, ExtraArguments, AnyAction>;
+type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
 
-const mockStore = configureMockStore<StoreState, DispatchExts>([
-  thunk.withExtraArgument({ apiRoot: 'http://testserver/' }),
-]);
+const mockStore = configureMockStore<StoreState, DispatchExts>([thunk]);
 
 describe('PrizeActions', () => {
   let store: ReturnType<typeof mockStore>;

--- a/bundles/tracker/prizes/PrizeActionsSpec.ts
+++ b/bundles/tracker/prizes/PrizeActionsSpec.ts
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { fetchPrizes } from './PrizeActions';
 import { AnyAction } from 'redux';
 import { StoreState } from '../Store';
+import Endpoints from '../Endpoints';
 
 type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
 
@@ -19,13 +20,13 @@ describe('PrizeActions', () => {
 
   describe('#fetchPrizes', () => {
     it('works with a numeric event id', () => {
-      fetchMock.getOnce('path:/search/', 200, { query: { event: '1', type: 'prize' } });
+      fetchMock.getOnce(`${Endpoints.SEARCH}?event=1&type=prize`, 200);
       store.dispatch(fetchPrizes({ event: '1' }));
       expect(fetchMock.done()).toBe(true);
     });
 
     it('works with an event shortname', () => {
-      fetchMock.getOnce('path:/search/', 200, { query: { eventshort: 'test', type: 'prize' } });
+      fetchMock.getOnce(`${Endpoints.SEARCH}?eventshort=test&type=prize`, 200);
       store.dispatch(fetchPrizes({ event: 'test' }));
       expect(fetchMock.done()).toBe(true);
     });

--- a/bundles/tracker/prizes/PrizeActionsSpec.ts
+++ b/bundles/tracker/prizes/PrizeActionsSpec.ts
@@ -1,33 +1,35 @@
 import fetchMock from 'fetch-mock';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
-import Endpoints from '../Endpoints';
 import { fetchPrizes } from './PrizeActions';
 import { AnyAction } from 'redux';
-import { StoreState } from '../Store';
+import { ExtraArguments, StoreState } from '../Store';
 
-type DispatchExts = ThunkDispatch<StoreState, void, AnyAction>;
+type DispatchExts = ThunkDispatch<StoreState, ExtraArguments, AnyAction>;
 
-const mockStore = configureMockStore<StoreState, DispatchExts>([thunk]);
+const mockStore = configureMockStore<StoreState, DispatchExts>([
+  thunk.withExtraArgument({ apiRoot: 'http://testserver/' }),
+]);
 
 describe('PrizeActions', () => {
   let store: ReturnType<typeof mockStore>;
 
   beforeEach(() => {
     store = mockStore();
+    fetchMock.restore();
   });
 
   describe('#fetchPrizes', () => {
     it('works with a numeric event id', () => {
-      fetchMock.once(`${Endpoints.SEARCH}?event=1&type=prize`, 200);
+      fetchMock.getOnce('path:/search/', 200, { query: { event: '1', type: 'prize' } });
       store.dispatch(fetchPrizes({ event: '1' }));
-      expect(fetchMock.called()).toBe(true);
+      expect(fetchMock.done()).toBe(true);
     });
 
     it('works with an event shortname', () => {
-      fetchMock.once(`${Endpoints.SEARCH}?eventshort=test&type=prize`, 200);
+      fetchMock.getOnce('path:/search/', 200, { query: { eventshort: 'test', type: 'prize' } });
       store.dispatch(fetchPrizes({ event: 'test' }));
-      expect(fetchMock.called()).toBe(true);
+      expect(fetchMock.done()).toBe(true);
     });
   });
 });

--- a/bundles/tracker/prizes/components/Prize.tsx
+++ b/bundles/tracker/prizes/components/Prize.tsx
@@ -13,7 +13,7 @@ import Text from '../../../uikit/Text';
 import useDispatch from '../../hooks/useDispatch';
 import * as EventActions from '../../events/EventActions';
 import * as EventStore from '../../events/EventStore';
-import { Routes, useRouterUtils } from '../../router/RouterUtils';
+import RouterUtils, { Routes } from '../../router/RouterUtils';
 import { StoreState } from '../../Store';
 import * as PrizeActions from '../PrizeActions';
 import * as PrizeStore from '../PrizeStore';
@@ -109,21 +109,19 @@ const Prize = (props: PrizeProps) => {
     }
   }, [dispatch, event, eventId]);
 
-  const routerUtils = useRouterUtils();
-
   const handleDonate = useCallback(() => {
     if (prize == null) return;
-    routerUtils.navigateTo(Routes.EVENT_DONATE(prize.eventId), {
+    RouterUtils.navigateTo(Routes.EVENT_DONATE(prize.eventId), {
       hash: prize.minimumBid != null ? prize.minimumBid.toFixed(2) : '',
       forceReload: true,
     });
-  }, [prize, routerUtils]);
+  }, [prize]);
 
   const handleBack = useCallback(() => {
     if (prize) {
-      routerUtils.navigateTo(Routes.EVENT_PRIZES(prize.eventId));
+      RouterUtils.navigateTo(Routes.EVENT_PRIZES(prize.eventId));
     }
-  }, [prize, routerUtils]);
+  }, [prize]);
 
   if (prize == null)
     return (

--- a/bundles/tracker/prizes/components/Prize.tsx
+++ b/bundles/tracker/prizes/components/Prize.tsx
@@ -13,7 +13,7 @@ import Text from '../../../uikit/Text';
 import useDispatch from '../../hooks/useDispatch';
 import * as EventActions from '../../events/EventActions';
 import * as EventStore from '../../events/EventStore';
-import RouterUtils, { Routes } from '../../router/RouterUtils';
+import { Routes, useRouterUtils } from '../../router/RouterUtils';
 import { StoreState } from '../../Store';
 import * as PrizeActions from '../PrizeActions';
 import * as PrizeStore from '../PrizeStore';
@@ -109,19 +109,21 @@ const Prize = (props: PrizeProps) => {
     }
   }, [dispatch, event, eventId]);
 
+  const routerUtils = useRouterUtils();
+
   const handleDonate = useCallback(() => {
     if (prize == null) return;
-    RouterUtils.navigateTo(Routes.EVENT_DONATE(prize.eventId), {
+    routerUtils.navigateTo(Routes.EVENT_DONATE(prize.eventId), {
       hash: prize.minimumBid != null ? prize.minimumBid.toFixed(2) : '',
       forceReload: true,
     });
-  }, [prize]);
+  }, [prize, routerUtils]);
 
   const handleBack = useCallback(() => {
     if (prize) {
-      RouterUtils.navigateTo(Routes.EVENT_PRIZES(prize.eventId));
+      routerUtils.navigateTo(Routes.EVENT_PRIZES(prize.eventId));
     }
-  }, [prize]);
+  }, [prize, routerUtils]);
 
   if (prize == null)
     return (

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -9,7 +9,7 @@ import Clickable from '../../../uikit/Clickable';
 import Header from '../../../uikit/Header';
 import Text from '../../../uikit/Text';
 import { StoreState } from '../../Store';
-import { Routes, useRouterUtils } from '../../router/RouterUtils';
+import RouterUtils, { Routes } from '../../router/RouterUtils';
 import * as PrizeStore from '../PrizeStore';
 import getPrizeRelativeAvailability from '../getPrizeRelativeAvailability';
 import * as PrizeUtils from '../PrizeUtils';
@@ -25,7 +25,6 @@ type PrizeCardProps = {
 const PrizeCard = (props: PrizeCardProps) => {
   const { prizeId, className } = props;
   const now = TimeUtils.getNowLocal();
-  const routerUtils = useRouterUtils();
 
   const [prizeError, setPrizeError] = useState(false);
   const setPrizeErrorTrue = useCallback(() => setPrizeError(true), []);
@@ -34,7 +33,7 @@ const PrizeCard = (props: PrizeCardProps) => {
 
   const handleViewPrize = useCallback(() => {
     if (prize) {
-      routerUtils.navigateTo(Routes.EVENT_PRIZE(prize.eventId, prize.id));
+      RouterUtils.navigateTo(Routes.EVENT_PRIZE(prize.eventId, prize.id));
     }
   }, [prize]);
 

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -9,7 +9,7 @@ import Clickable from '../../../uikit/Clickable';
 import Header from '../../../uikit/Header';
 import Text from '../../../uikit/Text';
 import { StoreState } from '../../Store';
-import RouterUtils, { Routes } from '../../router/RouterUtils';
+import { Routes, useRouterUtils } from '../../router/RouterUtils';
 import * as PrizeStore from '../PrizeStore';
 import getPrizeRelativeAvailability from '../getPrizeRelativeAvailability';
 import * as PrizeUtils from '../PrizeUtils';
@@ -25,6 +25,7 @@ type PrizeCardProps = {
 const PrizeCard = (props: PrizeCardProps) => {
   const { prizeId, className } = props;
   const now = TimeUtils.getNowLocal();
+  const routerUtils = useRouterUtils();
 
   const [prizeError, setPrizeError] = useState(false);
   const setPrizeErrorTrue = useCallback(() => setPrizeError(true), []);
@@ -33,7 +34,7 @@ const PrizeCard = (props: PrizeCardProps) => {
 
   const handleViewPrize = useCallback(() => {
     if (prize) {
-      RouterUtils.navigateTo(Routes.EVENT_PRIZE(prize.eventId, prize.id));
+      routerUtils.navigateTo(Routes.EVENT_PRIZE(prize.eventId, prize.id));
     }
   }, [prize]);
 

--- a/bundles/tracker/router/RouterUtils.ts
+++ b/bundles/tracker/router/RouterUtils.ts
@@ -1,12 +1,6 @@
 import { createBrowserHistory } from 'history';
 import queryString from 'query-string';
-
-export const APP_BASE_PATH = ((root?: string) => {
-  if (root == null) return '';
-  return root.endsWith('/') ? root.substring(0, root.length - 1) : root;
-})(window.ROOT_PATH);
-
-export const EXTERNAL_TRACKER_BASE_PATH = window;
+import React from 'react';
 
 export const Routes = {
   EVENT_BASE: (eventId: string | number) => `/events/${eventId}`,
@@ -21,47 +15,55 @@ export const Routes = {
 type NavigateOptions = {
   replace?: boolean;
   forceReload?: boolean;
-  query?: object;
+  query?: Record<string, unknown>;
   hash?: string;
-  state?: object;
+  state?: Record<string, unknown>;
 };
 
-export const history = createBrowserHistory({ basename: APP_BASE_PATH });
+export function createRouterUtils({ rootPath }: { rootPath: string }) {
+  const history = createBrowserHistory({ basename: rootPath });
 
-// Re-apply browser-standard scrolling behavior on route transitions
-history.listen((location, action) => {
-  // If the user is navigating backwards, don't reset scroll.
-  if (action === 'POP') return;
-  window.scrollTo(0, 0);
-});
+  // Re-apply browser-standard scrolling behavior on route transitions
+  history.listen((location, action) => {
+    // If the user is navigating backwards, don't reset scroll.
+    if (action === 'POP') return;
+    window.scrollTo(0, 0);
+  });
 
-export default {
-  history,
+  return {
+    history,
 
-  getLocation: () => history.location,
-  getLocationHash: () => history.location.hash.slice(1),
+    getLocation: () => history.location,
+    getLocationHash: () => history.location.hash.slice(1),
 
-  navigateTo(pathname: string, options: NavigateOptions = {}) {
-    const { replace = false, forceReload = false, query, hash, state } = options;
+    navigateTo(pathname: string, options: NavigateOptions = {}) {
+      const { replace = false, forceReload = false, query, hash, state } = options;
 
-    const navigate = replace ? history.replace : history.push;
+      const navigate = replace ? history.replace : history.push;
 
-    let fullPath = pathname;
-    if (query != null) {
-      fullPath += `?${queryString.stringify(query)}`;
-    }
-    if (hash != null) {
-      fullPath += `#${hash}`;
-    }
+      let fullPath = pathname;
+      if (query != null) {
+        fullPath += `?${queryString.stringify(query)}`;
+      }
+      if (hash != null) {
+        fullPath += `#${hash}`;
+      }
 
-    navigate(fullPath, state);
+      navigate(fullPath, state);
 
-    if (forceReload) {
-      window.location.reload();
-    }
-  },
+      if (forceReload) {
+        window.location.reload();
+      }
+    },
 
-  isLocalUrl(url: string) {
-    return !/(?:^[a-z][a-z0-9+.-]*:|\/\/)/.test(url);
-  },
-};
+    isLocalUrl(url: string) {
+      return !/(?:^[a-z][a-z0-9+.-]*:|\/\/)/.test(url);
+    },
+  };
+}
+
+export const RouterUtils = React.createContext(createRouterUtils({ rootPath: 'http://testserver/' }));
+
+export function useRouterUtils() {
+  return React.useContext(RouterUtils);
+}

--- a/spec/Suite.tsx
+++ b/spec/Suite.tsx
@@ -6,6 +6,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import { combinedReducer, StoreState } from '../bundles/tracker/Store';
 import './matchers';
 import { Provider } from 'react-redux';
+import { setAPIRoot } from '../bundles/tracker/Endpoints';
 
 let componentFakes: any[] = [];
 let oldCreateElement: typeof React.createElement;
@@ -113,3 +114,7 @@ export function mountWithState(...[element, options]: Parameters<typeof mount>):
 }
 
 Enzyme.configure({ adapter: new Adapter() });
+
+beforeEach(() => {
+  setAPIRoot('http://testserver/');
+});

--- a/tracker/templates/ui/index.html
+++ b/tracker/templates/ui/index.html
@@ -17,10 +17,6 @@
     <script type='text/javascript'>
       <!--
       document.addEventListener("DOMContentLoaded", function () {
-        // TODO: fix the remaining places where these are needed
-        window.API_ROOT = JSON.parse(document.getElementById('CONSTANTS').textContent).API_ROOT;
-        window.ROOT_PATH = JSON.parse(document.getElementById('CONSTANTS').textContent).ROOT_PATH;
-
         window[JSON.parse(document.getElementById('app_name').textContent)](
           Object.assign(
             JSON.parse(document.getElementById('props').textContent),

--- a/tracker/ui/views.py
+++ b/tracker/ui/views.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_protect
 from webpack_manifest import webpack_manifest
@@ -206,14 +205,10 @@ def donate(request, event):
             'app_name': 'TrackerApp',
             'title': 'Donation Tracker',
             'forms': {'bidsform': bidsform},
-            'form_errors': mark_safe(
-                json.dumps(
-                    {
-                        'commentform': json.loads(commentform.errors.as_json()),
-                        'bidsform': bidsform.errors,
-                    }
-                )
-            ),
+            'form_errors': {
+                'commentform': json.loads(commentform.errors.as_json()),
+                'bidsform': bidsform.errors,
+            },
             'props': {
                 'event': json.loads(serializers.serialize('json', [event]))[0][
                     'fields'


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175027382

### Description of the Change

While working on Reactifying the donation processing page I ran into a couple of lingering "this should really be an initializer prop" situations, but there were still a few places that weren't directly related to those pages that were relying on window-level globals to function correctly. This corrects that.

Also one of the PRs I merged today broke the Donate page for reasons that would take a while to explain (and only would have been caught in automation with a browser level test) and this fixes that as a very happy side-effect.

### Verification Process

Checked any pages that were relying on `API_ROOT` or `ROOT_PATH` and made sure they worked with the new method. This includes anything that was using anything from `actions/models` since those were using `API_ROOT` instead of `redux-thunk`s method of storing an extra constant.