### PR TITLE
fix auto-approve [#182383750]

### DIFF
--- a/tracker/paypalutil.py
+++ b/tracker/paypalutil.py
@@ -60,7 +60,7 @@ def verify_ipn_recipient_email(ipn, email):
     recipient_email = ipn.business if ipn.business else ipn.receiver_email
     if recipient_email.lower() != email.lower():
         raise SpoofedIPNException(
-            "IPN receiver %s doesn't match %s".format(recipient_email, email)
+            f"IPN receiver `{recipient_email}` doesn't match `{email}`"
         )
 
 
@@ -211,12 +211,6 @@ def initialize_paypal_donation(ipnObj):
             ),
             event=donation.event,
         )
-
-    # Automatically approve anonymous, no-comment donations if an auto-approve
-    # threshold is set.
-    auto_min = donation.event.auto_approve_threshold
-    if auto_min:
-        donation.approve_if_anonymous_and_no_comment(auto_min)
 
     donation.save()
     # I think we only care if the _donation_ was freshly created


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/182383750

### Description of the Change

Some time ago we changed where the auto-approve threshold was being used, but forgot to remove it from one critical path: The IPN processing. Somebody discovered this the hard way. This removes the offending bit.

I also fixed an error formatting string to actually be useful instead of logging placeholders.

### Verification Process

Created a donation via the form, then sent myself IPNs via ngrok to make sure the expected results happened, including the spoof case, to make sure the logged error was useful.

Can't really add automated tests for this until we move the IPN processing to a signal handler instead.