### PR TITLE
link back to the admin root from the React-ified admin pages [#175625196]

### DIFF
--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -111,7 +111,7 @@ const App = () => {
     status: state.status,
   }));
 
-  const { API_ROOT } = useConstants();
+  const { API_ROOT, ADMIN_ROOT } = useConstants();
   const canChangeDonations = usePermission('tracker.change_donation');
   const canChangeBids = usePermission('tracker.change_bid');
 
@@ -136,6 +136,12 @@ const App = () => {
     <div style={{ position: 'relative', display: 'flex', height: 'calc(100vh - 51px)', flexDirection: 'column' }}>
       <div style={{ height: 60, display: 'flex', alignItems: 'center' }}>
         <Spinner spinning={status.event !== 'success'}>
+          {ADMIN_ROOT && (
+            <>
+              <a href={ADMIN_ROOT}>Admin Home</a>
+              &mdash;
+            </>
+          )}
           <DropdownMenu name="Schedule Editor" path="schedule_editor" />
           &mdash;
           <DropdownMenu name="Interstitials" path="interstitials" />

--- a/tracker/templates/admin/tracker/app_index.html
+++ b/tracker/templates/admin/tracker/app_index.html
@@ -1,4 +1,4 @@
-{% extends 'admin/index.html' %}
+{% extends 'admin/app_index.html' %}
 
 {% block sidebar %}
   {{ block.super }}

--- a/tracker/templates/admin/tracker/extra_actions.html
+++ b/tracker/templates/admin/tracker/extra_actions.html
@@ -1,0 +1,45 @@
+<div class="module" style="float: left; width: 498px">
+  <table style="width: 100%">
+    <tbody>
+    {% if request.user.is_superuser %}
+      <tr>
+        <td><a href="{% url 'admin:diagnostics' %}">Diagnostics</a></td>
+      </tr>
+    {% endif %}
+    {% if perms.tracker.change_prizewinner %}
+      <tr>
+        <td><a href="{% url 'admin:automail_prize_contributors' %}">Mail Prize Contributors</a></td>
+      </tr>
+      <tr>
+        <td><a href="{% url 'admin:automail_prize_winners' %}">Mail Prize Winners</a></td>
+      </tr>
+      <tr>
+        <td><a href="{% url 'admin:automail_prize_accept_notifications' %}">Mail Prize Winner Accept Notifications</a>
+        </td>
+      </tr>
+      <tr>
+        <td><a href="{% url 'admin:automail_prize_shipping_notifications' %}">Mail Prize Winner Shipping
+          Notifications</a></td>
+      </tr>
+    {% endif %}
+    {% if perms.tracker.change_donation %}
+      <tr>
+        <td><a href="{% url 'admin:tracker_ui' extra='process_donations/' %}">Process Donations</a></td>
+      </tr>
+      <tr>
+        <td><a href="{% url 'admin:tracker_ui' extra='read_donations/' %}">Read Donations</a></td>
+      </tr>
+    {% endif %}
+    {% if perms.tracker.change_interstitial %}
+      <tr>
+        <td><a href="{% url 'admin:view_full_schedule' %}">View Full Schedule</a></td>
+      </tr>
+    {% endif %}
+    {% if perms.tracker.change_bid %}
+      <tr>
+        <td><a href="{% url 'admin:tracker_ui' extra='process_pending_bids/' %}">Process Pending Bids</a></td>
+      </tr>
+    {% endif %}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~ (Just template changes.)
- [X ] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175625196

### Description of the Change

Ted pointed out the lack of a link back to the admin root when looking at the React-ified Donation Processing pages, which is especially confusing since the header has a 'Home' link that takes you back to the front public page. This addresses that and also adds the extra Tracker admin actions to the `/admin/tracker` page, since I realized they were missing from there.

### Verification Process

Pages show the new links, and the links work. Pretty straightforward.