### PR TITLE
remove betterforms due to compatibility issues with Django 3 [#175589771]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ celery==5.0.2
 channels==3.0.1
 Django==2.2.17
 django-ajax-selects==1.9.1
-django-betterforms==1.1.4
 django-ical==1.7.1
 django-paypal==1.0.0
 django-mptt==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'channels~=3.0',
         'Django~=2.2',
         'django-ajax-selects~=1.9',
-        'django-betterforms~=1.1',
         'django-ical~=1.7',
         'django-mptt~=0.10',
         'django-paypal~=1.0',

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -1775,7 +1775,7 @@ class TestPrizeWinner(TestCase):
             'admin', 'nobody@example.com', 'password'
         )
 
-    def test_donor_cache(self):
+    def test_prize_winner_donor_cache(self):
         self.assertEqual(
             self.write_in_prize.get_prize_winner().donor_cache, self.write_in_donor
         )

--- a/tracker/forms.py
+++ b/tracker/forms.py
@@ -1,13 +1,16 @@
-import collections
 import datetime
 import re
 from decimal import Decimal
 
-import betterforms.multiform
 import django.core.exceptions
 import django.db.utils
 import post_office
 import post_office.models
+import tracker.auth as auth
+import tracker.prizemail as prizemail
+import tracker.util
+import tracker.viewutil as viewutil
+import tracker.widgets
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
@@ -19,12 +22,6 @@ from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
-
-import tracker.auth as auth
-import tracker.prizemail as prizemail
-import tracker.util
-import tracker.viewutil as viewutil
-import tracker.widgets
 from tracker import models
 from tracker.validators import positive, nonzero
 
@@ -48,7 +45,6 @@ __all__ = [
     'AutomailPrizeWinnersForm',
     'RegistrationConfirmationForm',
     'PrizeAcceptanceForm',
-    'PrizeAcceptanceWithAddressForm',
     'PrizeShippingFormSet',
 ]
 
@@ -921,7 +917,7 @@ class PrizeAcceptanceForm(forms.ModelForm):
         super(PrizeAcceptanceForm, self).__init__(*args, **kwargs)
         self.accepted = None
 
-        data = kwargs['data'] or {}
+        data = kwargs.get('data', {})
 
         if 'accept' in data:
             self.accepted = True
@@ -1026,17 +1022,6 @@ class AddressForm(forms.ModelForm):
 class NullForm(forms.Form):
     def save(self, commit=True):
         return None
-
-
-class PrizeAcceptanceWithAddressForm(betterforms.multiform.MultiModelForm):
-    form_classes = collections.OrderedDict(
-        [('address', AddressForm), ('prizeaccept', PrizeAcceptanceForm)]
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(PrizeAcceptanceWithAddressForm, self).__init__(*args, **kwargs)
-        if not self.forms['prizeaccept'].instance.prize.requiresshipping:
-            del self.forms['address']
 
 
 class PrizeShippingForm(forms.ModelForm):

--- a/tracker/templates/tracker/prize_winner.html
+++ b/tracker/templates/tracker/prize_winner.html
@@ -36,7 +36,11 @@ Also, please enter/confirm your shipping address.
 <form method="post">
 {% csrf_token %}
 
-{% form_innards form showrequired=False %}
+{% if address_form %}
+  {% form_innards address_form showrequired=False %}
+{% endif %}
+
+{% form_innards acceptance_form showrequired=False %}
 
 {% if prize_win.pendingcount > 1 %}
 <input type="submit" name="accept" value="Accept">


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~ (See below.)
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175589771

### Description of the Change

While trying to add Django 3 to the test matrix (see #305) I noticed some failures that I had to dig into. One of them was a dependency on `django-betterforms` which hasn't seen a commit in two years and no longer works with Django 3. We were only using it for one form, prize acceptance, and it was relatively simple to replace. There are a couple of tests that interact with the old form via the view, but they did not require any changes once the new forms were in place.

### Verification Process

Set up a test prize that had pending acceptance. Tried it with and without the address form (prizes that don't need shipping don't require an address), with both accepting and declining the prize. Prize wins and donor address updated as expected.