### PR TITLE
New donation reading pages

### DIFF
--- a/bundles/.design_system/base_tokens.json
+++ b/bundles/.design_system/base_tokens.json
@@ -133,6 +133,6 @@
     "minimal": "1px",
     "normal": "4px",
     "large": "16px",
-    "full": "100%"
+    "full": "10000px"
   }
 }

--- a/bundles/.design_system/generated/Spacing.css
+++ b/bundles/.design_system/generated/Spacing.css
@@ -5,7 +5,7 @@
   --radius-minimal: 1px;
   --radius-normal: 4px;
   --radius-large: 16px;
-  --radius-full: 100%;
+  --radius-full: 10000px;
   --space-xxxs: 0.5px;
   --space-xxs: 1px;
   --space-xs: 2px;

--- a/bundles/processing/ActionLog.tsx
+++ b/bundles/processing/ActionLog.tsx
@@ -8,7 +8,8 @@ import { Donation } from '@public/apiv2/APITypes';
 import * as CurrencyUtils from '@public/util/currency';
 import Undo from '@uikit/icons/Undo';
 
-import useProcessingStore, { HistoryAction, useDonation } from './ProcessingStore';
+import { loadDonations, useDonation } from './DonationsStore';
+import useProcessingStore, { HistoryAction } from './ProcessingStore';
 import { AdminRoutes, useAdminRoute } from './Routes';
 
 import styles from './ActionLog.mod.css';
@@ -39,7 +40,7 @@ function ActionEntry({ action }: { action: HistoryAction }) {
     },
     {
       onSuccess: (donation: Donation) => {
-        store.loadDonations([donation]);
+        loadDonations([donation]);
         store.undoAction(action.id);
       },
     },

--- a/bundles/processing/AuthStore.tsx
+++ b/bundles/processing/AuthStore.tsx
@@ -1,0 +1,25 @@
+import create from 'zustand';
+
+import { Me } from '@public/apiv2/APITypes';
+
+interface AuthStoreState {
+  me: Me | null;
+}
+
+const useAuthStore = create<AuthStoreState>()(() => ({
+  me: null,
+}));
+
+export default useAuthStore;
+
+export function useMe() {
+  return useAuthStore(state => state.me);
+}
+
+export function loadMe(me: Me) {
+  useAuthStore.setState({ me });
+}
+
+export function logout() {
+  useAuthStore.setState({ me: null });
+}

--- a/bundles/processing/CreateEditDonationGroupModal.mod.css
+++ b/bundles/processing/CreateEditDonationGroupModal.mod.css
@@ -1,0 +1,3 @@
+.modal {
+  min-width: 440px;
+}

--- a/bundles/processing/CreateEditDonationGroupModal.tsx
+++ b/bundles/processing/CreateEditDonationGroupModal.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import {
+  Button,
+  Card,
+  FormControl,
+  Header,
+  SelectInput,
+  Spacer,
+  Stack,
+  TabColor,
+  Tabs,
+  TextInput,
+} from '@spyrothon/sparx';
+
+import useDonationGroupsStore, { DonationGroup } from './DonationGroupsStore';
+
+import styles from './CreateEditDonationGroupModal.mod.css';
+
+interface GroupColorItem {
+  name: string;
+  value: TabColor;
+}
+
+const GROUP_COLOR_ITEMS: GroupColorItem[] = [
+  { name: 'Default', value: 'default' },
+  { name: 'Teal', value: 'info' },
+  { name: 'Blue', value: 'accent' },
+  { name: 'Green', value: 'success' },
+  { name: 'Orange', value: 'warning' },
+  { name: 'Red', value: 'danger' },
+];
+
+interface CreateEditDonationGroupModalProps {
+  group?: DonationGroup;
+  onClose: () => unknown;
+}
+
+export default function CreateEditDonationGroupModal(props: CreateEditDonationGroupModalProps) {
+  const { group, onClose } = props;
+  const [name, setName] = React.useState(group?.name || 'New Group');
+  const [color, setColor] = React.useState<GroupColorItem>(() => {
+    return GROUP_COLOR_ITEMS.find(g => g.name === group?.name) || GROUP_COLOR_ITEMS[0];
+  });
+  const { createDonationGroup, updateDonationGroup } = useDonationGroupsStore();
+
+  function handleCreate() {
+    const action = group != null ? updateDonationGroup : createDonationGroup;
+    action({ name, color: color.value });
+    onClose();
+  }
+
+  return (
+    <Card floating className={styles.modal}>
+      <Stack spacing="space-lg">
+        <Header tag="h1">Create Donation Group</Header>
+        <FormControl label="Group Name">
+          <TextInput
+            value={name}
+            // eslint-disable-next-line react/jsx-no-bind
+            onChange={event => setName(event.target.value)}
+          />
+        </FormControl>
+        <FormControl label="Group Color">
+          <SelectInput
+            items={GROUP_COLOR_ITEMS}
+            // eslint-disable-next-line react/jsx-no-bind
+            onSelect={item => item != null && setColor(item)}
+            selectedItem={color}
+          />
+        </FormControl>
+        <Button onClick={handleCreate}>Create Group</Button>
+        <Spacer />
+        <Tabs.Tab color={color.value} label={name || '\b'} badge={15} selected></Tabs.Tab>
+      </Stack>
+    </Card>
+  );
+}

