### PR TITLE
clean up some Bid Inlines that do not allow graceful creation [#180368747]

### DIFF
--- a/tracker/admin/bid.py
+++ b/tracker/admin/bid.py
@@ -43,7 +43,7 @@ class BidAdmin(CustomModelAdmin):
         BidParentFilter,
         BidListFilter,
     )
-    readonly_fields = ('parent', 'parent_', 'total')
+    readonly_fields = ('parent', 'effective_parent', 'total')
     fieldsets = [
         (
             None,
@@ -63,11 +63,22 @@ class BidAdmin(CustomModelAdmin):
                 ]
             },
         ),
-        ('Link Info', {'fields': ['event', 'speedrun', 'parent_', 'biddependency']}),
+        (
+            'Link Info',
+            {
+                'fields': [
+                    'event',
+                    'speedrun',
+                    'parent',
+                    'effective_parent',
+                    'biddependency',
+                ]
+            },
+        ),
     ]
     inlines = [BidOptionInline, BidDependentsInline]
 
-    def parent_(self, obj):
+    def effective_parent(self, obj):
         targetObject = None
         if obj.parent:
             targetObject = obj.parent
@@ -81,8 +92,10 @@ class BidAdmin(CustomModelAdmin):
                     str(viewutil.admin_url(targetObject)), targetObject
                 )
             )
+        elif obj.id is None:
+            return 'Not saved yet'
         else:
-            return '<None>'
+            return '-'
 
     def get_queryset(self, request):
         params = {}
@@ -91,6 +104,12 @@ class BidAdmin(CustomModelAdmin):
         if not request.user.has_perm('tracker.can_edit_locked_events'):
             params['locked'] = False
         return search_filters.run_model_query('allbids', params, user=request.user)
+
+    def get_inlines(self, request, obj):
+        if obj is None:
+            return []
+        else:
+            return [BidOptionInline, BidDependentsInline]
 
     def has_add_permission(self, request):
         return request.user.has_perm('tracker.top_level_bid')

--- a/tracker/admin/inlines.py
+++ b/tracker/admin/inlines.py
@@ -68,6 +68,9 @@ class BidDependentsInline(BidInline):
     verbose_name = 'Dependent Bid'
     fk_name = 'biddependency'
 
+    def has_add_permission(self, request, obj):
+        return False
+
 
 class EventBidInline(BidInline):
     def get_queryset(self, request):


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/180368747
https://www.pivotaltracker.com/story/show/180368392

### Description of the Change

Two-fold:

1. Trying to create child bids before saving does not work. 
2. Trying to create dependent bids from the inline does not work.

Fix (1) by only showing child bids after the parent has been saved, so that it has a database id.
"Fix" (2) by disabling creating dependent bids from the inline at all, making it view only.

No tests were added for this since it's just limiting what the admin lets you do.

### Verification Process

The inlines do not show at all when first creating the parent. Afterwards, was able to create a new child inline, and was able to view a separately created dependent bid.