### PR TITLE
move Draw Prizes dropdown to optional Celery [#175276109]

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -147,11 +147,6 @@ class TestAdminViews(TestCase):
         response = self.client.get(reverse('admin:automail_prize_winners'))
         self.assertEqual(response.status_code, 200)
 
-    def test_draw_prize_winners(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get(reverse('admin:draw_prize_winners'))
-        self.assertEqual(response.status_code, 200)
-
     def test_automail_prize_accept_notifications(self):
         self.client.force_login(self.superuser)
         response = self.client.get(reverse('admin:automail_prize_accept_notifications'))

--- a/tracker/tasks.py
+++ b/tracker/tasks.py
@@ -3,10 +3,13 @@ import datetime
 import pytz
 from asgiref.sync import async_to_sync
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from channels.layers import get_channel_layer
 
-from . import eventutil
-from .models import Donation
+from . import eventutil, prizeutil
+from .models import Donation, Prize
+
+logger = get_task_logger(__name__)
 
 
 @shared_task
@@ -21,3 +24,19 @@ def celery_test():
         'celery',
         {'type': 'pong', 'timestamp': datetime.datetime.now(tz=pytz.utc).isoformat(),},
     )
+
+
+@shared_task(bind=True, max_retries=0)
+def draw_prize(self, prize_or_pk):
+    if isinstance(prize_or_pk, Prize):
+        prize = prize_or_pk
+    else:
+        prize = Prize.objects.get(pk=prize_or_pk)
+    drawn, msg = prizeutil.draw_prize(prize)
+    if drawn:
+        logger.info(f'Drew {len(msg["winners"])} winner(s) for Prize #{prize.pk}')
+    else:
+        logger.error(f'Could not draw winner(s) for Prize #{prize.pk}: {msg["error"]}')
+        if self.request.id:
+            raise ValueError(msg['error']) from msg.get('exc', None)
+    return drawn, msg

--- a/tracker/templates/admin/tracker/menu.html
+++ b/tracker/templates/admin/tracker/menu.html
@@ -8,7 +8,6 @@
         {% if request.user.is_superuser %}
           <tr><td><a href="{% url 'admin:diagnostics' %}">Diagnostics</a></td></tr>
         {% endif %}
-        <tr><td><a href="{% url 'admin:draw_prize_winners' %}">Draw Prize Winners</a></td></tr>
         <tr><td><a href="{% url 'admin:automail_prize_contributors' %}">Mail Prize Contributors</a></td></tr>
         <tr><td><a href="{% url 'admin:automail_prize_winners' %}">Mail Prize Winners</a></td></tr>
         <tr><td><a href="{% url 'admin:automail_prize_accept_notifications' %}">Mail Prize Winner Accept Notifications</a></td></tr>


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175276109

### Description of the Change

The sort of volume we have when it comes to prizes and eligible donors means that drawing all of them at once is kinda slow, which usually means that trying to draw them all at once times out. The primary thing this work does is move the drawing to a Celery task, putting it in the queue if Celery is enabled or just calling immediately if not. I also removed a redundant admin view that did mostly the same thing as the dropdown option that I forgot even existed, and cleaned up the logic a bit on the actual prize draw to simplify it and remove some functionality that was already effectively gone (multi-win, weighted wins, etc).

I didn't go quite as far as merging the key and non-key logic, but maybe that could be done later, since they're 80% identical.

### Verification Process

Tested various states of the prizes, with and without Celery turned on. One thing I did notice is that with Celery on most of the error checking would only show up in the task result (prize already drawn, etc), but that's probably fine. Even edited the code to throw errors in unlikely ways (such as while trying to save the winners) and everything worked (or failed in a controlled fashion) as expected.
