### PR TITLE
fix useFetchDonors throttling/fetch behavior [#175749519]

### DIFF
--- a/bundles/admin/donationProcessing/processDonationsSpec.tsx
+++ b/bundles/admin/donationProcessing/processDonationsSpec.tsx
@@ -17,11 +17,17 @@ describe('ProcessDonations', () => {
   const eventId = 1;
 
   beforeEach(() => {
+    jasmine.clock().install();
     fetchMock.restore();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
   });
 
   it('loads donors and donations on mount', () => {
     render({});
+    jasmine.clock().tick(0);
     expect(store.getActions()).toContain(jasmine.objectContaining({ type: 'MODEL_STATUS_LOADING', model: 'donor' }));
     expect(store.getActions()).toContain(jasmine.objectContaining({ type: 'MODEL_STATUS_LOADING', model: 'donation' }));
   });

--- a/bundles/admin/donationProcessing/readDonationsSpec.tsx
+++ b/bundles/admin/donationProcessing/readDonationsSpec.tsx
@@ -17,11 +17,17 @@ describe('ReadDonations', () => {
   const eventId = 1;
 
   beforeEach(() => {
+    jasmine.clock().install();
     fetchMock.restore();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
   });
 
   it('loads donors and donations on mount', () => {
     render({});
+    jasmine.clock().tick(0);
     expect(store.getActions()).toContain(jasmine.objectContaining({ type: 'MODEL_STATUS_LOADING', model: 'donor' }));
     expect(store.getActions()).toContain(jasmine.objectContaining({ type: 'MODEL_STATUS_LOADING', model: 'donation' }));
   });

--- a/bundles/public/api/actions/models.js
+++ b/bundles/public/api/actions/models.js
@@ -70,7 +70,6 @@ function loadModels(model, params, additive) {
       type: fetchModel,
     })
       .then(models => {
-        dispatch(onModelStatusSuccess(model));
         const action = additive ? onModelCollectionAdd : onModelCollectionReplace;
         dispatch(
           action(
@@ -84,12 +83,13 @@ function loadModels(model, params, additive) {
             }, []),
           ),
         );
+        dispatch(onModelStatusSuccess(model));
       })
       .catch(error => {
-        dispatch(onModelStatusError(model));
         if (!additive) {
           dispatch(onModelCollectionReplace(realModel, []));
         }
+        dispatch(onModelStatusError(model));
       });
   };
 }

--- a/bundles/public/hooks/useFetchDonors.ts
+++ b/bundles/public/hooks/useFetchDonors.ts
@@ -1,26 +1,36 @@
 import modelActions from '../api/actions/models';
 import { useSelector, useDispatch } from 'react-redux';
-import { useEffect } from 'react';
+import * as React from 'react';
 
 export function useFetchDonors(eventId: number | string | undefined) {
-  const donations = useSelector((state: any) => state.models.donation);
-  const donors = useSelector((state: any) => state.models.donor);
+  const { donation: donations, donor: donors } = useSelector((state: any) => state.models);
+  const { donor: donorStatus } = useSelector((state: any) => state.status);
   const dispatch = useDispatch();
+  const timeoutId = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
-    if (!donors && eventId != null) {
-      dispatch(modelActions.loadModels('donor', { event: +eventId }));
-    } else if (donations) {
-      const ids = new Set(
-        donations
-          .filter(
-            (dn: any) => dn.donor && dn.donor__visibility !== 'ANON' && !donors?.find((dr: any) => dr.pk === dn.donor),
-          )
-          .map((dn: any) => dn.donor),
-      );
-      if (ids.size) {
-        dispatch(modelActions.loadModels('donor', { ids: [...ids.values()].join(',') }, true));
-      }
+  React.useEffect(() => {
+    if (!timeoutId.current && donorStatus !== 'loading') {
+      timeoutId.current = setTimeout(() => {
+        if (!donors && eventId != null) {
+          dispatch(modelActions.loadModels('donor', { event: +eventId }));
+        } else if (donations) {
+          const ids = new Set(
+            donations
+              .filter(
+                (dn: any) =>
+                  dn.donor &&
+                  dn.donor__visibility &&
+                  dn.donor__visibility !== 'ANON' &&
+                  !donors?.find((dr: any) => dr.pk === dn.donor),
+              )
+              .map((dn: any) => dn.donor),
+          );
+          if (ids.size) {
+            dispatch(modelActions.loadModels('donor', { ids: [...ids.values()].join(',') }, true));
+          }
+        }
+        timeoutId.current = null;
+      }, 0);
     }
-  }, [dispatch, donations, donors, eventId]);
+  }, [dispatch, donations, donors, donorStatus, eventId]);
 }

--- a/bundles/public/hooks/useFetchDonorsSpec.tsx
+++ b/bundles/public/hooks/useFetchDonorsSpec.tsx
@@ -26,12 +26,18 @@ describe('useFetchDonors', () => {
   const eventId = 1;
 
   beforeEach(() => {
+    jasmine.clock().install();
     fetchMock.restore();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
   });
 
   it('fetches donors by event if donors are completely missing', () => {
     fetchMock.getOnce(`${Endpoints.SEARCH}?event=${eventId}&type=donor`, { body: [] });
     render({});
+    jasmine.clock().tick(0);
     expect(fetchMock.done()).toBe(true);
   });
 
@@ -57,9 +63,14 @@ describe('useFetchDonors', () => {
             donor: 4,
             donor__visibility: 'ANON',
           },
+          {
+            donor: 5,
+            // no visibility information, e.g. the donation has been edited since the last fetch, so treat as anonymous
+          },
         ],
       },
     });
+    jasmine.clock().tick(0);
     expect(fetchMock.done()).toBe(true);
   });
 
@@ -77,9 +88,14 @@ describe('useFetchDonors', () => {
             donor: 2,
             donor__visibility: 'ALIAS',
           },
+          {
+            donor: 3,
+            // no visibility information, e.g. the donation has been edited since the last fetch, so treat as anonymous
+          },
         ],
       },
     });
+    jasmine.clock().tick(0);
     expect(fetchMock.calls().length).toBe(0);
   });
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/175749519

### Description of the Change

There's a couple of unfortunate bugs happening with the new donation processing page when it comes to anonymous donors and this branch addresses those.

Firstly, it throttles the request so that only one can be in flight at a time.

Secondly, after editing a Donation with an anonymous Donor, sometimes it would get stuck in an infinite loop trying to fetch Donor information that will never be returned, resulting in server hammering. This fixes the logic so that it doesn't occur.

### Verification Process

It's been on the live GDQ server for months now.