### PR TITLE
remove a problematic and dubious filter [#175099994]

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import logging
+import json
 from argparse import ArgumentParser
 from subprocess import check_call
 
@@ -46,7 +47,9 @@ if __name__ == '__main__':
         help='Tells Django to stop running the test suite after first failed test.',
     )
     # TODO: the fetches for the ui endpoints blow up if the manifest doesn't exist so we have to build the webpack bundles first
-    if not os.access('tracker/ui-tracker.manifest.json', os.R_OK):
+    try:
+        json.load(open('tracker/ui-tracker.manifest.json'))['files']['tracker']
+    except (IOError, KeyError):
         check_call(['yarn', '--frozen-lockfile', '--production'])
         check_call(['yarn', 'build'])
     TestRunner = get_runner(settings, 'xmlrunner.extra.djangotestrunner.XMLTestRunner')

--- a/tracker/admin/prize.py
+++ b/tracker/admin/prize.py
@@ -94,7 +94,7 @@ class DonorPrizeEntryAdmin(CustomModelAdmin):
         'donor__lastname',
     ]
     list_display = ['prize', 'donor', 'weight']
-    list_filter = ['prize__event', 'prize', 'donor']
+    list_filter = ['prize__event']
     fieldsets = [
         (None, {'fields': ['donor', 'prize', 'weight']}),
     ]


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175099994

### Description of the Change

The `DonorPrizeEntry` model admin tries to show a list of every single prize and Donor in the system to allow you to filter on them. This is of dubious value, not only because I'm not sure such a filter actually sees much use, but also because you can still just put e.g. `?prize=<id>` in the url even without the filter being displayed. Where this actually becomes a problem, though, is that the GDQ database has close to a quarter million donors and building that list either runs the server process OOM or takes 15 seconds or more to load the page.

All this does is delete those filters.

And also makes the test script a little more robust because why not?

### Verification Process

Page still loads but the filters are gone as expected.