### PR TITLE
prize mail admin form actually updates accept deadline [#175194600]

### DIFF
--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -1636,6 +1636,7 @@ class TestPrizeAdmin(TestCase):
 EVENT:{{ event.id }}
 WINNER:{{ winner.id }}
 WINNER_CONTACT_NAME:{{ winner.contact_name }}
+ACCEPT_DEADLINE:{{ accept_deadline }}
 {% for prize_winner in prize_wins %}
 PRIZE:{{ prize_winner.prize.id }}
 CLAIM_URL:{{ prize_winner.claim_url }}
@@ -1677,7 +1678,7 @@ CLAIM_URL:{{ prize_winner.claim_url }}
                 'prizewinners': [pw.id for pw in winners],
                 'fromaddress': 'root@localhost',
                 'emailtemplate': email_template.id,
-                'acceptdeadline': '2020-10-21 19:49:36',  # totally arbitrary
+                'acceptdeadline': '2020-10-21',
             },
         )
 
@@ -1690,6 +1691,12 @@ CLAIM_URL:{{ prize_winner.claim_url }}
             self.assertTrue(
                 winner.emailsent,
                 f'Prize Winner {winner.id} did not have email sent flag set',
+            )
+            self.assertEqual(
+                winner.acceptdeadline.astimezone(pytz.timezone('Etc/GMT-12')),
+                datetime.datetime(
+                    2020, 10, 22, 0, 0, 0, tzinfo=pytz.timezone('Etc/GMT-12')
+                ),
             )
 
         self.assertEqual(
@@ -1722,6 +1729,7 @@ CLAIM_URL:{{ prize_winner.claim_url }}
                 self.assertEqual(
                     [donor.contact_name()], contents['winner_contact_name']
                 )
+                self.assertEqual(['Oct. 21, 2020'], contents['accept_deadline'])
                 self.assertSetEqual(
                     {p.prize.id for p in won_prizes},
                     {int(p) for p in contents['prize']},

--- a/tracker/admin/prize.py
+++ b/tracker/admin/prize.py
@@ -1,6 +1,8 @@
+import datetime
 import json
 from itertools import groupby
 
+import pytz
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib import messages
@@ -468,9 +470,6 @@ class PrizeAdmin(CustomModelAdmin):
                 ):
                     prizewins = list(prizewins)
 
-                    winner.acceptdeadline = form.cleaned_data['acceptdeadline']
-                    winner.save()
-
                     for prizewin in prizewins:
                         prizewin.create_claim_url(request)
 
@@ -494,6 +493,12 @@ class PrizeAdmin(CustomModelAdmin):
 
                     for prizewin in prizewins:
                         prizewin.emailsent = True
+                        # "anywhere on earth" Time Zone is GMT-12
+                        prizewin.acceptdeadline = datetime.datetime.combine(
+                            form.cleaned_data['acceptdeadline']
+                            + datetime.timedelta(days=1),
+                            datetime.time(0, 0),
+                        ).replace(tzinfo=pytz.timezone('Etc/GMT-12'))
                         prizewin.save()
 
                 viewutil.tracker_log(

--- a/tracker/forms.py
+++ b/tracker/forms.py
@@ -610,7 +610,7 @@ class AutomailPrizeWinnersForm(forms.Form):
             label='Email Template',
             help_text='Select an email template to use. Can be overridden by the prize itself.',
         )
-        self.fields['acceptdeadline'] = forms.DateTimeField(
+        self.fields['acceptdeadline'] = forms.DateField(
             initial=timezone.now() + datetime.timedelta(weeks=2)
         )
 

--- a/tracker/templates/tracker/email/default_prize_winner_template.html
+++ b/tracker/templates/tracker/email/default_prize_winner_template.html
@@ -31,7 +31,7 @@ Hello {{ winner.contact_name }},
 {% endif %}
 
 <p>
-    You must accept/deny your prize{{ prize_count|pluralize }} on or before {{ accept_deadline }} (anywhere on earth),
+    You must accept/deny your prize{{ prize_count|pluralize }} on or before {{ accept_deadline }},
     after which it will be automatically re-rolled.
     If you do simply want to decline receiving your prize, we would still ask you do so promptly so we can re-roll to
     another winner it as quickly as possible.
@@ -46,4 +46,4 @@ Hello {{ winner.contact_name }},
 </p>
 
 Sincerely,
-- INSERT CORRESPONDANCE NAME HERE
+- INSERT CORRESPONDENCE NAME HERE


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175194600

### Description of the Change

While working on #281, a consolidation of the prize winner mailing code lost the "update the accept deadline" part of the functionality due to two things: 1) accidentally moved the code to a place where it was nonsense (trying to update the donor instead of the win entry) and 2) that piece of functionality was not in the test suite, so the previous issue was not noticed immediately.

This fixes that bug as well as making the form only accept a date, because Sent never needs to be more precise than that. The date governs which prizes are eligible for redraw, not when the link expires (the link expires after redraw, however).

### Verification Process

Mailed a winner locally and verified that the accept deadline updated to the expected value.