### PR TITLE
Differentiate between Primary and Summary images for Prizes

### DIFF
--- a/bundles/tracker/prizes/PrizeTypes.ts
+++ b/bundles/tracker/prizes/PrizeTypes.ts
@@ -12,14 +12,30 @@ export type Prize = {
   public: string;
   description: string;
   shortDescription: string;
-  // NOTE: This currently represents the server's idea of a canonical URL for
-  // the prize, not this app's route for it.
+  /**
+   * NOTE: This currently represents the server's idea of a canonical URL for
+   * the prize, not this app's route for it.
+   */
   canonicalUrl: string;
   extraInfo?: string;
   categoryId?: string;
   category?: PrizeCategory;
+  /**
+   * A representative image of the Prize, often as submitted by the prize donor.
+   * Size and resolution can be variable.
+   */
   image?: string;
+  /**
+   * A cropped image of the Prize, meant to fit consistently inside of stream layouts,
+   * often taken specifically for the event.
+   */
   altImage?: string;
+  /**
+   * An image for this prize that is hosted by the tracker itself in case remote
+   * services for `image` or `altImage` aren't available.
+   *
+   * This will always take priority over the other two images.
+   */
   imageFile?: string;
   estimatedValue?: number;
   minimumBid: number;

--- a/bundles/tracker/prizes/PrizeUtils.ts
+++ b/bundles/tracker/prizes/PrizeUtils.ts
@@ -1,6 +1,16 @@
 import { Prize } from './PrizeTypes';
 import _ from 'lodash';
 
+/**
+ * Returns the URL of an image to use when showing a Prize individually.
+ */
 export function getPrimaryImage(prize: Prize): string | undefined {
+  return _.find([prize.imageFile, prize.image, prize.altImage]);
+}
+
+/**
+ * Returns the URL of an image to use when showing a Prize as part of a group.
+ */
+export function getSummaryImage(prize: Prize): string | undefined {
   return _.find([prize.imageFile, prize.altImage, prize.image]);
 }

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -41,7 +41,7 @@ const PrizeCard = (props: PrizeCardProps) => {
     return <div className={styles.card} />;
   }
 
-  const coverImage = prizeError ? null : PrizeUtils.getPrimaryImage(prize);
+  const coverImage = prizeError ? null : PrizeUtils.getSummaryImage(prize);
 
   return (
     <Clickable className={classNames(styles.card, className)} onClick={handleViewPrize}>


### PR DESCRIPTION
### Description of the Change

This makes it so that `PrizeCard` (as used in the list of prizes for an event) can/will use a different image than the Prize details page, since the details page isn't constrained to a specific aspect ratio.

### Verification Process

Kinda flyin blind, couldn't get the backend to run, but it did compile!