### PR TITLE
test all supported Node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Django 3.0, 3.1, and 4.0 are not officially supported but may work with some twe
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 
-- Node 12.x
+- Node 12, 14, or 16 (17 is known to not work currently, see
+  [this issue in webpack](https://github.com/webpack/webpack/issues/14532))
 - `yarn` (`npm i -g yarn`)
 - `pre-commit` (`pip install pre-commit`)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,11 +98,23 @@ jobs:
     continueOnError: true
     variables:
       YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+    strategy:
+      matrix:
+        Node12:
+          NODE_VERSION: 12
+        Node14:
+          NODE_VERSION: 14
+        Node16:
+          NODE_VERSION: 16
 
     steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '$(NODE_VERSION)'
+
       - task: Cache@2
         inputs:
-          key: yarn | $(Agent.OS) | development | yarn.lock
+          key: yarn | $(Agent.OS) | "$(NODE_VERSION)" | development | yarn.lock
           path: $(YARN_CACHE_FOLDER)
         displayName: 'Cache yarn'
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/181162555

### Description of the Change

Similarly to the Python/Django matrix in #408, it would be nice to know if other versions of node have build/test problems. I genuinely don't know how likely it is that somebody is using a different version of Node other than the latest but doesn't really hurt to be thorough. 

### Verification Process

Does the package still build and are the tests still green? Node 17 in particular doesn't work, though I think it's because of still being on Webpack 4. Maybe should turn on Dependabot for Node packages.