### PR TITLE
volunteer emails action now supports hosts [#174849468]

### DIFF
--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -159,8 +159,50 @@ class EventAdmin(CustomModelAdmin):
                 volunteers = csv.DictReader(
                     StringIO(request.FILES['volunteers'].read().decode('utf-8'))
                 )
-                admin_group = auth.Group.objects.get_or_create(name='Bid Admin')[0]
                 tracker_group = auth.Group.objects.get_or_create(name='Bid Tracker')[0]
+                tracker_group.permissions.set(
+                    auth.Permission.objects.filter(
+                        content_type__app_label='tracker',
+                        codename__in=[
+                            'change_donation',
+                            'view_donation',
+                            'view_comments',
+                            'view_pending',
+                        ],
+                    )
+                )
+                admin_group = auth.Group.objects.get_or_create(name='Bid Admin')[0]
+                admin_group.permissions.set(
+                    auth.Permission.objects.filter(
+                        content_type__app_label='tracker',
+                        codename__in=[
+                            # bid screening/assignment
+                            'add_donation_bid',
+                            'change_donation_bid',
+                            'delete_donation_bid',
+                            'view_donation_bid',
+                            'add_bid',
+                            'change_bid',
+                            'view_bid',
+                            'view_hidden_bids',
+                            # donations
+                            'change_donation',
+                            'view_donation',
+                            'view_comments',
+                            'view_pending',
+                            'send_to_reader',
+                            # donors
+                            'add_donor',
+                            'change_donor',
+                            'view_donor',
+                            'view_emails',
+                            'view_usernames',
+                            # needed for 'Start Run'
+                            'change_speedrun',
+                            'view_speedrun',
+                        ],
+                    )
+                )
                 successful = 0
                 for row, volunteer in enumerate(volunteers, start=2):
                     try:
@@ -168,6 +210,7 @@ class EventAdmin(CustomModelAdmin):
                             volunteer['name'].strip().partition(' ')
                         )
                         is_head = 'head' in volunteer['position'].strip().lower()
+                        is_host = 'host' in volunteer['position'].strip().lower()
                         email = volunteer['email'].strip()
                         EmailValidator()(email)
                         username = volunteer['username'].strip()
