### PR TITLE
upgrade `react-hooks/exhaustive-deps` to an error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,7 +73,7 @@
     "react/prop-types": 1,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
-      "warn",
+      "error",
       {
         "additionalHooks": "useCachedCallback"
       }

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ import tracker.urls
 import ajax_select.urls
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
     path('admin/lookups/', include(ajax_select.urls)),
+    path('admin/', admin.site.urls),
     path('tracker/', include(tracker.urls, namespace='tracker')),
 ]
 ```

--- a/bundles/admin/donationProcessing/processDonations.tsx
+++ b/bundles/admin/donationProcessing/processDonations.tsx
@@ -61,7 +61,7 @@ export default React.memo(function ProcessDonations() {
       dispatch(modelActions.loadModels('donation', params));
       e?.preventDefault();
     },
-    [dispatch, secondStep, eventId],
+    [dispatch, eventId, mode],
   );
   useFetchDonors(eventId);
   useEffect(() => {

--- a/bundles/admin/scheduleEditor/speedrunTable.js
+++ b/bundles/admin/scheduleEditor/speedrunTable.js
@@ -66,7 +66,7 @@ function SpeedrunTable({
         'order',
         1,
       ),
-    [],
+    [saveField, speedruns],
   );
 
   // this is hard as hell to understand and kinda slow so uh maybe clean it up a bit

--- a/bundles/tracker/donation/components/DonationBidForm.tsx
+++ b/bundles/tracker/donation/components/DonationBidForm.tsx
@@ -46,14 +46,6 @@ const DonationBidForm = (props: DonationBidFormProps) => {
   const [customOptionSelected, setCustomOptionSelected] = React.useState(false);
   const [customOption, setCustomOption] = React.useState('');
 
-  // When the selected incentive changes, reset the form fields
-  React.useEffect(() => {
-    setAllocatedAmount(remainingDonationTotal);
-    setSelectedChoiceId(undefined);
-    setCustomOptionSelected(false);
-    setCustomOption('');
-  }, [incentiveId]);
-
   const bidValidation = React.useMemo(
     () =>
       validateBid(
@@ -69,7 +61,17 @@ const DonationBidForm = (props: DonationBidFormProps) => {
         selectedChoiceId != null,
         customOptionSelected,
       ),
-    [selectedChoiceId, allocatedAmount, customOption, incentive, donation, bids, bidChoices, customOptionSelected],
+    [
+      selectedChoiceId,
+      incentiveId,
+      allocatedAmount,
+      customOption,
+      incentive,
+      donation,
+      bids,
+      bidChoices.length,
+      customOptionSelected,
+    ],
   );
 
   const handleNewChoice = useCachedCallback(choiceId => {

--- a/bundles/tracker/donation/components/DonationIncentives.tsx
+++ b/bundles/tracker/donation/components/DonationIncentives.tsx
@@ -84,6 +84,7 @@ const DonationIncentives = (props: DonationIncentivesProps) => {
 
           {selectedIncentiveId != null ? (
             <DonationBidForm
+              key={selectedIncentiveId} // reset the form if the incentive changes
               className={styles.right}
               incentiveId={selectedIncentiveId}
               step={step}

--- a/bundles/tracker/prizes/components/Prize.tsx
+++ b/bundles/tracker/prizes/components/Prize.tsx
@@ -101,7 +101,7 @@ const Prize = (props: PrizeProps) => {
 
   useEffect(() => {
     dispatch(PrizeActions.fetchPrizes({ id: prizeId }));
-  }, [dispatch]);
+  }, [dispatch, prizeId]);
 
   useEffect(() => {
     if (event == null && eventId != null) {

--- a/bundles/tracker/prizes/components/Prizes.tsx
+++ b/bundles/tracker/prizes/components/Prizes.tsx
@@ -69,12 +69,12 @@ const Prizes = (props: PrizesProps) => {
   React.useEffect(() => {
     setLoadingPrizes(true);
     dispatch(PrizeActions.fetchPrizes({ event: eventId })).finally(() => setLoadingPrizes(false));
-  }, [eventId]);
+  }, [dispatch, eventId]);
 
   React.useEffect(() => {
     if (event != null) return;
     dispatch(EventActions.fetchEvents({ id: eventId }));
-  }, [event, eventId]);
+  }, [dispatch, event, eventId]);
 
   if (event == null) {
     return (

--- a/bundles/uikit/Checkbox.tsx
+++ b/bundles/uikit/Checkbox.tsx
@@ -54,7 +54,7 @@ const Checkbox = (props: CheckboxProps) => {
 
   const handleClick = React.useCallback(() => {
     onChange(!checked);
-  }, [checked]);
+  }, [checked, onChange]);
 
   return (
     <Clickable

--- a/bundles/uikit/CurrencyInput.tsx
+++ b/bundles/uikit/CurrencyInput.tsx
@@ -42,7 +42,7 @@ const CurrencyInput = (props: CurrencyInputProps) => {
     (_event, value) => {
       onChange != null && onChange(value, name);
     },
-    [name, value, onChange],
+    [name, onChange],
   );
 
   return (


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/181159249

### Description of the Change

This is mostly correcting some lint warnings (now errors) around the `react-hooks/exhaustive-deps` rule. Made one slightly more significant code change, replacing a `React.useEffect` call with a `key` prop to trigger a form reset.

### Verification Process

Visited all the pages (the donate form with the incentive selection especially) that were affected and verified that all still worked as expected.