### PR TITLE
donation form no longer eats linebreaks [#178848796]

### DIFF
--- a/bundles/tracker/donation/DonationActions.ts
+++ b/bundles/tracker/donation/DonationActions.ts
@@ -83,7 +83,7 @@ export function submitDonation(donateUrl: string, csrfToken: string, donation: D
   const submissionData = buildDonationPayload(csrfToken, donation, bids);
 
   _.forEach(submissionData, (value, field) => {
-    const input = document.createElement('input');
+    const input = document.createElement('textarea');
     input.name = field;
     input.value = value.toString();
     form.appendChild(input);


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/178848796

### Description of the Change

As part of the glue layer between the React donation form and sending the data in the way that Django form processing expects, the code makes a temporary form and pushes all of the data into it before using a standard form submit. Problem is that it was using `input` instead of `textarea` so any newlines (in the comment field specifically) got lost. This corrects that.

### Verification Process

Before the change, entering in newlines to the donate form would be lost when inspecting the resulting POST request. After the change that no longer occurs, and the database entry for the pending donation correctly contains newlines. There's no test for the specific glue code and writing one probably would have required a full browser test to actually be a useful test, so maybe later.