### PR TITLE
update paypal flow to work with django-paypal 1.1 [#180018794]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'django-ajax-selects~=1.9',
         'django-ical~=1.7',
         'django-mptt~=0.10',
-        'django-paypal~=1.0.0',
+        'django-paypal~=1.1',
         'django-post-office~=3.2',
         'django-timezone-field>=3.1,<5.0',
         'djangorestframework~=3.9',

--- a/tracker/templates/tracker/paypal_redirect.html
+++ b/tracker/templates/tracker/paypal_redirect.html
@@ -1,12 +1,12 @@
 <head>
   <script>
     window.onload = function() {
-      document.PaypalRedirect.submit();
+      document.querySelector("#form form").submit();
     }
   </script>
 </head>
 <body>
-  <form name="PaypalRedirect" method="post" action="{{ form.get_endpoint }}">
-    {{ form.as_p }}
-  </form>
+  <div id="form" style="display: none">
+    {{ form.render }}
+  </div>
 </body>


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/180018794

### Description of the Change

`django-paypal` 1.1.x changed an undocumented api call that we were relying on for our PayPal flow, causing users to be unable to receive donations if they installed that version as a result of version matching, requiring them to explicitly downgrade to 1.0. This uses the correct method of rendering the form before redirecting the user to PayPal to finish the donation, which should allow upgrading to 1.1.x.

### Verification Process

Did a donation, verified that the fields (especially the `custom` field) were intact when looking at the transaction from the receiver side (e.g. sandbox receiver account), and sent a test IPN with the simulator to make sure the donation was marked as received.