### PR TITLE
correctly parse partial seconds in timestamp fields [#175787753]

### DIFF
--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -18,20 +18,28 @@ class TestSpeedRun(TransactionTestCase):
     def setUp(self):
         self.event1 = models.Event.objects.create(datetime=today_noon, targetamount=5)
         self.run1 = models.SpeedRun.objects.create(
-            name='Test Run', run_time='0:45:00', setup_time='0:05:00', order=1
+            name='Test Run', run_time='45:00', setup_time='5:00', order=1
         )
         self.run2 = models.SpeedRun.objects.create(
-            name='Test Run 2', run_time='0:15:00', setup_time='0:05:00', order=2
+            name='Test Run 2', run_time='15:00', setup_time='5:00', order=2
         )
         self.run3 = models.SpeedRun.objects.create(
-            name='Test Run 3', run_time='0:05:00', order=3
+            name='Test Run 3', run_time='5:00', order=3
         )
         self.run4 = models.SpeedRun.objects.create(
-            name='Test Run 4', run_time='0:20:00', setup_time='0:05:00', order=None
+            name='Test Run 4', run_time='1:20:00', setup_time='5:00', order=None
         )
         self.run5 = models.SpeedRun.objects.create(name='Test Run 5', order=4)
         self.runner1 = models.Runner.objects.create(name='trihex')
         self.runner2 = models.Runner.objects.create(name='neskamikaze')
+
+    # TODO: maybe disallow partial seconds? this cropped as a bug but we never actually use milliseconds
+
+    def test_run_time(self):
+        self.run1.run_time = '45:00.1'
+        self.run1.save()
+        self.run1.refresh_from_db()
+        self.assertEqual(self.run1.run_time, '0:45:00.100')
 
     def test_first_run_start_time(self):
         self.assertEqual(self.run1.starttime, self.event1.datetime)

--- a/tracker/models/fields.py
+++ b/tracker/models/fields.py
@@ -45,9 +45,12 @@ class TimestampValidator(validators.RegexValidator):
             )
 
 
+# TODO: give this a proper unit test and maybe pull it into its own library? or maybe just find an already existing duration field that does what we want
+
+
 class TimestampField(models.Field):
     default_validators = [TimestampValidator()]
-    match_string = re.compile(r'(?:(?:(\d+):)?(?:(\d+):))?(\d+)(?:\.(\d+))?')
+    match_string = re.compile(r'(?:(?:(\d+):)?(?:(\d+):))?(\d+)(?:\.(\d{1,3}))?')
 
     def __init__(
         self,
@@ -115,7 +118,14 @@ class TimestampField(models.Field):
         s %= 60
         h = int(h or m / 60)
         m %= 60
-        ms = int(ms or 0)
+        if ms:
+            ln = len(ms)
+            ms = int(ms)
+            while ln < 3:
+                ln += 1
+                ms *= 10
+        else:
+            ms = 0
         return h * 3600000 + m * 60000 + s * 1000 + ms
 
     def get_prep_value(self, value):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175787753

### Description of the Change

This has been a latent bug for quite a while but we never used partial seconds so it was easy to miss. `0.1` was being parsed as `0.001`. This fixes that particular, though it's possible that it should just not accept partial seconds at all for the fields in question (`run_time` and `setup_time`) since we never care about that level of precision.

### Verification Process

Edited some runs to use partial seconds for `run_time` and `setup_time` and verified that the resulting schedule still looked correct.