--- a/bundles/processing/DonationGroupsStore.tsx
+++ b/bundles/processing/DonationGroupsStore.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+import { TabColor } from '@spyrothon/sparx';
+
+export interface DonationGroup {
+  name: string;
+  color: TabColor;
+  donationIds: number[];
+}
+
+type DonationGroupProps = Omit<DonationGroup, 'donationIds'>;
+
+interface DonationGroupsStoreState {
+  /**
+   * Ordered list of donation groups maintained locally.
+   */
+  groups: DonationGroup[];
+  /**
+   * Create a new group for donations to be filtered into.
+   */
+  createDonationGroup(props: DonationGroupProps): void;
+  /**
+   * Change properties of an existing donation group.
+   */
+  updateDonationGroup(props: DonationGroupProps): void;
+  /**
+   * Adds the donation to the given group.
+   */
+  addDonationToGroup(groupName: string, donationId: number): void;
+  /**
+   * Removes the donation to the given group.
+   */
+  removeDonationFromGroup(groupName: string, donationId: number): void;
+  /**
+   * Removes the donation from all groups, such as when the donation has been
+   * read or ignored and should no longer be shown to readers.
+   */
+  removeDonationFromAllGroups(donationId: number): void;
+}
+
+const useDonationGroupsStore = create<DonationGroupsStoreState>()(
+  persist(
+    (set, get) => ({
+      groups: [] as DonationGroup[],
+      createDonationGroup(props: DonationGroupProps) {
+        const newGroup: DonationGroup = { ...props, donationIds: [] };
+        set(state => ({ groups: [...state.groups, newGroup] }));
+      },
+      updateDonationGroup(props: DonationGroupProps) {
+        const { groups } = get();
+        const groupIndex = groups.findIndex(group => group.name === props.name);
+        const group = { ...groups[groupIndex], ...props };
+        const newGroups = [...groups];
+        newGroups.splice(groupIndex, 1, group);
+        set({ groups: newGroups });
+      },
+      addDonationToGroup(groupName: string, donationId: number) {
+        const { groups } = get();
+        const groupIndex = groups.findIndex(group => group.name === groupName);
+        const oldGroup = groups[groupIndex];
+        const group = { ...oldGroup, donationIds: [...oldGroup.donationIds, donationId] };
+        const newGroups = [...groups];
+        newGroups.splice(groupIndex, 1, group);
+        set({ groups: newGroups });
+      },
+      removeDonationFromGroup(groupName: string, donationId: number) {
+        const { groups } = get();
+        const groupIndex = groups.findIndex(group => group.name === groupName);
+        const oldGroup = groups[groupIndex];
+
+        const group = { ...oldGroup, donationIds: oldGroup.donationIds.filter(id => id !== donationId) };
+        const newGroups = [...groups];
+        newGroups.splice(groupIndex, 1, group);
+        set({ groups: newGroups });
+      },
+      removeDonationFromAllGroups(donationId: number) {
+        const filteredGroups = get().groups.map(
+          (group): DonationGroup => ({
+            ...group,
+            donationIds: group.donationIds.filter(id => id !== donationId),
+          }),
+        );
+        set({ groups: filteredGroups });
+      },
+    }),
+    {
+      name: 'processing-donation-groups',
+      partialize: state => ({
+        groups: state.groups,
+      }),
+    },
+  ),
+);
+
+export default useDonationGroupsStore;
+
+export function useDonationGroup(name: string) {
+  return useDonationGroupsStore(state => state.groups.find(group => group.name === name));
+}
+
+export function useGroupsForDonation(donationId: number) {
+  const groups = useDonationGroupsStore(state => state.groups);
+  return React.useMemo(() => groups.filter(group => group.donationIds.includes(donationId)), [groups, donationId]);
+}

--- a/bundles/processing/DonationRow.mod.css
+++ b/bundles/processing/DonationRow.mod.css
@@ -29,6 +29,10 @@
   white-space: pre-wrap;
 }
 
