### PR TITLE
lock down pytz and tzdata for now [#184852604]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,5 @@ updates:
     versions:
     - 4.1.1
   - dependency-name: importlib-metadata
+  - dependency-name: pytz
+  - depeddency-name: tzdata

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,10 +10,12 @@ django-post-office==3.6.0
 django-timezone-field==5.0
 djangorestframework==3.13.1
 # can be removed when either 3.7 is not supported or once we upgrade Celery
-importlib_metadata==4.13.0
+importlib_metadata==4.13.0 ; python_version<"3.8"
 pre-commit==2.21.0
 python-dateutil==2.8.2
-pytz==2022.7
+# lock these down until backports.zoneinfo is in use
+pytz==2022.2.1
+tzdata==2022.2
 webpack-manifest==2.1.1
 # only for testing
 responses~=0.22.0


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~


### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184852604

### Description of the Change

Ran into some strange startup errors with the versions of pytz and tzdata that were being pulled in. This is a bandaid until we can migrate to zoneinfo.

### Verification Process

Are the tests still green?