@@ -208,11 +251,12 @@ class EventAdmin(CustomModelAdmin):
                         context = dict(
                             event=event,
                             is_head=is_head,
+                            is_host=is_host,
                             password_reset_url=request.build_absolute_uri(
                                 reverse('tracker:password_reset')
                             ),
-                            registration_url=request.build_absolute_uri(
-                                reverse('tracker:register')
+                            admin_url=request.build_absolute_uri(
+                                reverse('admin:index')
                             ),
                         )
 

--- a/tracker/auth.py
+++ b/tracker/auth.py
@@ -1,50 +1,12 @@
 import post_office.mail
 import post_office.models
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-from django.utils.safestring import mark_safe
 
 from . import viewutil, mailutil
-
-# Future proofing against replacing auth model
-AuthUser = get_user_model()
-
-
-class EmailLoginAuthBackend:
-    """Custom authentication backend which supports
-    e-mail as identity. Note that if more than one user has
-    the same e-mail, they will all not be able to use that
-    email and must use the user id instead"""
-
-    supports_inactive_user = False
-
-    def authenticate(self, request=None, username=None, password=None, email=None):
-        AUTH_METHODS = [
-            {'email': username},
-            {'email': email},
-        ]
-
-        try:
-            userFilter = AuthUser.objects.none()
-            for method in AUTH_METHODS:
-                userFilter = AuthUser.objects.filter(**method)
-                if userFilter.count() == 1:
-                    user = userFilter[0]
-                    if user.check_password(password):
-                        return user
-        except Exception:
-            pass
-        return None
-
-    def get_user(self, user_id):
-        try:
-            return AuthUser.objects.get(pk=user_id)
-        except AuthUser.DoesNotExist:
-            return None
 
 
 def default_password_reset_template_name():
@@ -104,7 +66,100 @@ reset_url -- the token-encoded url to redirect the user to
     </p>
 
     - The GamesDoneQuick Staff
-""",
+""".strip(),
+    )
+
+
+def default_volunteer_registration_template_name():
+    return getattr(
+        settings,
+        'VOLUNTEER_REGISTRATION_TEMPLATE_NAME',
+        'default_volunteer_registration_template',
+    )
+
+
+def default_volunteer_registration_template():
+    return post_office.models.EmailTemplate(
+        name=default_volunteer_registration_template_name(),
+        subject='Donation Processing',
+        description="""Email template for donation volunteers.
+
+The following context variables are defined:
+user -- the User object
+event -- the Event that this email is being send for
+is_host -- True if the user was imported as a host
+is_head -- True if the user was importes as a head donation screener
+confirmation_url -- the full URL (including token) the user should visit to confirm their registration and set their password
+reset_url -- deprecated name for confirmation_url
+password_reset_url -- the full URL the user should visit if the above link expires (happens after 3 days if using default Django settings)
+admin_url -- the full URL of the admin site (which will redirect them to login if need be)
+""".strip(),
+        content="""
+Hello {{ user }},
+
+{% if is_head %}
+You are receiving this e-mail because you have been listed as a head donation processor during {{ event.name }}.
+{% elif is_host %}
+You are receiving this e-mail because you have been listed as a host during {{ event.name }}.
+{% else %}
+You are receiving this e-mail because you have been listed as a donation processer during {{ event.name }}.
+{% endif %}
+
+{% if user.is_active %}
+You seem to already have an active account on the donation tracker. If so, no further action is required on your part at this time. If you have forgotten your password, you may re-set it by entering your e-mail at: {{ password_reset_url }}
+{% else %}
+You have been registered for an account on the donation tracker. You will be required to log into this account during all of your shifts. To activate your account and set your password, you have been provided with a temporary URL below to confirm your account and select a username and password.
+
+Confirm your account: {{ confirmation_url }}
+
+The above link will expire after a certain period, and if that time has elapsed, please request a password reset password reset with the following email address: {{ user.email }}
+
+{{ password_reset_url }}
+{% endif %}
+
+Once you're finished with that, you may log in to the admin site at the url below. Please note that the username and password are both CaSe SeNsItIvE.
+
+{{ admin_url }}
+
+- The Staff
+""".strip(),
+        html_content="""
+Hello {{ user }},
+
+<p>
+{% if is_head %}
+You are receiving this e-mail because you have been listed as a head donation processor during {{ event.name }}.
+{% elif is_host %}
+You are receiving this e-mail because you have been listed as a host during {{ event.name }}.
+{% else %}
+You are receiving this e-mail because you have been listed as a donation processer during {{ event.name }}.
+{% endif %}
+</p>
+
+{% if user.is_active %}
+<p>
+You seem to already have an active account on the donation tracker. If so, no further action is required on your part at this time. If you have forgotten your password, you may re-set it by entering your e-mail on this page (<a href="{{ password_reset_url }}">{{ password_reset_url }}</a>).
+</p>
+{% else %}
+<p>
+You have been registered for an account on the donation tracker. You will be required to log into this account during all of your shifts. To activate your account and set your password, you have been provided with a temporary URL below to confirm your account and select a username and password.
+</p>
+
+<p>
+Confirm your account: <a href="{{ confirmation_url }}">{{ confirmation_url }}</a>
+</p>
+
+<p>
+The above link will expire after a certain period, and if that time has elapsed, please request a <a href="{{ password_reset_url }}">password reset</a> with the following email address: <tt>{{ user.email }}</tt>.
+</p>
+{% endif %}
+
+<p>
+Once you're finished with that, you may <a href="{{ admin_url }}">log in to the admin site</a>. Please note that the username and password are both CaSe SeNsItIvE.
+</p>
+
+- The Staff
+""".strip(),
     )
 
 
