### PR TITLE
various fixes to new React donation processing flow

### DIFF
--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -39,15 +39,20 @@ function EventMenu(name, path) {
       }));
       const url = useRouteMatch().url;
       path = path || url;
+      const sortedEvents = React.useMemo(
+        () => [...(events || [])].sort((a, b) => a.datetime.localeCompare(b.dateTime)),
+        [events],
+      );
 
       return (
         <Spinner spinning={status.event === 'loading'}>
           {name}
           <ul style={{ display: 'block' }}>
-            {events &&
-              events.map(e => (
+            {sortedEvents &&
+              sortedEvents.map(e => (
                 <li key={e.pk}>
                   <Link to={`${path}/${e.pk}`}>{e.short}</Link>
+                  {(!e.allow_donations || e.locked) && '🔒'}
                 </li>
               ))}
           </ul>
@@ -61,6 +66,9 @@ function DropdownMenu({ name, path }) {
   const match = useRouteMatch();
 
   const events = useSelector(state => state.models.event);
+  const sortedEvents = React.useMemo(() => [...(events || [])].sort((a, b) => a.datetime.localeCompare(b.dateTime)), [
+    events,
+  ]);
 
   return (
     <Dropdown closeOnClick={true} label={name}>
@@ -74,10 +82,11 @@ function DropdownMenu({ name, path }) {
           overflowY: 'auto',
         }}>
         <ul style={{ display: 'block' }}>
-          {events &&
-            events.map(e => (
+          {sortedEvents &&
+            sortedEvents.map(e => (
               <li key={e.pk}>
                 <Link to={`${match.url}/${path}/${e.pk}`}>{e.short}</Link>
+                {(!e.allow_donations || e.locked) && '🔒'}
               </li>
             ))}
         </ul>

--- a/bundles/admin/donationProcessing/processDonations.tsx
+++ b/bundles/admin/donationProcessing/processDonations.tsx
@@ -10,6 +10,7 @@ import styles from './donations.mod.css';
 import { useCachedCallback } from '../../public/hooks/useCachedCallback';
 import { useFetchDonors } from '../../public/hooks/useFetchDonors';
 
+type Mode = 'confirm' | 'regular';
 type Action = 'approved' | 'sent' | 'blocked';
 
 interface State {
@@ -38,9 +39,9 @@ export default React.memo(function ProcessDonations() {
   const canEditDonors = usePermission('tracker.change_donor');
   const [partitionId, setPartitionId] = useState(0);
   const [partitionCount, setPartitionCount] = useState(1);
-  const [mode, setMode] = useState<'confirm' | 'regular'>('regular');
+  const [mode, setMode] = useState<Mode>('regular');
   const setProcessingMode = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    setMode(e.target.value as 'confirm' | 'regular');
+    setMode(e.target.value as Mode);
   }, []);
   const secondStep = useMemo(() => {
     return (canApprove && mode === 'confirm') || event?.use_one_step_screening;
@@ -128,8 +129,8 @@ export default React.memo(function ProcessDonations() {
             {donations
               ?.filter((donation: any) => donation.pk % partitionCount === partitionId)
               .map((donation: any) => {
-                const donor = donors.find((d: any) => d.pk === donation.donor);
-                const donorLabel = donor?.alias ? `${donor.alias}#${donor.alias_no}` : '(Anonymous)';
+                const donor = donors?.find((d: any) => d.pk === donation.donor);
+                const donorLabel = donor?.alias ? `${donor.alias}#${donor.alias_num}` : '(Anonymous)';
 
                 return (
                   <tr key={donation.pk}>

--- a/bundles/admin/donationProcessing/processDonationsSpec.tsx
+++ b/bundles/admin/donationProcessing/processDonationsSpec.tsx
@@ -33,7 +33,7 @@ describe('ProcessDonations', () => {
           donor: [
             {
               alias: 'alias',
-              alias_no: 1234,
+              alias_num: 1234,
               pk: 1,
             },
           ],

--- a/bundles/admin/donationProcessing/readDonations.tsx
+++ b/bundles/admin/donationProcessing/readDonations.tsx
@@ -112,8 +112,8 @@ export default React.memo(function ReadDonations() {
         <table className="table table-condensed table-striped small">
           <tbody>
             {sortedDonations.map((donation: any) => {
-              const donor = donors.find((d: any) => d.pk === donation.donor);
-              const donorLabel = donor?.alias ? `${donor.alias}#${donor.alias_no}` : '(Anonymous)';
+              const donor = donors?.find((d: any) => d.pk === donation.donor);
+              const donorLabel = donor?.alias ? `${donor.alias}#${donor.alias_num}` : '(Anonymous)';
               const pinned = !!pinState[donation.pk];
 
               return (

--- a/bundles/admin/donationProcessing/readDonationsSpec.tsx
+++ b/bundles/admin/donationProcessing/readDonationsSpec.tsx
@@ -33,7 +33,7 @@ describe('ReadDonations', () => {
           donor: [
             {
               alias: 'alias',
-              alias_no: 1234,
+              alias_num: 1234,
               pk: 1,
             },
           ],

--- a/bundles/admin/index.js
+++ b/bundles/admin/index.js
@@ -8,6 +8,7 @@ import { Redirect, Route, Switch } from 'react-router';
 
 import ErrorBoundary from 'ui/public/errorBoundary';
 
+import '../common/init';
 import App from './app';
 import Constants from '../common/Constants';
 import { createTrackerStore } from '../public/api';

--- a/bundles/common/init.js
+++ b/bundles/common/init.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = window.webpackPublicPath;

--- a/bundles/public/hooks/useFetchDonors.ts
+++ b/bundles/public/hooks/useFetchDonors.ts
@@ -11,11 +11,16 @@ export function useFetchDonors(eventId: number | string | undefined) {
     if (!donors && eventId != null) {
       dispatch(modelActions.loadModels('donor', { event: +eventId }));
     } else if (donations) {
-      donations.forEach((donation: any) => {
-        if (!donors[donation.donor]) {
-          dispatch(modelActions.loadModels('donor', { pk: donation.donor }, true));
-        }
-      });
+      const ids = new Set(
+        donations
+          .filter(
+            (dn: any) => dn.donor && dn.donor__visibility !== 'ANON' && !donors?.find((dr: any) => dr.pk === dn.donor),
+          )
+          .map((dn: any) => dn.donor),
+      );
+      if (ids.size) {
+        dispatch(modelActions.loadModels('donor', { ids: [...ids.values()].join(',') }, true));
+      }
     }
   }, [dispatch, donations, donors, eventId]);
 }

--- a/bundles/public/hooks/useFetchDonorsSpec.tsx
+++ b/bundles/public/hooks/useFetchDonorsSpec.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Provider, useSelector } from 'react-redux';
+import { mount } from 'enzyme';
+import fetchMock from 'fetch-mock';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { useFetchDonors } from './useFetchDonors';
+import Endpoints from '../../tracker/Endpoints';
+
+const mockStore = configureMockStore([thunk]);
+
+function TestComponent({ eventId }: { eventId: number }) {
+  const donors = useSelector((state: any) => state.models.donors);
+  useFetchDonors(eventId);
+  return (
+    <div>
+      {donors?.map((d: any) => (
+        <div key={d.pk}>{d.public}</div>
+      ))}
+    </div>
+  );
+}
+
+describe('useFetchDonors', () => {
+  let store: ReturnType<typeof mockStore>;
+  const eventId = 1;
+
+  beforeEach(() => {
+    fetchMock.restore();
+  });
+
+  it('fetches donors by event if donors are completely missing', () => {
+    fetchMock.getOnce(`${Endpoints.SEARCH}?event=${eventId}&type=donor`, { body: [] });
+    render({});
+    expect(fetchMock.done()).toBe(true);
+  });
+
+  it('fetches missing non-anonymous donors when donors already exist', () => {
+    fetchMock.getOnce(`${Endpoints.SEARCH}?ids=1%2C3&type=donor`, { body: [] });
+    render({
+      models: {
+        donor: [{ pk: 2 }],
+        donation: [
+          {
+            donor: 1,
+            donor__visibility: 'ALIAS',
+          },
+          {
+            donor: 2,
+            donor__visibility: 'ALIAS',
+          },
+          {
+            donor: 3,
+            donor__visibility: 'ALIAS',
+          },
+          {
+            donor: 4,
+            donor__visibility: 'ANON',
+          },
+        ],
+      },
+    });
+    expect(fetchMock.done()).toBe(true);
+  });
+
+  it('fetches nothing when no non-anonymous donors are missing', () => {
+    fetchMock.get('*', 404);
+    render({
+      models: {
+        donor: [{ pk: 2 }],
+        donation: [
+          {
+            donor: 1,
+            donor__visibility: 'ANON',
+          },
+          {
+            donor: 2,
+            donor__visibility: 'ALIAS',
+          },
+        ],
+      },
+    });
+    expect(fetchMock.calls().length).toBe(0);
+  });
+
+  function render(storeState: any) {
+    store = mockStore({
+      models: { ...storeState.models },
+      singletons: { ...storeState.singletons },
+      status: { ...storeState.status },
+    });
+    return mount(
+      <Provider store={store}>
+        <TestComponent eventId={eventId} />
+      </Provider>,
+    );
+  }
+});

--- a/bundles/tracker/index.tsx
+++ b/bundles/tracker/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
+import '../common/init';
+
 import ErrorBoundary from '../public/errorBoundary';
 import ThemeProvider from '../uikit/ThemeProvider';
 import AppWrapper from './App';

--- a/tests/randgen.py
+++ b/tests/randgen.py
@@ -131,9 +131,12 @@ def generate_donor(rand, *, firstname=None, lastname=None, alias=None, visibilit
     donor.firstname = firstname or random_first_name(rand)
     donor.lastname = lastname or random_last_name(rand)
     donor.visibility = visibility or rand.choice(DonorVisibilityChoices)[0]
-    if donor.visibility == 'ALIAS' or alias:
-        donor.alias = alias or random_alias(rand)
-    donor.email = random_email(rand, alias or random_alias(rand))
+    provided_alias = alias
+    alias = alias or random_alias(rand)
+    if donor.visibility == 'ALIAS' or provided_alias:
+        # don't actually assign an alias unless we need it
+        donor.alias = alias
+    donor.email = random_email(rand, alias)
     if rand.getrandbits(1):
         donor.paypalemail = random_paypal_email(rand, alias, donor.email)
     donor.clean()

--- a/tests/randgen.py
+++ b/tests/randgen.py
@@ -130,11 +130,10 @@ def generate_donor(rand, *, firstname=None, lastname=None, alias=None, visibilit
     donor = Donor()
     donor.firstname = firstname or random_first_name(rand)
     donor.lastname = lastname or random_last_name(rand)
-    alias = alias or random_alias(rand)
     donor.visibility = visibility or rand.choice(DonorVisibilityChoices)[0]
-    if rand.getrandbits(1) or donor.visibility == 'ALIAS':
-        donor.alias = alias
-    donor.email = random_email(rand, alias)
+    if donor.visibility == 'ALIAS' or alias:
+        donor.alias = alias or random_alias(rand)
+    donor.email = random_email(rand, alias or random_alias(rand))
     if rand.getrandbits(1):
         donor.paypalemail = random_paypal_email(rand, alias, donor.email)
     donor.clean()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1111,7 +1111,7 @@ class TestDonor(APITestCase):
         self.parseJSON(tracker.views.api.search(request), status_code=403)
 
     def test_donor_full_names_with_permission(self):
-        donor = randgen.generate_donor(self.rand, visibility='ANON')
+        donor = randgen.generate_donor(self.rand, visibility='ALIAS')
         donor.save()
         request = self.factory.get(
             reverse('tracker:api_v1:search'), dict(type='donor', donor_names='')
@@ -1254,9 +1254,13 @@ class TestDonation(APITestCase):
         )
         donation.save()
 
+        self.donor.visibility = 'ALIAS'
+        self.donor.save()
+
         request = self.factory.get(
             reverse('tracker:api_v1:search'), dict(type='donation', donor=self.donor.id)
         )
+        request.user = self.anonymous_user
 
         data = self.parseJSON(tracker.views.api.search(request))
         self.assertEqual(len(data), 1)
@@ -1272,6 +1276,7 @@ class TestDonation(APITestCase):
         request = self.factory.get(
             reverse('tracker:api_v1:search'), dict(type='donation', donor=self.donor.id)
         )
+        request.user = self.anonymous_user
 
         data = self.parseJSON(tracker.views.api.search(request))
         self.assertEqual(len(data), 0, msg='Anonymous donor was searchable')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1254,6 +1254,7 @@ class TestDonation(APITestCase):
         )
         donation.save()
 
+        self.donor.alias = 'Foo'
         self.donor.visibility = 'ALIAS'
         self.donor.save()
 

--- a/tracker/templates/ui/index.html
+++ b/tracker/templates/ui/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'main.css' %}"/>
     <script type='text/javascript'>
       <!--
+      window.webpackPublicPath = "{% static 'gen/' %}";
       document.addEventListener("DOMContentLoaded", function () {
         window[JSON.parse(document.getElementById('app_name').textContent)](
           Object.assign(

--- a/tracker/views/api.py
+++ b/tracker/views/api.py
@@ -258,6 +258,7 @@ def donation_privacy_filter(fields):
     if fields['commentstate'] != 'APPROVED':
         del fields['comment']
         del fields['commentlanguage']
+    # FIXME?: these don't get filtered out on `all_comments` searches but maybe that's ok
     if fields['donor__visibility'] == 'ANON':
         del fields['donor']
         del fields['donor__alias']


### PR DESCRIPTION
[#175445588]

* sorts events by reverse date and labels locked events
* batches donor fetches better
* no longer tries to fetch anonymous donors
* API no longer returns anonymous donors or allows donation searches
  on anonymous donors (results will be empty)
* use `__webpack_public_path__` for CDN support

# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175445588

### Description of the Change

After deploying the new flow to the server I noticed that I didn't particularly like the order the events were showing up in (seemed to be creation date rather than event date, and was backwards), so I fixed that.

While doing so I noticed that the hook to fetch missing donors had some behavior that needed fixing (fetching the same donor repeatedly in some cases, sending separate requests instead of using the `ids` parameter, etc), so I went ahead and fixed that too.

Then I noticed that the donation search allowed you to search by donor id even if the donor was anonymous, and that the donor search would happily return anonymous donor ids (but no other information), which partially defeats the purpose of being anonymous. We removed the capability to list an anonymous donor's donations on the public pages a while back, so extending that behavior to the API seems prudent.

Note that anonymous donations still show up in a more generic search, but they are missing the donor information unless the user a) has permission and b) specifically requests it (confusingly, via `all_comments`, but the permission model isn't more granular than that, so I left a note to remind myself of this).

### Verification Process

Locked some events and fiddled with the start date to ensure the sort was working.

Made a donor anonymous and made sure they stopped showing up in a donor search, and that searching for donations specifically by donor returned an empty list if the donor was anonymous.