### PR TITLE
fix permissions check for Ad endpoint [#175423168]

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -195,19 +195,25 @@ class APITestCase(TransactionTestCase):
         )
         self.anonymous_user = AnonymousUser()
         self.user = User.objects.create(username='test')
+        self.view_user = User.objects.create(username='view')
         self.add_user = User.objects.create(username='add')
         self.locked_user = User.objects.create(username='locked')
         self.locked_user.user_permissions.add(
             Permission.objects.get(name='Can edit locked events')
         )
         if self.model_name:
+            self.view_user.user_permissions.add(
+                Permission.objects.get(name=f'Can view {self.model_name}'),
+            )
             self.add_user.user_permissions.add(
                 Permission.objects.get(name=f'Can add {self.model_name}'),
                 Permission.objects.get(name=f'Can change {self.model_name}'),
+                Permission.objects.get(name=f'Can view {self.model_name}'),
             )
             self.locked_user.user_permissions.add(
                 Permission.objects.get(name=f'Can add {self.model_name}'),
                 Permission.objects.get(name=f'Can change {self.model_name}'),
+                Permission.objects.get(name=f'Can view {self.model_name}'),
             )
         self.super_user = User.objects.create(username='super', is_superuser=True)
         self.maxDiff = None

--- a/tracker/api_urls.py
+++ b/tracker/api_urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     path('command/', api.command, name='command'),
     path('me/', api.me, name='me'),
     # moved over from private repo, stopgap until v2 is ready
-    path('ads/<int:event>/', api.ads),
+    path('ads/<int:event>/', api.ads, name='ads'),
     path('interstitial/', api.interstitial, name='interstitial'),
     path('interviews/<int:event>/', api.interviews),
     path('hosts/<int:event>/', api.hosts),

--- a/tracker/views/api.py
+++ b/tracker/views/api.py
@@ -772,7 +772,7 @@ def _interstitial_info(models, Model):
 
 @generic_api_view
 @never_cache
-@permission_required('tracker.view_interstitials', raise_exception=True)
+@permission_required('tracker.view_ad', raise_exception=True)
 @require_GET
 def ads(request, event):
     models = Ad.objects.filter(event=event)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175423168

### Description of the Change

When the Ad endpoint got moved over from the private repo, it didn't get a proper test written for it, so I missed that it was checking for a permission that no longer existed, because hitting as a superuser worked just fine (superusers have all permissions, including ones that don't exist). It was a special permission because we weren't on Django 2 yet (which supports `view` permissions natively), but now it's just a regular ol' view permission. With a test, even.

### Verification Process

Hit the endpoint anonymously, then as a user with only the relevant permission, and got the expected results.