### PR TITLE
fix linebreaks on process/read donations [#176433147]

### DIFF
--- a/bundles/admin/donationProcessing/donations.mod.css
+++ b/bundles/admin/donationProcessing/donations.mod.css
@@ -1,6 +1,7 @@
 td.comment {
   max-width: 60vw;
   overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 td.status {


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/176433147

### Description of the Change

Just a formatting fix for multi-line comments. #399 fixed the database eating the linebreaks, but this is required to fix the actual display.

### Verification Process

Made a multi-line comment and it preserved the formatting in Read Donations.

![image](https://user-images.githubusercontent.com/419927/172074519-2509b9ac-cbdb-479e-9c45-9775aa57fa83.png)
