### PR TITLE
Lock Node to 16 for Python tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,10 @@ jobs:
           versionSpec: '$(PYTHON_VERSION)'
           architecture: 'x64'
 
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '16'
+
       - task: Cache@2
         inputs:
           key: pip | $(Agent.OS) | "$(DJANGO_VERSION)" | tests/requirements.txt | setup.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,10 @@ jobs:
   - job: build_package
     displayName: Tracker Package
     steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '16'
+
       - task: Cache@2
         inputs:
           key: pip | $(Agent.OS) | setup.py


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

N/A

### Description of the Change

Tests fail on Node 18, lock Python tests to Node 16.

### Verification Process

Is it green on Azure?