### PR TITLE
remove 3.6 from supported python versions [#181224192]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.6 to 3.10
+- Python 3.7 to 3.10
 - Django 2.2, 3.2
 
 Django 3.0, 3.1, and 4.0 are not officially supported but may work with some tweaking.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,14 +14,11 @@ jobs:
           PYTHON_VERSION: '3.10'
           DJANGO_VERSION: '3.2'
         Oldest:
-          PYTHON_VERSION: '3.6'
+          PYTHON_VERSION: '3.7'
           DJANGO_VERSION: '2.2'
         Django22:
           PYTHON_VERSION: '3.9'
           DJANGO_VERSION: '2.2'
-        Python36:
-          PYTHON_VERSION: '3.6'
-          DJANGO_VERSION: '3.2'
         Python37:
           PYTHON_VERSION: '3.7'
           DJANGO_VERSION: '3.2'

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'pytz>=2019.3',
         'webpack-manifest~=2.1',
     ],
-    python_requires='>=3.6, <3.11',
+    python_requires='>=3.7, <3.11',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -77,7 +77,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/181224192

### Description of the Change

Just removing 3.6 from the supported Python matrix since it's EOL.

### Verification Process

The tests still pass and the live GDQ server is running on 3.7.13.