### PR TITLE
fix ordering on event prev/next

### DIFF
--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 import io
 import json
 import random
@@ -36,6 +37,25 @@ class TestEvent(TestCase):
         self.event.save()
         self.run.refresh_from_db()
         self.assertEqual(self.run.starttime, self.event.datetime)
+
+    def test_prev_and_next(self):
+        events = []
+        for i in range(5):
+            events.append(
+                models.Event.objects.create(
+                    name=f'Event #{i}',
+                    short=f'event{i}',
+                    datetime=today_noon + datetime.timedelta(days=i + 5),
+                )
+            )
+        for i, e in enumerate(events):
+            e.refresh_from_db()
+            if i > 0:
+                with self.subTest(f'{e.name} prev'):
+                    self.assertEqual(e.prev(), events[i - 1])
+            if i < 4:
+                with self.subTest(f'{e.name} next'):
+                    self.assertEqual(e.next(), events[i + 1])
 
 
 class TestEventViews(TransactionTestCase):

--- a/tracker/models/event.py
+++ b/tracker/models/event.py
@@ -219,13 +219,17 @@ class Event(models.Model):
     def next(self):
         return (
             Event.objects.filter(datetime__gte=self.datetime)
+            .order_by('datetime')
             .exclude(pk=self.pk)
             .first()
         )
 
     def prev(self):
         return (
-            Event.objects.filter(datetime__lte=self.datetime).exclude(pk=self.pk).last()
+            Event.objects.filter(datetime__lte=self.datetime)
+            .order_by('datetime')
+            .exclude(pk=self.pk)
+            .last()
         )
 
     def get_absolute_url(self):


### PR DESCRIPTION
[#184085878]

# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184085878

### Description of the Change

After deploying the change to the server as a test, realized that the prev/next was broken still and going too far. This corrects it.

### Verification Process

Put it on the live server this time and stepped through all the events.