### PR TITLE
loading a schedule editor URL directly loads correctly [#175655776]

### DIFF
--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -164,6 +164,7 @@ const App = () => {
       <Spinner spinning={!ready}>
         <div style={{ flex: '1 0 1', overflow: 'auto' }}>
           <Switch>
+            <Route path={`${match.url}/schedule_editor/`} exact component={EventMenu('Schedule Editor')} />
             <Route path={`${match.url}/schedule_editor/:event`} component={ScheduleEditor} />
             <Route path={`${match.url}/interstitials/:event`} component={Interstitials} />
             {canChangeDonations && (

--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -161,24 +161,30 @@ const App = () => {
           )}
         </Spinner>
       </div>
-      <div style={{ flex: '1 0 1', overflow: 'auto' }}>
-        <Switch>
-          <Route path={`${match.url}/schedule_editor/:event`} component={ScheduleEditor} />
-          <Route path={`${match.url}/interstitials/:event`} component={Interstitials} />
-          {canChangeDonations && (
-            <Route path={`${match.url}/read_donations/`} exact component={EventMenu('Read Donations')} />
-          )}
-          {canChangeDonations && <Route path={`${match.url}/read_donations/:event`} component={ReadDonations} />}
-          {canChangeDonations && (
-            <Route path={`${match.url}/process_donations/`} exact component={EventMenu('Process Donations')} />
-          )}
-          {canChangeDonations && <Route path={`${match.url}/process_donations/:event`} component={ProcessDonations} />}
-          {canChangeBids && (
-            <Route path={`${match.url}/process_pending_bids/`} exact component={EventMenu('Process Pending Bids')} />
-          )}
-          {canChangeBids && <Route path={`${match.url}/process_pending_bids/:event`} component={ProcessPendingBids} />}
-        </Switch>
-      </div>
+      <Spinner spinning={!ready}>
+        <div style={{ flex: '1 0 1', overflow: 'auto' }}>
+          <Switch>
+            <Route path={`${match.url}/schedule_editor/:event`} component={ScheduleEditor} />
+            <Route path={`${match.url}/interstitials/:event`} component={Interstitials} />
+            {canChangeDonations && (
+              <Route path={`${match.url}/read_donations/`} exact component={EventMenu('Read Donations')} />
+            )}
+            {canChangeDonations && <Route path={`${match.url}/read_donations/:event`} component={ReadDonations} />}
+            {canChangeDonations && (
+              <Route path={`${match.url}/process_donations/`} exact component={EventMenu('Process Donations')} />
+            )}
+            {canChangeDonations && (
+              <Route path={`${match.url}/process_donations/:event`} component={ProcessDonations} />
+            )}
+            {canChangeBids && (
+              <Route path={`${match.url}/process_pending_bids/`} exact component={EventMenu('Process Pending Bids')} />
+            )}
+            {canChangeBids && (
+              <Route path={`${match.url}/process_pending_bids/:event`} component={ProcessPendingBids} />
+            )}
+          </Switch>
+        </div>
+      </Spinner>
     </div>
   );
 };

--- a/bundles/admin/scheduleEditor/index.js
+++ b/bundles/admin/scheduleEditor/index.js
@@ -12,9 +12,16 @@ class ScheduleEditor extends React.Component {
     const { speedruns, event, drafts, status, moveSpeedrun, editable } = this.props;
     const { saveField_, saveModel_, editModel_, cancelEdit_, newSpeedrun_, updateField_ } = this;
     const loading = status.speedrun === 'loading' || status.event === 'loading' || status.me === 'loading';
+    const error = status.speedrun === 'error' || status.event === 'error' || status.me === 'error';
     return (
       <Spinner spinning={loading}>
-        {status.speedrun === 'success' ? (
+        {error ? (
+          <>
+            {status.speedrun === 'error' && <div>Failed to fetch speedruns</div>}
+            {status.event === 'error' && <div>Failed to fetch events</div>}
+            {status.me === 'error' && <div>Failed to fetch me</div>}
+          </>
+        ) : (
           <SpeedrunTable
             event={event}
             drafts={drafts}
@@ -27,7 +34,7 @@ class ScheduleEditor extends React.Component {
             saveField={editable ? saveField_ : null}
             updateField={editable ? updateField_ : null}
           />
-        ) : null}
+        )}
       </Spinner>
     );
   }
@@ -80,13 +87,13 @@ class ScheduleEditor extends React.Component {
 function select(state, props) {
   const { models, drafts, status, singletons } = state;
   const { speedrun: speedruns, event: events = [] } = models;
-  const event = events.find(e => e.pk === parseInt(props.match.params.event)) || null;
+  const event = events.find(e => e.pk === parseInt(props.match?.params?.event)) || null;
   const { me } = singletons;
   return {
     event,
     speedruns,
     status,
-    drafts: drafts.speedrun || {},
+    drafts: drafts?.speedrun || {},
     editable:
       authHelper.hasPermission(me, `tracker.change_speedrun`) &&
       (!(event && event.locked) || authHelper.hasPermission(me, `tracker.can_edit_locked_events`)),

--- a/bundles/admin/scheduleEditor/indexSpec.tsx
+++ b/bundles/admin/scheduleEditor/indexSpec.tsx
@@ -4,7 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
-import { StaticRouter } from 'react-router';
+import fetchMock from 'fetch-mock';
 
 const mockStore = configureMockStore([thunk]);
 
@@ -12,6 +12,11 @@ describe('ScheduleEditor', () => {
   let store: ReturnType<typeof mockStore>;
   let subject: ReturnType<typeof render>;
   const eventId = 1;
+
+  beforeEach(() => {
+    fetchMock.restore();
+    fetchMock.get('*', 404);
+  });
 
   it('shows an error if things fail to load', () => {
     subject = render({ status: { speedrun: 'error', event: 'error', me: 'error' } });

--- a/bundles/admin/scheduleEditor/indexSpec.tsx
+++ b/bundles/admin/scheduleEditor/indexSpec.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import ScheduleEditor from './index';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { StaticRouter } from 'react-router';
+
+const mockStore = configureMockStore([thunk]);
+
+describe('ScheduleEditor', () => {
+  let store: ReturnType<typeof mockStore>;
+  let subject: ReturnType<typeof render>;
+  const eventId = 1;
+
+  it('shows an error if things fail to load', () => {
+    subject = render({ status: { speedrun: 'error', event: 'error', me: 'error' } });
+    expect(subject.text()).toContain('Failed to fetch speedruns');
+  });
+
+  function render(storeState: any) {
+    store = mockStore({
+      models: { ...storeState.models },
+      singletons: { ...storeState.singletons },
+      status: { ...storeState.status },
+    });
+    return mount(
+      <Provider store={store}>
+        <ScheduleEditor match={{ params: { event: eventId } }} />
+      </Provider>,
+    );
+  }
+});

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     cmdclass={'package': PackageCommand,},
     install_requires=[
         'celery~=5.0',
-        'channels~=3.0',
+        'channels>=2.0',
         'Django~=2.2',
         'django-ajax-selects~=1.9',
         'django-ical~=1.7',

--- a/tracker/routing.py
+++ b/tracker/routing.py
@@ -2,8 +2,17 @@ from django.urls import path
 
 from . import consumers
 
+
+def channel_six(consumer):
+    as_asgi = getattr(consumer, 'as_asgi', None)
+    if callable(as_asgi):
+        return as_asgi()
+    else:
+        return consumer
+
+
 websocket_urlpatterns = [
-    path('ws/donations/', consumers.DonationConsumer.as_asgi()),
-    path('ws/ping/', consumers.PingConsumer.as_asgi()),
-    path('ws/celery/', consumers.CeleryConsumer.as_asgi()),
+    path('ws/donations/', channel_six(consumers.DonationConsumer)),
+    path('ws/ping/', channel_six(consumers.PingConsumer)),
+    path('ws/celery/', channel_six(consumers.CeleryConsumer)),
 ]

--- a/tracker/templates/admin/tracker/extra_actions.html
+++ b/tracker/templates/admin/tracker/extra_actions.html
@@ -30,6 +30,9 @@
         <td><a href="{% url 'admin:tracker_ui' extra='read_donations/' %}">Read Donations</a></td>
       </tr>
     {% endif %}
+    <tr>
+      <td><a href="{% url 'admin:tracker_ui' extra='schedule_editor/' %}">View Run Schedule</a></td>
+    </tr>
     {% if perms.tracker.change_interstitial %}
       <tr>
         <td><a href="{% url 'admin:view_full_schedule' %}">View Full Schedule</a></td>


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175655776

### Description of the Change

The recent changes to the way the API root works broke the schedule editor if you tried to go to it before visiting another page due to an accident of timing. This prevents the router from kicking in and loading any of the sub-pages before the Admin root has a change to set the API root.

And also makes the schedule editor actually display something if anything it needs fails to load.

### Verification Process

Visited a schedule editor url directly (e.g. `/admin/tracker/event/ui/schedule_editor/1`) and the schedule actually loads properly.

Then I took the backend down and swapped between events to see the error message about runs failing to fetch.