@@ -119,36 +174,25 @@ def send_registration_mail(
     template = template or mailutil.get_email_template(
         default_registration_template_name(), default_registration_template()
     )
-    return send_auth_token_mail(
-        user,
-        request.get_host(),
-        request.build_absolute_uri(
-            reverse(
-                'tracker:confirm_registration',
-                kwargs={
-                    'uidb64': urlsafe_base64_encode(force_bytes(user.pk)),
-                    'token': token_generator.make_token(user),
-                },
-            )
-        ),
-        template,
-        sender,
-        extra_context,
+    sender = sender or viewutil.get_default_email_from_user()
+    extra_context = extra_context or {}
+    confirmation_url = request.build_absolute_uri(
+        reverse(
+            'tracker:confirm_registration',
+            kwargs={
+                'uidb64': urlsafe_base64_encode(force_bytes(user.pk)),
+                'token': token_generator.make_token(user),
+            },
+        )
     )
-
-
-def send_auth_token_mail(
-    user, domain, confirm_url, template, sender=None, extra_context=None,
-):
-    if not sender:
-        sender = viewutil.get_default_email_from_user()
-    formatContext = {
-        'domain': domain,
-        'user': user,
-        'reset_url': mark_safe(confirm_url),
-    }
-    if extra_context:
-        formatContext.update(extra_context)
     return post_office.mail.send(
-        recipients=[user.email], sender=sender, template=template, context=formatContext
+        recipients=[user.email],
+        sender=sender,
+        template=template,
+        context={
+            **extra_context,
+            'user': user,
+            'confirmation_url': confirmation_url,
+            'reset_url': confirmation_url,  # reset_url is deprecated
+        },
     )

--- a/tracker/commandutil.py
+++ b/tracker/commandutil.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+
+
+class TrackerCommand(BaseCommand):
+    requires_system_checks = False
+
+    def __init__(self, *args, **kwargs):
+        super(TrackerCommand, self).__init__(*args, **kwargs)
+        self.verbosity = 0
+
+    def message(self, message, verbosity_level=1):
+        if self.verbosity >= verbosity_level:
+            self.stdout.write(message)
+
+    def handle(self, *args, **options):
+        if 'verbosity' in options:
+            self.verbosity = options['verbosity']
+        else:
+            self.verbosity = 1
+        self.message('Positional arguments: {0}'.format(args), 3)
+        self.message('Named arguments: {0}'.format(options), 3)

--- a/tracker/management/commands/default_email_templates.py
+++ b/tracker/management/commands/default_email_templates.py
@@ -1,12 +1,11 @@
-import post_office
+import post_office.models
 
-import tracker.prizemail as prizemail
-import tracker.auth as auth
-import tracker.commandutil as commandutil
+from tracker import prizemail, auth, commandutil
 
-_defaultTemplates = {
+_default_templates = {
     auth.default_password_reset_template_name(): auth.default_password_reset_template(),
     auth.default_registration_template_name(): auth.default_registration_template(),
+    auth.default_volunteer_registration_template_name(): auth.default_volunteer_registration_template(),
     prizemail.default_prize_winner_template_name(): prizemail.default_prize_winner_template(),
     prizemail.default_prize_contributor_template_name(): prizemail.default_prize_contributor_template(),
     prizemail.default_prize_winner_accept_template_name(): prizemail.default_prize_winner_accept_template(),
@@ -17,41 +16,41 @@ _defaultTemplates = {
 
 def email_template_name(arg):
     parts = arg.partition(':')
-    templateObj = _defaultTemplates[parts[0]]
-    customName = None
+    template_obj = _default_templates[parts[0]]
+    custom_name = None
     if parts[1] == ':':
         if parts[2]:
-            customName = parts[2]
+            custom_name = parts[2]
         else:
             raise Exception('Must specify custom name after colon')
-    return (templateObj, customName)
+    return (template_obj, custom_name)
 
 
 class Command(commandutil.TrackerCommand):
     help = 'Generates all default mail templates that are not currently in the database'
 
     def add_arguments(self, parser):
-        commandGroup = parser.add_mutually_exclusive_group(required=True)
-        commandGroup.add_argument(
+        command_group = parser.add_mutually_exclusive_group(required=True)
+        command_group.add_argument(
             '-l', '--list', help='List all default email templates', action='store_true'
         )
-        commandGroup.add_argument(
+        command_group.add_argument(
             '-c',
             '--create',
             help='Create the specified template(s) (use the format <default>:<name> to specify a custom name in the database)',
             nargs='+',
             type=email_template_name,
         )
-        commandGroup.add_argument(
+        command_group.add_argument(
             '-a',
             '--create-all',
             help='Create all known templates(s)',
             action='store_true',
         )
         parser.add_argument(
-            '-f',
-            '--force',
-            help='Force run the command even if it would overwrite existing data (by default, the command will abort if any existing objects would be overwritten)',
+            '-o',
+            '--overwrite',
+            help='Overwrite existing templates even if they exist already',
             action='store_true',
             default=False,
         )
@@ -63,61 +62,47 @@ class Command(commandutil.TrackerCommand):
             default='',
         )
 
-    def check_validity(self, createList, force=False):
-        currentNames = set()
-        for create in createList:
-            if create[1] in currentNames:
-                raise Exception('Name {0} was specified twice'.format(create[1]))
-            if (
-                not force
-                and post_office.models.EmailTemplate.objects.filter(
-                    name=create[1]
-                ).exists()
-            ):
-                raise Exception('Name {0} already exsits in database'.format(create[1]))
-            currentNames.add(create[1])
-
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
 
-        self.prefix = options['prefix']
-
         if options['list']:
-            for option in _defaultTemplates.keys():
+            for option in _default_templates:
                 self.message(option, 0)
             return
 
         if options['create']:
-            self.templates = options['create']
+            templates = options['create']
 
         if options['create_all']:
-            self.templates = map(email_template_name, _defaultTemplates.keys())
+            templates = map(email_template_name, _default_templates)
 
-        self.templates = [
-            (x[0], x[1] or (options['prefix'] + x[0].name)) for x in self.templates
-        ]
+        templates = [(x[0], x[1] or (options['prefix'] + x[0].name)) for x in templates]
 
-        self.check_validity(self.templates, options['force'])
-
-        for create in self.templates:
+        for create in templates:
             found = post_office.models.EmailTemplate.objects.filter(name=create[1])
             if found.exists():
-                targetTemplate = found[0]
-                self.message(
-                    'Overwriting email template {0} (id={1})'.format(
-                        create[1], targetTemplate.id
-                    ),
-                    1,
-                )
-                for field in targetTemplate._meta.fields:
-                    if field.name not in ['id', 'created', 'last_updated']:
-                        setattr(
-                            targetTemplate, field.name, getattr(create[0], field.name)
-                        )
-                targetTemplate.name = create[1]
-                targetTemplate.save()
+                if options['overwrite']:
+                    target_template = found[0]
+                    self.message(
+                        f'Overwriting email template {create[1]} (id={target_template.id})',
+                        1,
+                    )
+                    for field in target_template._meta.fields:
+                        if field.name not in ['id', 'created', 'last_updated']:
+                            setattr(
+                                target_template,
+                                field.name,
+                                getattr(create[0], field.name),
+                            )
+                    target_template.name = create[1]
+                    target_template.save()
+                else:
+                    self.message(
+                        f'Skipping email template {create[1]} because it already exists',
+                        1,
+                    )
             else:
-                self.message('Creating email template {0}'.format(create[1]), 1)
+                self.message(f'Creating email template {create[1]}', 1)
                 create[0].name = create[1]
                 create[0].save()
 

--- a/tracker/models/donation.py
+++ b/tracker/models/donation.py
@@ -175,7 +175,10 @@ class Donation(models.Model):
         app_label = 'tracker'
         permissions = (
             ('delete_all_donations', 'Can delete non-local donations'),
-            ('view_full_list', 'Can view full donation list'),
+            (
+                'view_full_list',
+                'Can view full donation list',
+            ),  # TODO: is this still used?
             ('view_comments', 'Can view all comments'),
             ('view_pending', 'Can view pending donations'),
             ('view_test', 'Can view test donations'),

--- a/tracker/models/profile.py
+++ b/tracker/models/profile.py
@@ -10,9 +10,12 @@ class UserProfile(models.Model):
         app_label = 'tracker'
         verbose_name = 'User Profile'
         permissions = (
-            ('show_rendertime', 'Can view page render times'),
+            (
+                'show_rendertime',
+                'Can view page render times',
+            ),  # TODO: Is this still used?
             ('show_queries', 'Can view database queries'),
-            ('can_search', 'Can use search url'),
+            ('can_search', 'Can use search url'),  # TODO: Is this still used?
         )
 
     def __str__(self):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/174849468

### Description of the Change

Up until now the solution to "donation screeners and hosts should get different copy" has apparently been to send two rounds of emails, which is weird and confusing. This solves solves that by adding a check to see if the role contains 'host' and setting a template variable so the email template can show something different if it wants to.

Additionally, this adds a default template for said volunteer email (and cleans up the related management command) and also codifies what the related permissions should look like, since that was just sort of left up in the air. I don't know if anybody actually USES this function besides us, or would, but the fewer questions I have about a core part of our volunteer flow the better.

I also removed an Authentication backend that we don't use any more. If somebody wants that I'm sure there's another project out there that provides something similar.

### Verification Process

Ran the email templates command to verify that it still loads everything correctly (skipping any that already exist by default, instead of erroring out if there's a collision).

Imported a CSV that hit the new code paths and made sure the resulting emails/users were working as expected.