### PR TITLE
upgrade pre-commit isort rev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,47 +1,47 @@
 default_stages: [commit]
 exclude: (migrations/|static/(jquery.*|main.css))
 repos:
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-    - id: black
-      name: black
-- repo: https://github.com/pycqa/isort
-  rev: 5.11.2
-  hooks:
-    - id: isort
-      name: isort (python)
-- repo: https://github.com/pycqa/flake8
-  rev: 3.7.9
-  hooks:
-    - id: flake8
-- repo: local
-  hooks:
-    - id: prettier
-      name: prettier
-      entry: ./node_modules/.bin/prettier
-      language: node
-      stages: [commit]
-      files: (.*)\.(js|jsx|ts|tsx|css)$
-      args: ["--write"]
-    - id: eslint
-      name: eslint
-      entry: yarn fix:lint
-      language: system
-      stages: [commit]
-      files: (.*)\.(jsx?|tsx?)$
-      pass_filenames: false
-    - id: typescript
-      name: typescript
-      entry: ./node_modules/.bin/tsc
-      language: script
-      stages: [push]
-      files: (.*)\.(jsx?|tsx?)$
-      pass_filenames: false
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.4.0
-  hooks:
-    - id: double-quote-string-fixer
-    - id: end-of-file-fixer
-    - id: mixed-line-ending
-      args: ["--fix=lf"]
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        name: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: ./node_modules/.bin/prettier
+        language: node
+        stages: [commit]
+        files: (.*)\.(js|jsx|ts|tsx|css)$
+        args: ['--write']
+      - id: eslint
+        name: eslint
+        entry: yarn fix:lint
+        language: system
+        stages: [commit]
+        files: (.*)\.(jsx?|tsx?)$
+        pass_filenames: false
+      - id: typescript
+        name: typescript
+        entry: ./node_modules/.bin/tsc
+        language: script
+        stages: [push]
+        files: (.*)\.(jsx?|tsx?)$
+        pass_filenames: false
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: double-quote-string-fixer
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ['--fix=lf']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,47 +1,47 @@
 default_stages: [commit]
 exclude: (migrations/|static/(jquery.*|main.css))
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-        name: black
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
-    hooks:
-      - id: isort
-        name: isort (python)
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.7.9
-    hooks:
-      - id: flake8
-  - repo: local
-    hooks:
-      - id: prettier
-        name: prettier
-        entry: ./node_modules/.bin/prettier
-        language: node
-        stages: [commit]
-        files: (.*)\.(js|jsx|ts|tsx|css)$
-        args: ['--write']
-      - id: eslint
-        name: eslint
-        entry: yarn fix:lint
-        language: system
-        stages: [commit]
-        files: (.*)\.(jsx?|tsx?)$
-        pass_filenames: false
-      - id: typescript
-        name: typescript
-        entry: ./node_modules/.bin/tsc
-        language: script
-        stages: [push]
-        files: (.*)\.(jsx?|tsx?)$
-        pass_filenames: false
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
-    hooks:
-      - id: double-quote-string-fixer
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
-        args: ['--fix=lf']
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+    - id: black
+      name: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.11.5
+  hooks:
+    - id: isort
+      name: isort (python)
+- repo: https://github.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
+    - id: flake8
+- repo: local
+  hooks:
+    - id: prettier
+      name: prettier
+      entry: ./node_modules/.bin/prettier
+      language: node
+      stages: [commit]
+      files: (.*)\.(js|jsx|ts|tsx|css)$
+      args: ["--write"]
+    - id: eslint
+      name: eslint
+      entry: yarn fix:lint
+      language: system
+      stages: [commit]
+      files: (.*)\.(jsx?|tsx?)$
+      pass_filenames: false
+    - id: typescript
+      name: typescript
+      entry: ./node_modules/.bin/tsc
+      language: script
+      stages: [push]
+      files: (.*)\.(jsx?|tsx?)$
+      pass_filenames: false
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+    - id: double-quote-string-fixer
+    - id: end-of-file-fixer
+    - id: mixed-line-ending
+      args: ["--fix=lf"]


### PR DESCRIPTION
### Description of the Change

isort had a version change that affected some dependencies and caused older pre-commit revisions (which we were using, 5.11.2) to error out when you try to install them the first time. Upgrading to the latest version fixes that issue.

https://stackoverflow.com/questions/75281731/pre-commit-fails-to-install-isort-5-10-1-with-error-runtimeerror-the-poetry-co

### Verification Process

Checked that pre-commit was able to install it's environments on a new machine.