+.noCommentHint {
+  text-align: center;
+}
+
 .highlighted {
   background-color: #ff0;
   color: #000;

--- a/bundles/processing/DonationsStore.tsx
+++ b/bundles/processing/DonationsStore.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import create from 'zustand';
+
+import { Donation } from '@public/apiv2/APITypes';
+
+type DonationId = Donation['id'];
+
+export type DonationState = 'unprocessed' | 'flagged' | 'ready' | 'done';
+
+/**
+ * Return the state of the donation as inferred purely by its readstate, as in,
+ * whether the donation should be shown to hosts or head donations, rather than
+ * considered 'done' or 'unprocessed'. If the donation is not in one of those
+ * middle states, return `defaultState` instead.
+ */
+function getDonationStateFromReadState(donation: Donation, defaultState: DonationState): DonationState {
+  switch (donation.readstate) {
+    case 'READY':
+      return 'ready';
+    case 'FLAGGED':
+      return 'flagged';
+    default:
+      return defaultState;
+  }
+}
+
+function getDonationState(donation: Donation): DonationState {
+  switch (donation.commentstate) {
+    case 'APPROVED':
+      return getDonationStateFromReadState(donation, 'done');
+    case 'ABSENT':
+    case 'PENDING':
+      return getDonationStateFromReadState(donation, 'unprocessed');
+    // FLAGGED does not get used on commentstates (never assigned in code)
+    case 'FLAGGED':
+    case 'DENIED':
+    default:
+      return 'done';
+  }
+}
+
+interface DonationsStoreState {
+  /**
+   * All donations the client is currently aware of, including donations that
+   * have already been processed.
+   */
+  donations: Record<number, Donation>;
+  /**
+   * The set of donations that are completely unprocessed and should be handled
+   * by the first tier of donation processors.
+   */
+  unprocessed: Set<DonationId>;
+  /**
+   * Donations that were flagged by the first tier of processors and are now
+   * waiting to be handled by Head Donations.
+   */
+  flagged: Set<DonationId>;
+  /**
+   * Donations that have been approved and sent to readers.
+   */
+  ready: Set<DonationId>;
+  /**
+   * Donations that have been processed to completion, whether by being denied,
+   * approved only, read, or ignored.
+   */
+  done: Set<DonationId>;
+}
+
+const useDonationsStore = create<DonationsStoreState>()(() => ({
+  donations: {},
+  unprocessed: new Set(),
+  flagged: new Set(),
+  ready: new Set(),
+  done: new Set(),
+}));
+
+export default useDonationsStore;
+
+/**
+ * Add the given set of donations to the list of known donations, inserting
+ * them as appropriate into the store's state. All donations loaded this way
+ * will be considered "unprocessed".
+ */
+export function loadDonations(donations: Donation[]) {
+  useDonationsStore.setState(state => {
+    const newDonations = { ...state.donations };
+    const unprocessed = new Set(state.unprocessed);
+    const flagged = new Set(state.flagged);
+    const ready = new Set(state.ready);
+    const done = new Set(state.done);
+    for (const donation of donations) {
+      newDonations[donation.id] = donation;
+      switch (getDonationState(donation)) {
+        case 'unprocessed':
+          unprocessed.add(donation.id);
+          flagged.delete(donation.id);
+          ready.delete(donation.id);
+          done.delete(donation.id);
+          break;
+        case 'flagged':
+          unprocessed.delete(donation.id);
+          flagged.add(donation.id);
+          ready.delete(donation.id);
+          done.delete(donation.id);
+          break;
+        case 'ready':
+          unprocessed.delete(donation.id);
+          flagged.delete(donation.id);
+          ready.add(donation.id);
+          done.delete(donation.id);
+          break;
+        case 'done':
+          unprocessed.delete(donation.id);
+          flagged.delete(donation.id);
+          ready.delete(donation.id);
+          done.add(donation.id);
+          break;
+      }
+    }
+
+    return { donations: newDonations, unprocessed, flagged, ready, done };
+  });
+}
+
+export function useDonation(donationId: number) {
+  const donations = useDonationsStore(state => state.donations);
+  return donations[donationId];
+}
+
+export function useDonations(donationIds: DonationId[] | Set<DonationId>) {
+  const donations = useDonationsStore(state => state.donations);
+  return React.useMemo(() => Array.from(donationIds).map(id => donations[id]), [donations, donationIds]);
+}
+
+export function useFilteredDonations(group: DonationState, predicate: (donation: Donation) => boolean) {
+  const [donations, groupIds] = useDonationsStore(state => [state.donations, state[group]]);
+  return React.useMemo(
+    () =>
+      Array.from(groupIds)
+        .map(id => donations[id])
+        .filter(predicate),
+    [donations, groupIds, predicate],
+  );
+}
+
+function getAndSortDonations(donations: Record<string, Donation>, ids: Set<DonationId>) {
+  return Array.from(ids)
+    .map(id => donations[id])
+    .sort((a, b) => a.timereceived.localeCompare(b.timereceived));
+}
+
+export function useDonationsInState(donationState: DonationState) {
+  const [donations, ids] = useDonationsStore(state => [state.donations, state[donationState]]);
+  return React.useMemo(() => getAndSortDonations(donations, ids), [donations, ids]);
+}

--- a/bundles/processing/MutationButton.tsx
+++ b/bundles/processing/MutationButton.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { UseMutationResult } from 'react-query';
+import { Button, ButtonVariant, useTooltip } from '@spyrothon/sparx';
+
+interface MutationButtonProps<T> {
+  mutation: UseMutationResult<T, unknown, number, unknown>;
+  donationId: number;
+  label: string;
+  icon: React.ComponentType;
+  variant?: ButtonVariant;
+  disabled?: boolean;
+}
+
+export default function MutationButton<T>(props: MutationButtonProps<T>) {
+  const { mutation, donationId, variant = 'default', label, icon: Icon, disabled = false } = props;
+
+  const [tooltipProps] = useTooltip<HTMLButtonElement>(label);
+
+  return (
+    <Button
+      {...tooltipProps}
+      // eslint-disable-next-line react/jsx-no-bind
+      onClick={() => mutation.mutate(donationId)}
+      disabled={disabled || mutation.isLoading}
+      variant={variant}>
+      <Icon />
+    </Button>
+  );
+}

--- a/bundles/processing/PrimaryNavPopout.tsx
+++ b/bundles/processing/PrimaryNavPopout.tsx
@@ -21,6 +21,8 @@ const NavRoutes = {
   MILESTONES: (eventId: string) => `/tracker/milestones/${eventId}`,
   PRIZES: (eventId: string) => `/tracker/prizes/${eventId}`,
   RUNS: (eventId: string) => `/tracker/runs/${eventId}`,
+  LOGOUT: `/tracker/logout/`,
+  SELF_SERVICE: `/user/index/`,
 
   ADMIN_HOME: `/`,
   INTERSTITIALS: (eventId: string) => `interstitials/${eventId}`,
@@ -72,6 +74,12 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
           <Anchor href={NavRoutes.DONORS(eventId)}>Donors</Anchor>
           <Anchor href={NavRoutes.DONATIONS(eventId)}>Donations</Anchor>
           <Anchor href={NavRoutes.EVENTS}>All Events</Anchor>
+          <Spacer />
+          <Header tag="h2" variant="header-md/normal">
+            User
+          </Header>
+          <Anchor href={NavRoutes.SELF_SERVICE}>Self Service</Anchor>
+          <Anchor href={NavRoutes.LOGOUT}>Logout</Anchor>
         </Stack>
       </Stack>
     </Card>

--- a/bundles/processing/PrimaryNavPopout.tsx
+++ b/bundles/processing/PrimaryNavPopout.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
-import { Anchor, Button, Card, Header, Spacer, Stack, usePopout } from '@spyrothon/sparx';
+import { useQuery } from 'react-query';
+import { Anchor, Button, Card, Header, Spacer, Stack, Text, usePopout } from '@spyrothon/sparx';
 
 import { useConstants } from '@common/Constants';
+import APIClient from '@public/apiv2/APIClient';
 import Bars from '@uikit/icons/Bars';
+
+import { loadMe, useMe } from './AuthStore';
+import { ThemeButton } from './Theming';
 
 import styles from './PrimaryNavPopout.mod.css';
 
@@ -21,8 +26,8 @@ const NavRoutes = {
   MILESTONES: (eventId: string) => `/tracker/milestones/${eventId}`,
   PRIZES: (eventId: string) => `/tracker/prizes/${eventId}`,
   RUNS: (eventId: string) => `/tracker/runs/${eventId}`,
-  LOGOUT: `/tracker/logout/`,
-  SELF_SERVICE: `/user/index/`,
+  LOGOUT: `/tracker/user/logout/`,
+  SELF_SERVICE: `/tracker/user/index/`,
 
   ADMIN_HOME: `/`,
   INTERSTITIALS: (eventId: string) => `interstitials/${eventId}`,
@@ -41,6 +46,21 @@ function path(route: string) {
   return adminPath + route;
 }
 
+function CurrentUser() {
+  useQuery('auth.me', () => APIClient.getMe(), { onSuccess: me => loadMe(me), staleTime: 5 * 60 * 1000 });
+
+  const me = useMe();
+
+  return (
+    <div>
+      <Text variant="text-xs/normal">Logged in as</Text>
+      <Text>
+        <strong>{me?.username}</strong>
+      </Text>
+    </div>
+  );
+}
+
 interface PrimaryNavPopoutProps {
   eventId: string;
 }
@@ -53,6 +73,13 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
   return (
     <Card floating className={styles.container}>
       <Stack direction="horizontal" spacing="space-xl">
+        <Stack spacing="space-lg">
+          <CurrentUser />
+          <Anchor href={NavRoutes.SELF_SERVICE}>Self Service</Anchor>
+          <Anchor href={NavRoutes.LOGOUT}>Logout</Anchor>
+          <Spacer />
+          <ThemeButton />
+        </Stack>
         <Stack spacing="space-lg">
           <Header tag="h2" variant="header-md/normal">
             Admin
@@ -74,12 +101,6 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
           <Anchor href={NavRoutes.DONORS(eventId)}>Donors</Anchor>
           <Anchor href={NavRoutes.DONATIONS(eventId)}>Donations</Anchor>
           <Anchor href={NavRoutes.EVENTS}>All Events</Anchor>
-          <Spacer />
-          <Header tag="h2" variant="header-md/normal">
-            User
-          </Header>
-          <Anchor href={NavRoutes.SELF_SERVICE}>Self Service</Anchor>
-          <Anchor href={NavRoutes.LOGOUT}>Logout</Anchor>
         </Stack>
       </Stack>
     </Card>
@@ -88,7 +109,7 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
 
 export function PrimaryNavPopoutButton(props: PrimaryNavPopoutProps) {
   const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const [openPopout] = usePopout(() => <PrimaryNavPopout {...props} />, buttonRef, { attach: 'left' });
+  const [openPopout] = usePopout(() => <PrimaryNavPopout {...props} />, buttonRef, { attach: 'right' });
 
   return (
     <Button variant="default/outline" ref={buttonRef} onClick={openPopout}>

--- a/bundles/processing/Processing.mod.css
+++ b/bundles/processing/Processing.mod.css
@@ -40,16 +40,25 @@
 .donationEnterActive {
   opacity: 1;
   transform: translateY(0);
-  transition: 240ms ease-out;
+  transition: 120ms ease-out;
   pointer-events: none;
 }
 .donationExit {
   opacity: 1;
-  transition: 240ms ease-out;
+  transition: 50ms ease-out;
   pointer-events: none;
 }
 .donationExitActive {
-  transform: translateX(-300px);
+  transform: translateY(-30px);
   opacity: 0;
   pointer-events: none;
+}
+
+.groupsHeader {
+  display: flex;
+  align-items: center;
+}
+
+.groupsHeaderTitle {
+  margin-right: auto;
 }

--- a/bundles/processing/ProcessingSidebar.tsx
+++ b/bundles/processing/ProcessingSidebar.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Header, Stack, Text } from '@spyrothon/sparx';
+
+import { Event } from '@public/apiv2/APITypes';
+
+import { PrimaryNavPopoutButton } from './PrimaryNavPopout';
+import { ThemeButton } from './Theming';
+
+interface ProcessingHeaderProps {
+  event: Event | undefined;
+  subtitle: string;
+}
+
+function ProcessingHeader(props: ProcessingHeaderProps) {
+  const { event, subtitle } = props;
+
+  if (event == null) {
+    return (
+      <Header tag="h1" variant="header-md/normal">
+        Loading...
+      </Header>
+    );
+  }
+
+  return (
+    <Stack direction="horizontal" justify="space-between" align="center" spacing="space-lg" wrap={false}>
+      <div>
+        <Header tag="h1" variant="header-md/normal">
+          {event.name}
+        </Header>
+        <Text>{subtitle}</Text>
+      </div>
+      <PrimaryNavPopoutButton eventId={`${event.id}`} />
+    </Stack>
+  );
+}
+
+interface ProcessingSidebarProps {
+  event: Event | undefined;
+  subtitle: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export default function ProcessingSidebar(props: ProcessingSidebarProps) {
+  const { event, subtitle, className, children } = props;
+
+  return (
+    <Stack className={className} spacing="space-xl">
+      <ProcessingHeader event={event} subtitle={subtitle} />
+      <ThemeButton />
+      {children}
+    </Stack>
+  );
+}

--- a/bundles/processing/ProcessingSidebar.tsx
+++ b/bundles/processing/ProcessingSidebar.tsx
@@ -4,7 +4,6 @@ import { Header, Stack, Text } from '@spyrothon/sparx';
 import { Event } from '@public/apiv2/APITypes';
 
 import { PrimaryNavPopoutButton } from './PrimaryNavPopout';
-import { ThemeButton } from './Theming';
 
 interface ProcessingHeaderProps {
   event: Event | undefined;
@@ -48,7 +47,6 @@ export default function ProcessingSidebar(props: ProcessingSidebarProps) {
   return (
     <Stack className={className} spacing="space-xl">
       <ProcessingHeader event={event} subtitle={subtitle} />
-      <ThemeButton />
       {children}
     </Stack>
   );

--- a/bundles/processing/ProcessingV2.tsx
+++ b/bundles/processing/ProcessingV2.tsx
@@ -5,8 +5,10 @@ import { Accent, AppContainer, Theme } from '@spyrothon/sparx';
 import { usePermission } from '@public/api/helpers/auth';
 import { ProcessingSocket } from '@public/apiv2/sockets/ProcessingSocket';
 
+import { loadDonations } from './DonationsStore';
 import ProcessDonations from './ProcessDonations';
 import useProcessingStore from './ProcessingStore';
+import ReadDonations from './ReadDonations';
 import { useThemeStore } from './Theming';
 
 import '../.design_system/generated/DesignSystem.css';
@@ -14,14 +16,13 @@ import '@spyrothon/sparx/style.css';
 
 export default function ProcessingV2() {
   const canChangeDonations = usePermission('tracker.change_donation');
-  const { loadDonations, processDonation } = useProcessingStore();
+  const { processDonation } = useProcessingStore();
   const { theme, accent } = useThemeStore();
 
   React.useEffect(() => {
     const unsubActions = ProcessingSocket.on('processing_action', event => {
-      if (event.action === 'unprocessed') {
-        loadDonations([event.donation]);
-      } else {
+      loadDonations([event.donation]);
+      if (event.action !== 'unprocessed') {
         processDonation(event.donation, event.action, false);
       }
     });
@@ -29,16 +30,22 @@ export default function ProcessingV2() {
     const unsubNewDonations = ProcessingSocket.on('donation_received', event => {
       loadDonations([event.donation]);
     });
+
     return () => {
       unsubActions();
       unsubNewDonations();
     };
-  }, [loadDonations, processDonation]);
+  }, [processDonation]);
 
   return (
     <AppContainer theme={theme as Theme} accent={accent as Accent}>
       <Switch>
-        {canChangeDonations && <Route path="/v2/:eventId/processing/donations" exact component={ProcessDonations} />}
+        {canChangeDonations && (
+          <>
+            <Route path="/v2/:eventId/processing/donations" exact component={ProcessDonations} />
+            <Route path="/v2/:eventId/processing/read" exact component={ReadDonations} />
+          </>
+        )}
       </Switch>
     </AppContainer>
   );

--- a/bundles/processing/ProcessingV2.tsx
+++ b/bundles/processing/ProcessingV2.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
+import { useQuery } from 'react-query';
 import { Route, Switch } from 'react-router';
 import { Accent, AppContainer, Theme } from '@spyrothon/sparx';
 
 import { usePermission } from '@public/api/helpers/auth';
+import APIClient from '@public/apiv2/APIClient';
 import { ProcessingSocket } from '@public/apiv2/sockets/ProcessingSocket';
 
+import { loadMe } from './AuthStore';
 import { loadDonations } from './DonationsStore';
 import ProcessDonations from './ProcessDonations';
 import useProcessingStore from './ProcessingStore';

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -1,0 +1,383 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { useMutation, useQuery } from 'react-query';
+import { useParams } from 'react-router';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import {
+  Anchor,
+  Button,
+  Card,
+  Checkbox,
+  Header,
+  openModal,
+  openPopout,
+  Spacer,
+  Stack,
+  TabColor,
+  Tabs,
+  Tag,
+  Text,
+  useTooltip,
+} from '@spyrothon/sparx';
+
+import { usePermission } from '@public/api/helpers/auth';
+import APIClient from '@public/apiv2/APIClient';
+import type { Donation } from '@public/apiv2/APITypes';
+import * as CurrencyUtils from '@public/util/currency';
+import TimeUtils from '@public/util/TimeUtils';
+import Approve from '@uikit/icons/Approve';
+import Deny from '@uikit/icons/Deny';
+import Dots from '@uikit/icons/Dots';
+import Plus from '@uikit/icons/Plus';
+
+import ConnectionStatus from './ConnectionStatus';
+import CreateEditDonationGroupModal from './CreateEditDonationGroupModal';
+import useDonationGroupsStore, { useGroupsForDonation } from './DonationGroupsStore';
+import { loadDonations, useDonation, useDonations, useDonationsInState } from './DonationsStore';
+import getEstimatedReadingTime from './getEstimatedReadingTIme';
+import MutationButton from './MutationButton';
+import ProcessingSidebar from './ProcessingSidebar';
+import { AdminRoutes, useAdminRoute } from './Routes';
+
+import donationStyles from './DonationRow.mod.css';
+import styles from './Processing.mod.css';
+
+interface AddToGroupPopoutProps {
+  donationId: number;
+}
+
+function AddToGroupPopout(props: AddToGroupPopoutProps) {
+  const { donationId } = props;
+  const donation = useDonation(donationId);
+  const { groups, addDonationToGroup, removeDonationFromGroup } = useDonationGroupsStore();
+
+  const amount = CurrencyUtils.asCurrency(donation.amount);
+  const donationLink = useAdminRoute(AdminRoutes.DONATION(donation.id));
+  const donorLink = useAdminRoute(AdminRoutes.DONOR(donation.donor));
+  const canEditDonors = usePermission('tracker.change_donor');
+
+  const pin = useMutation(() => APIClient.pinDonation(`${donation.id}`), {
+    onSuccess: donation => loadDonations([donation]),
+  });
+  const unpin = useMutation(() => APIClient.unpinDonation(`${donation.id}`), {
+    onSuccess: donation => loadDonations([donation]),
+  });
+
+  function handlePinChange() {
+    donation.pinned ? unpin.mutate() : pin.mutate();
+  }
+
+  return (
+    <Card floating>
+      <Stack>
+        <div>
+          <Header tag="h1" variant="header-sm/normal">
+            {amount} from {donation.donor_name}
+          </Header>
+          <Text variant="text-sm/secondary">
+            #{donation.id}
+            {' · '}
+            <Anchor href={donationLink} newTab>
+              Edit Donation
+            </Anchor>
+            {canEditDonors ? (
+              <>
+                {' · '}
+                <Anchor href={donorLink} newTab>
+                  Edit Donor
+                </Anchor>
+              </>
+            ) : null}
+          </Text>
+        </div>
+        <Spacer />
+        <Checkbox label="Pin for Everyone" checked={donation.pinned} onChange={handlePinChange} />
+        <Header tag="h2" variant="header-sm/normal">
+          Add to Groups
+        </Header>
+        {groups.map(group => {
+          const isIncluded = group.donationIds.includes(donation.id);
+          function handleGroupChange() {
+            isIncluded ? removeDonationFromGroup(group.name, donation.id) : addDonationToGroup(group.name, donation.id);
+          }
+          return <Checkbox key={group.name} label={group.name} checked={isIncluded} onChange={handleGroupChange} />;
+        })}
+      </Stack>
+    </Card>
+  );
+}
+
+interface DonationRowProps {
+  donation: Donation;
+}
+
+function DonationRow(props: DonationRowProps) {
+  const { donation } = props;
+  const timestamp = TimeUtils.parseTimestamp(donation.timereceived);
+
+  const readingTime = getEstimatedReadingTime(donation.comment);
+  const amount = CurrencyUtils.asCurrency(donation.amount);
+  const hasComment = donation.comment != null && donation.comment.length > 0;
+
+  const removeDonationFromAllGroups = useDonationGroupsStore(state => state.removeDonationFromAllGroups);
+  const groups = useGroupsForDonation(donation.id);
+  const [moreActionsTooltipProps] = useTooltip<HTMLButtonElement>('More Actions');
+
+  const read = useMutation((donationId: number) => APIClient.readDonation(`${donationId}`), {
+    onSuccess: (donation: Donation) => {
+      loadDonations([donation]);
+      removeDonationFromAllGroups(donation.id);
+    },
+  });
+  const ignore = useMutation((donationId: number) => APIClient.ignoreDonation(`${donationId}`), {
+    onSuccess: (donation: Donation) => {
+      loadDonations([donation]);
+      removeDonationFromAllGroups(donation.id);
+    },
+  });
+
+  function handleMoreActions(event: React.MouseEvent) {
+    openPopout(() => <AddToGroupPopout donationId={donation.id} />, event.currentTarget as HTMLElement);
+  }
+
+  return (
+    <div className={donationStyles.container}>
+      <div className={donationStyles.header}>
+        <Stack direction="horizontal" justify="space-between" align="center" className={donationStyles.headerTop}>
+          <Stack spacing="space-sm">
+            <Text variant="text-md/normal">
+              <strong>{amount}</strong>
+              {' from '}
+              <strong>{donation.donor_name}</strong>
+            </Text>
+            <Stack direction="horizontal" spacing="space-sm" align="center">
+              {groups.map(group => (
+                <Tag key={group.name} color={group.color}>
+                  {group.name}
+                </Tag>
+              ))}
+              {groups.length > 0 ? ' · ' : null}
+              <Text variant="text-sm/normal">
+                <span>{timestamp.toFormat('yyyy-MM-dd hh:mm:ss a')}</span>
+                {' · '}
+                {readingTime} to read
+              </Text>
+            </Stack>
+          </Stack>
+          <Stack direction="horizontal">
+            <MutationButton
+              mutation={read}
+              donationId={donation.id}
+              icon={Approve}
+              label="Mark as Read"
+              variant="success"
+            />
+            <MutationButton
+              mutation={ignore}
+              donationId={donation.id}
+              icon={Deny}
+              label="Mark as Ignored"
+              variant="danger"
+            />
+            <Button {...moreActionsTooltipProps} onClick={handleMoreActions} variant="default">
+              <Dots />
+            </Button>
+          </Stack>
+        </Stack>
+      </div>
+
+      <Text
+        variant={hasComment ? 'text-md/normal' : 'text-md/secondary'}
+        className={classNames(donationStyles.comment, { [donationStyles.noCommentHint]: !hasComment })}>
+        {hasComment ? donation.comment : 'No comment was provided'}
+      </Text>
+    </div>
+  );
+}
+
+interface DonationListProps {
+  donationIds: Set<number> | number[];
+}
+
+function DonationList(props: DonationListProps) {
+  const { donationIds } = props;
+  const donations = useDonations(donationIds);
+
+  return (
+    <>
+      <TransitionGroup>
+        {donations.map(donation => (
+          <CSSTransition
+            key={donation.id}
+            timeout={240}
+            classNames={{
+              enter: styles.donationEnter,
+              enterActive: styles.donationEnterActive,
+              exit: styles.donationExit,
+              exitActive: styles.donationExitActive,
+            }}>
+            <DonationRow donation={donation} />
+          </CSSTransition>
+        ))}
+      </TransitionGroup>
+    </>
+  );
+}
+
+function CreateGroupButton() {
+  function handleClick() {
+    openModal(props => <CreateEditDonationGroupModal {...props} />);
+  }
+
+  return <Button variant="link/filled" icon={Plus} onClick={handleClick} />;
+}
+
+function useFilteredDonationGroups(donations: Donation[]) {
+  function noCommentDonationFilter(donation: Donation) {
+    return donation.comment == null || donation.comment.length === 0;
+  }
+
+  function pinnedDonationFilter(donation: Donation) {
+    return donation.pinned;
+  }
+
+  // TODO(faulty): Better represent anonymous donations so they actually have a
+  // flag instead of having to check the name like this.
+  function anonymousDonationFilter(donation: Donation) {
+    return donation.donor_name === '(Anonymous)' || donation.donor_name === '';
+  }
+
+  return React.useMemo(() => {
+    const noCommentDonationIds = [];
+    const pinnedDonationIds = [];
+    const anonymousDonationIds = [];
+
+    for (const donation of donations) {
+      if (noCommentDonationFilter(donation)) noCommentDonationIds.push(donation.id);
+      if (pinnedDonationFilter(donation)) pinnedDonationIds.push(donation.id);
+      if (anonymousDonationFilter(donation)) anonymousDonationIds.push(donation.id);
+    }
+
+    return { noCommentDonationIds, pinnedDonationIds, anonymousDonationIds };
+  }, [donations]);
+}
+
+interface FilterGroupItem {
+  label: string;
+  count: number;
+  color: TabColor;
+  donationIds: number[];
+}
+
+export default function ReadDonations() {
+  const params = useParams<{ eventId: string }>();
+  const { eventId } = params;
+
+  const { data: event } = useQuery(`events.${eventId}`, () => APIClient.getEvent(eventId));
+  const donationsQuery = useQuery(`donations.unread`, () => APIClient.getUnreadDonations(eventId), {
+    onSuccess: loadDonations,
+  });
+
+  const groups = useDonationGroupsStore(state => state.groups);
+  const donations = useDonationsInState('ready');
+  const { noCommentDonationIds, pinnedDonationIds, anonymousDonationIds } = useFilteredDonationGroups(donations);
+
+  const filterTabItems: FilterGroupItem[] = [
+    {
+      label: 'All Donations',
+      count: donations.length,
+      donationIds: donations.map(donation => donation.id),
+      color: 'default',
+    },
+    {
+      label: 'No Comment',
+      count: noCommentDonationIds.length,
+      donationIds: noCommentDonationIds,
+      color: 'default',
+    },
+    {
+      label: 'Anonymous',
+      count: anonymousDonationIds.length,
+      donationIds: anonymousDonationIds,
+      color: 'default',
+    },
+    {
+      label: 'Pinned',
+      count: pinnedDonationIds.length,
+      donationIds: pinnedDonationIds,
+      color: 'default',
+    },
+  ];
+
+  const groupTabItems: FilterGroupItem[] = groups.map(group => ({
+    label: group.name,
+    count: group.donationIds.length,
+    color: group.color,
+    donationIds: group.donationIds,
+  }));
+  const [selectedGroupName, setSelectedGroupName] = React.useState<string>(filterTabItems[0].label);
+  const selectedGroup =
+    filterTabItems.find(tab => tab.label === selectedGroupName) ||
+    groupTabItems.find(tab => tab.label === selectedGroupName) ||
+    filterTabItems[0];
+
+  // When the page first loads, force a refresh of all donations that have been
+  // saved into groups to ensure they are present and up-to-date.
+  React.useEffect(() => {
+    (async () => {
+      const { groups } = useDonationGroupsStore.getState();
+      const ids = new Set<string>();
+      for (const group of Object.values(groups)) {
+        group.donationIds.forEach(id => ids.add(String(id)));
+      }
+      const donations = await APIClient.getDonations(Array.from(ids));
+      loadDonations(donations);
+    })();
+  }, []);
+
+  function getGroupSelectHandler(groupName: string) {
+    return () => setSelectedGroupName(groupName);
+  }
+
+  return (
+    <div className={styles.container}>
+      <ProcessingSidebar event={event} subtitle="Read Donations" className={styles.sidebar}>
+        <ConnectionStatus refetch={donationsQuery.refetch} isFetching={donationsQuery.isRefetching} />
+        <Tabs.Group>
+          <Tabs.Header label="Filters" />
+          {filterTabItems.map(tab => (
+            <Tabs.Tab
+              key={tab.label}
+              label={tab.label}
+              color={tab.color}
+              onClick={getGroupSelectHandler(tab.label)}
+              selected={selectedGroupName === tab.label}
+              badge={tab.count}
+            />
+          ))}
+          <Tabs.Header
+            label={
+              <div className={styles.groupsHeader}>
+                <span className={styles.groupsHeaderTitle}>Custom Groups</span>
+                <CreateGroupButton />
+              </div>
+            }
+          />
+          {groupTabItems.map(tab => (
+            <Tabs.Tab
+              key={tab.label}
+              label={tab.label}
+              color={tab.color}
+              onClick={getGroupSelectHandler(tab.label)}
+              selected={selectedGroupName === tab.label}
+              badge={tab.count}
+            />
+          ))}
+        </Tabs.Group>
+      </ProcessingSidebar>
+      <main className={styles.main}>
+        <DonationList key={selectedGroupName} donationIds={selectedGroup.donationIds} />
+      </main>
+    </div>
+  );
+}

--- a/bundles/processing/Theming.tsx
+++ b/bundles/processing/Theming.tsx
@@ -46,7 +46,7 @@ export function setCurrentThemeFromQuery() {
 darkThemeQuery.addEventListener('change', setCurrentThemeFromQuery);
 lightThemeQuery.addEventListener('change', setCurrentThemeFromQuery);
 
-export function ThemeButton({ className }: { className: string }) {
+export function ThemeButton({ className }: { className?: string }) {
   const store = useThemeStore();
 
   function toggleTheme() {
@@ -54,8 +54,8 @@ export function ThemeButton({ className }: { className: string }) {
   }
 
   return (
-    <Button className={className} onClick={toggleTheme}>
-      {store.theme === 'dark' ? <Sun /> : <Moon />} Switch Themes
+    <Button className={className} onClick={toggleTheme} icon={store.theme === 'dark' ? Sun : Moon}>
+      Switch Themes
     </Button>
   );
 }

--- a/bundles/public/apiv2/APIClient.tsx
+++ b/bundles/public/apiv2/APIClient.tsx
@@ -1,9 +1,11 @@
 import * as donations from './routes/donations';
 import * as events from './routes/events';
+import * as me from './routes/me';
 
 const client = {
   ...donations,
   ...events,
+  ...me,
 };
 
 export default client;

--- a/bundles/public/apiv2/APITypes.tsx
+++ b/bundles/public/apiv2/APITypes.tsx
@@ -37,3 +37,10 @@ export type Event = {
   timezone: string;
   use_one_step_screening: boolean;
 };
+
+export type Me = {
+  username: string;
+  superuser: boolean;
+  staff: boolean;
+  permissions: string[];
+};

--- a/bundles/public/apiv2/Endpoints.tsx
+++ b/bundles/public/apiv2/Endpoints.tsx
@@ -18,6 +18,7 @@ const Endpoints = {
   DONATIONS_IGNORE: (donationId: string) => `donations/${donationId}/ignore/`,
   EVENTS: `events/`,
   EVENT: (eventId: string) => `events/${eventId}/`,
+  ME: `me/`,
 };
 
 export default Endpoints;

--- a/bundles/public/apiv2/Endpoints.tsx
+++ b/bundles/public/apiv2/Endpoints.tsx
@@ -3,8 +3,10 @@
  */
 
 const Endpoints = {
+  DONATIONS: `donations/`,
   DONATIONS_UNPROCESSED: `donations/unprocessed/`,
   DONATIONS_FLAGGED: `donations/flagged/`,
+  DONATIONS_UNREAD: `donations/unread/`,
   DONATIONS_UNPROCESS: (donationId: string) => `donations/${donationId}/unprocess/`,
   DONATIONS_APPROVE_COMMENT: (donationId: string) => `donations/${donationId}/approve_comment/`,
   DONATIONS_DENY_COMMENT: (donationId: string) => `donations/${donationId}/deny_comment/`,
@@ -12,6 +14,8 @@ const Endpoints = {
   DONATIONS_SEND_TO_READER: (donationId: string) => `donations/${donationId}/send_to_reader/`,
   DONATIONS_PIN: (donationId: string) => `donations/${donationId}/pin/`,
   DONATIONS_UNPIN: (donationId: string) => `donations/${donationId}/unpin/`,
+  DONATIONS_READ: (donationId: string) => `donations/${donationId}/read/`,
+  DONATIONS_IGNORE: (donationId: string) => `donations/${donationId}/ignore/`,
   EVENTS: `events/`,
   EVENT: (eventId: string) => `events/${eventId}/`,
 };

--- a/bundles/public/apiv2/routes/donations.tsx
+++ b/bundles/public/apiv2/routes/donations.tsx
@@ -22,6 +22,26 @@ export async function getFlaggedDonations(eventId: string, options: DonationsFil
   return response.data;
 }
 
+export async function getUnreadDonations(eventId: string, options: DonationsFilterOptions = {}) {
+  const response = await HTTPUtils.get<Donation[]>(Endpoints.DONATIONS_UNREAD, {
+    event_id: eventId,
+    after: options.after?.toISOString(),
+  });
+  return response.data;
+}
+
+/**
+ * Fetch specific donations from the API from the list of given IDs. Donations
+ * that do not correspond to an existing donation will be omitted from the
+ * returned list.
+ */
+export async function getDonations(donationIds: string[]) {
+  const response = await HTTPUtils.get<Donation[]>(Endpoints.DONATIONS, {
+    ids: donationIds,
+  });
+  return response.data;
+}
+
 export async function unprocessDonation(donationId: string) {
   const response = await HTTPUtils.post<Donation>(Endpoints.DONATIONS_UNPROCESS(donationId));
   return response.data;
@@ -54,5 +74,15 @@ export async function pinDonation(donationId: string) {
 
 export async function unpinDonation(donationId: string) {
   const response = await HTTPUtils.post<Donation>(Endpoints.DONATIONS_UNPIN(donationId));
+  return response.data;
+}
+
+export async function readDonation(donationId: string) {
+  const response = await HTTPUtils.post<Donation>(Endpoints.DONATIONS_READ(donationId));
+  return response.data;
+}
+
+export async function ignoreDonation(donationId: string) {
+  const response = await HTTPUtils.post<Donation>(Endpoints.DONATIONS_IGNORE(donationId));
   return response.data;
 }

--- a/bundles/public/apiv2/routes/me.tsx
+++ b/bundles/public/apiv2/routes/me.tsx
@@ -1,0 +1,8 @@
+import type { Me } from '../APITypes';
+import Endpoints from '../Endpoints';
+import HTTPUtils from '../HTTPUtils';
+
+export async function getMe() {
+  const response = await HTTPUtils.get<Me>(Endpoints.ME);
+  return response.data;
+}

--- a/bundles/uikit/icons/CheckboxChecked.tsx
+++ b/bundles/uikit/icons/CheckboxChecked.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { faCheckSquare } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const CheckboxOpen = (props: any) => {
+const CheckboxChecked = (props: any) => {
   return <FontAwesomeIcon {...props} icon={faCheckSquare} />;
 };
 
-export default CheckboxOpen;
+export default CheckboxChecked;

--- a/bundles/uikit/icons/Dots.tsx
+++ b/bundles/uikit/icons/Dots.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { faEllipsisH } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const Dots = (props: any) => {
+  return <FontAwesomeIcon {...props} icon={faEllipsisH} />;
+};
+
+export default Dots;

--- a/bundles/uikit/icons/InfoCircle.tsx
+++ b/bundles/uikit/icons/InfoCircle.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const InfoCircle = (props: any) => {
+  return <FontAwesomeIcon {...props} icon={faInfoCircle} />;
+};
+
+export default InfoCircle;

--- a/bundles/uikit/icons/Plus.tsx
+++ b/bundles/uikit/icons/Plus.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const Plus = (props: any) => {
+  return <FontAwesomeIcon {...props} icon={faPlus} />;
+};
+
+export default Plus;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@loadable/component": "^5.15.3",
     "@react-dnd/invariant": "^4.0.2",
     "@redux-devtools/extension": "^3.2.5",
-    "@spyrothon/sparx": "^0.3.3",
+    "@spyrothon/sparx": "^0.3.4",
     "axios": "^1.3.5",
     "classnames": "^2.3.2",
     "connected-react-router": "^6.9.3",

--- a/tests/apiv2/test_me.py
+++ b/tests/apiv2/test_me.py
@@ -1,0 +1,101 @@
+from typing import List
+
+from django.contrib.auth.models import Group, Permission, User
+from rest_framework.test import APIClient
+
+from .util import APITestCase
+
+
+def me_response(*, username: str, staff: bool, superuser: bool, permissions: List[str]):
+    return {
+        'username': username,
+        'staff': staff,
+        'superuser': superuser,
+        'permissions': permissions,
+    }
+
+
+class TestMe(APITestCase):
+    def setUp(self):
+        super(TestMe, self).setUp()
+        self.client = APIClient()
+
+    def test_normal_user(self):
+        normal_user = User.objects.create(username='normal user')
+        self.client.force_authenticate(user=normal_user)
+        response = self.client.get('/tracker/api/v2/me/')
+
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=normal_user.username,
+                staff=False,
+                superuser=False,
+                permissions=[],
+            ),
+        )
+
+    def test_staff_user(self):
+        staff = User.objects.create(username='staff user', is_staff=True)
+        self.client.force_authenticate(user=staff)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=staff.username,
+                staff=True,
+                superuser=False,
+                permissions=[],
+            ),
+        )
+
+    def test_super_user(self):
+        super_user = User.objects.create(username='super user', is_superuser=True)
+        self.client.force_authenticate(user=super_user)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictContainsSubset(
+            {'username': super_user.username, 'staff': False, 'superuser': True},
+            response.data,
+        )
+        self.assertSetEqual(
+            set(response.data['permissions']), super_user.get_all_permissions()
+        )
+
+    def test_user_with_permissions(self):
+        user = User.objects.create(username='user with permissions')
+        user.user_permissions.add(Permission.objects.get(codename='add_user'))
+
+        self.client.force_authenticate(user=user)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=user.username,
+                staff=False,
+                superuser=False,
+                permissions=['auth.add_user'],
+            ),
+        )
+
+    def test_user_with_group_permissions(self):
+        normal_user = User.objects.create(username='normal user')
+
+        group = Group.objects.create(name='Test Group')
+        group.permissions.add(Permission.objects.get(codename='add_user'))
+        group.user_set.add(normal_user)
+
+        self.client.force_authenticate(user=normal_user)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=normal_user.username,
+                staff=False,
+                superuser=False,
+                permissions=['auth.add_user'],
+            ),
+        )
+
+    def test_anonymous_user(self):
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertEqual(response.status_code, 403)

--- a/tracker/analytics/events.py
+++ b/tracker/analytics/events.py
@@ -17,4 +17,6 @@ class AnalyticsEventTypes(str, enum.Enum):
     DONATION_COMMENT_AUTOMOD_DENIED = 'donation_comment_automod_denied'
     DONATION_COMMENT_PINNED = 'donation_comment_pinned'
     DONATION_COMMENT_UNPINNED = 'donation_comment_unpinned'
+    DONATION_COMMENT_READ = 'donation_commment_read'
+    DONATION_COMMENT_IGNORED = 'donation_commment_ignored'
     REQUEST_SERVED = 'request_served'

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -4,7 +4,7 @@ from django.urls import include, path
 from rest_framework import routers
 
 from tracker.api import views
-from tracker.api.views import donations
+from tracker.api.views import donations, me
 
 # routers generate URLs based on the view sets, so that we don't need to do a bunch of stuff by hand
 router = routers.DefaultRouter()
@@ -12,6 +12,7 @@ router.register(r'events', views.EventViewSet)
 router.register(r'runners', views.RunnerViewSet)
 router.register(r'runs', views.SpeedRunViewSet)
 router.register(r'donations', donations.DonationViewSet, basename='donations')
+router.register(r'me', me.MeViewSet, basename='me')
 
 # use the router-generated URLs, and also link to the browsable API
 urlpatterns = [

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -125,13 +125,9 @@ class DonationViewSet(viewsets.GenericViewSet):
         and were not tests.
         """
         event_id = self.request.query_params.get('event_id')
-        query = (
-            Donation.objects.filter(
-                event_id=event_id, transactionstate='COMPLETED', testdonation=False
-            )
-            .order_by('timereceived')
-            .all()
-        )
+        query = Donation.objects.filter(
+            event_id=event_id, transactionstate='COMPLETED', testdonation=False
+        ).order_by('timereceived')
 
         after = self.request.query_params.get('after')
         if after is not None:
@@ -153,7 +149,7 @@ class DonationViewSet(viewsets.GenericViewSet):
                 {'error': 'Only a maximum of 200 donations may be specified at a time'},
                 status=422,
             )
-        donations = Donation.objects.filter(pk__in=donation_ids).all()
+        donations = Donation.objects.filter(pk__in=donation_ids)
         serializer = DonationSerializer(donations, many=True)
         return Response(serializer.data)
 

--- a/tracker/api/views/me.py
+++ b/tracker/api/views/me.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+
+
+class MeSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    superuser = serializers.BooleanField()
+    staff = serializers.BooleanField()
+    permissions = serializers.ListField(child=serializers.CharField())
+
+
+class MeViewSet(viewsets.GenericViewSet):
+    def list(self, request):
+        """
+        Return information about the user that made the request.
+        """
+
+        if request.user.is_anonymous or not request.user.is_active:
+            return Response(status=403)
+
+        me = MeSerializer(
+            {
+                'username': request.user.username,
+                'superuser': request.user.is_superuser,
+                'staff': request.user.is_staff,
+                'permissions': list(request.user.get_all_permissions()),
+            }
+        )
+
+        return Response(me.data)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,9 +2310,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spyrothon/sparx@npm:^0.3.3":
-  version: 0.3.3
-  resolution: "@spyrothon/sparx@npm:0.3.3"
+"@spyrothon/sparx@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "@spyrothon/sparx@npm:0.3.4"
   dependencies:
     "@iconscout/react-unicons": ^1.1.6
     "@iconscout/react-unicons-solid": ^0.0.3
@@ -2325,7 +2325,7 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: c79bc8234ee9205270c9267fa69fefe57dddd6e9932f116393428918b475739617973fbefa24e608face8266839c2d41b66c4f4a35934463c09a66b9e2f4c668
+  checksum: f5e55d56ff3852b4019a3bd730fc3eb0e2262ceb6f1b64e95980d34240aa1023f06623c55afea489332362baec353c8eae55753bff8c400d354bdff146b5f0c9
   languageName: node
   linkType: hard
 
@@ -7906,7 +7906,7 @@ __metadata:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.10
     "@react-dnd/invariant": ^4.0.2
     "@redux-devtools/extension": ^3.2.5
-    "@spyrothon/sparx": ^0.3.3
+    "@spyrothon/sparx": ^0.3.4
     "@storybook/addon-actions": ^5.1.3
     "@storybook/addon-links": ^5.1.3
     "@storybook/addons": ^5.1.3


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This introduces a new, revamped Read Donations page to match the existing new Process Donations page from last year. The new page focuses on the feedback we've received from hosts over the past few years, wanting to have more options for marking and grouping donations to be read at certain times. The list of general features includes:

- Live socket updating, so new donations will immediately show up as they are processed. The refresh button is still there for safety, but hosts should never really have to refresh the page.
- Local tagging, letting hosts create any number of groups they'd like and managing the donations within those groups as they wish. Tags show up on all views and in the sidebar as selectable filters. Tags and groups are specific to each device using the site.
- Permanent on the sidebar for different types of donations. Anonymous and No Comment are the only two that really exist right now, but that leads to:
- Pinned donations are now the way of "sharing" donations across hosts. Tags are only saved locally in each browser (using `localStorage`), but pins are an actual state on the donation, so they can be used to communicate a specific set of donations across multiple hosts and devices.
- Highly requested dark theme, since it comes for free with the design system.

Other features that are still to come after this initial merge include:
- Drag and drop for donations within groups, so hosts can have things ordered exactly how they wish.
- Relative timestamps to make the donation time easier to glance at.
- A list of recently-read donations to be able to undo or go back on donations that are accidentally marked wrong.
- Keyword highlighting similar to the processing pages.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/783733/230781278-e85e8ccf-1866-4022-b3f0-ac9046e769f1.png">


### Verification Process

Tested all features to ensure they work the same way as the old pages, and tested the revamped processing pages as well to make sure no functionality was broken/lost.
