### PR TITLE
remove Node 12 from supported versions [#182317605]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Django 3.0, 3.1, and 4.0 are not officially supported but may work with some twe
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 
-- Node 12, 14, or 16 (17 is known to not work currently, see
+- Node 14, or 16 (17+ is known to not work currently, see
   [this issue in webpack](https://github.com/webpack/webpack/issues/14532))
 - `yarn` (`npm i -g yarn`)
 - `pre-commit` (`pip install pre-commit`)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,8 +100,6 @@ jobs:
       YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
     strategy:
       matrix:
-        Node12:
-          NODE_VERSION: 12
         Node14:
           NODE_VERSION: 14
         Node16:


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/182317605

### Description of the Change

Just removing 12 from the supported Node matrix since it's EOL.

### Verification Process

The bundle still builds and runs and passes tests.