### PR TITLE
pre-commit check properly fails a build [#184859350]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,9 +124,11 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip setuptools wheel pre-commit
-          yarn --frozen-lockfile
-          pre-commit run --all
-          pre-commit run --hook-stage push --all
+          ss=0
+          yarn --frozen-lockfile || ss=1
+          pre-commit run --all || ss=1
+          pre-commit run --hook-stage push --all || ss=1
+          exit $ss
         displayName: 'Run pre-commit hooks'
 
   - job: tracker_frontend_tests

--- a/tests/apiv2/test_donations.py
+++ b/tests/apiv2/test_donations.py
@@ -1,18 +1,17 @@
-from datetime import datetime, timedelta
 import random
-from django.contrib.admin.models import CHANGE
+from datetime import datetime, timedelta
 
 import pytz
-
-from rest_framework.test import APIClient
+from django.contrib.admin.models import CHANGE
 from django.contrib.auth.models import Permission, User
+from rest_framework.test import APIClient
 
-from tracker.models import Donation, Event
 from tracker.api.serializers import DonationSerializer
 from tracker.api.views.donations import DONATION_CHANGE_LOG_MESSAGES
+from tracker.models import Donation, Event
 
-from .util import APITestCase
 from .. import randgen
+from .util import APITestCase
 
 
 class TestDonations(APITestCase):
@@ -96,10 +95,16 @@ class TestDonations(APITestCase):
     def test_unprocessed_returns_only_after_timestamp(self):
         date = datetime.utcnow()
         old_donations = self.generate_donations(
-            self.event, count=2, state='pending', time=date.replace(year=1),
+            self.event,
+            count=2,
+            state='pending',
+            time=date.replace(year=1),
         )
         new_donations = self.generate_donations(
-            self.event, count=2, state='pending', time=date.replace(year=9999),
+            self.event,
+            count=2,
+            state='pending',
+            time=date.replace(year=9999),
         )
 
         response = self.client.get(
@@ -124,7 +129,8 @@ class TestDonations(APITestCase):
             self.generate_donations(self.event, count=1, state=state)
 
         response = self.client.get(
-            '/tracker/api/v2/donations/unprocessed/', {'event_id': self.event.pk},
+            '/tracker/api/v2/donations/unprocessed/',
+            {'event_id': self.event.pk},
         )
 
         self.assertEqual(len(response.data), 0)
@@ -158,10 +164,16 @@ class TestDonations(APITestCase):
     def test_flagged_returns_only_after_timestamp(self):
         date = datetime.utcnow()
         old_donations = self.generate_donations(
-            self.event, count=2, state='flagged', time=date.replace(year=1),
+            self.event,
+            count=2,
+            state='flagged',
+            time=date.replace(year=1),
         )
         new_donations = self.generate_donations(
-            self.event, count=2, state='flagged', time=date.replace(year=9999),
+            self.event,
+            count=2,
+            state='flagged',
+            time=date.replace(year=9999),
         )
 
         response = self.client.get(
@@ -186,7 +198,8 @@ class TestDonations(APITestCase):
             self.generate_donations(self.event, count=1, state=state)
 
         response = self.client.get(
-            '/tracker/api/v2/donations/flagged/', {'event_id': self.event.pk},
+            '/tracker/api/v2/donations/flagged/',
+            {'event_id': self.event.pk},
         )
 
         self.assertEqual(len(response.data), 0)
@@ -266,7 +279,10 @@ class TestDonations(APITestCase):
         self.client.post(f'/tracker/api/v2/donations/{donation.pk}/approve_comment/')
 
         self.assertLogEntry(
-            'donation', donation.pk, CHANGE, DONATION_CHANGE_LOG_MESSAGES['approved'],
+            'donation',
+            donation.pk,
+            CHANGE,
+            DONATION_CHANGE_LOG_MESSAGES['approved'],
         )
 
     ###
@@ -305,7 +321,10 @@ class TestDonations(APITestCase):
         self.client.post(f'/tracker/api/v2/donations/{donation.pk}/deny_comment/')
 
         self.assertLogEntry(
-            'donation', donation.pk, CHANGE, DONATION_CHANGE_LOG_MESSAGES['denied'],
+            'donation',
+            donation.pk,
+            CHANGE,
+            DONATION_CHANGE_LOG_MESSAGES['denied'],
         )
 
     ###
@@ -342,7 +361,10 @@ class TestDonations(APITestCase):
         self.client.post(f'/tracker/api/v2/donations/{donation.pk}/flag/')
 
         self.assertLogEntry(
-            'donation', donation.pk, CHANGE, DONATION_CHANGE_LOG_MESSAGES['flagged'],
+            'donation',
+            donation.pk,
+            CHANGE,
+            DONATION_CHANGE_LOG_MESSAGES['flagged'],
         )
 
     ###
@@ -439,7 +461,10 @@ class TestDonations(APITestCase):
         self.client.post(f'/tracker/api/v2/donations/{donation.pk}/pin/')
 
         self.assertLogEntry(
-            'donation', donation.pk, CHANGE, DONATION_CHANGE_LOG_MESSAGES['pinned'],
+            'donation',
+            donation.pk,
+            CHANGE,
+            DONATION_CHANGE_LOG_MESSAGES['pinned'],
         )
 
     ###
@@ -476,5 +501,8 @@ class TestDonations(APITestCase):
         self.client.post(f'/tracker/api/v2/donations/{donation.pk}/unpin/')
 
         self.assertLogEntry(
-            'donation', donation.pk, CHANGE, DONATION_CHANGE_LOG_MESSAGES['unpinned'],
+            'donation',
+            donation.pk,
+            CHANGE,
+            DONATION_CHANGE_LOG_MESSAGES['unpinned'],
         )

--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -1,7 +1,7 @@
 import typing as t
 
-from rest_framework.request import Request
 from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
 
 
 def tracker_permission(permission_name: str):

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -7,7 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from tracker import logutil
-from tracker.analytics import analytics, AnalyticsEventTypes
+from tracker.analytics import AnalyticsEventTypes, analytics
 from tracker.api.permissions import tracker_permission
 from tracker.api.serializers import DonationSerializer
 from tracker.models import Donation
@@ -45,10 +45,17 @@ def _get_donation_analytics_fields(donation: Donation):
 
 
 def _track_donation_processing_event(
-    type: AnalyticsEventTypes, label: str, donation: Donation, request,
+    type: AnalyticsEventTypes,
+    label: str,
+    donation: Donation,
+    request,
 ):
     analytics.track(
-        type, {**_get_donation_analytics_fields(donation), 'user_id': request.user.pk,},
+        type,
+        {
+            **_get_donation_analytics_fields(donation),
+            'user_id': request.user.pk,
+        },
     )
     logutil.change(request, donation, label)
 
@@ -66,7 +73,10 @@ class DonationChangeManager:
 
     def track(self, type: AnalyticsEventTypes, label: str):
         _track_donation_processing_event(
-            type=type, label=label, request=self.request, donation=self.donation,
+            type=type,
+            label=label,
+            request=self.request,
+            donation=self.donation,
         )
 
     def response(self):
@@ -213,7 +223,9 @@ class DonationViewSet(viewsets.GenericViewSet):
         return manager.response()
 
     @action(
-        detail=True, methods=['post'], permission_classes=[CanChangeDonation],
+        detail=True,
+        methods=['post'],
+        permission_classes=[CanChangeDonation],
     )
     def pin(self, request, pk):
         """
@@ -230,7 +242,9 @@ class DonationViewSet(viewsets.GenericViewSet):
         return manager.response()
 
     @action(
-        detail=True, methods=['post'], permission_classes=[CanChangeDonation],
+        detail=True,
+        methods=['post'],
+        permission_classes=[CanChangeDonation],
     )
     def unpin(self, request, pk):
         """

--- a/tracker/models/mod_filter.py
+++ b/tracker/models/mod_filter.py
@@ -4,7 +4,8 @@ from django.db import models
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
-from tracker.analytics import analytics, AnalyticsEventTypes
+from tracker.analytics import AnalyticsEventTypes, analytics
+
 from .donation import Donation
 
 __all__ = [


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184859350

### Description of the Change

Noticed that some of the pre-commit checks are failing but not causing build failures. Turns out that only the last command in a script is taken into account. This changes that by tagging any single failure.

### Verification Process

The initial build should fail since master currently has errors on it. If so, I'll re-run the hook to fix the errors and move on.