### PR TITLE
Fix webpack manifest crashing after hot-update

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "terser-webpack-plugin": "^5.3.7",
     "validator": "^13.9.0",
     "webpack": "^5.78.0",
-    "webpack-yam-plugin": "^1.0.1",
+    "webpack-yam-plugin": "github:GamesDoneQuick/webpack-yam-plugin#commit=0e7acab356bd3d8a9098172ebd84536013c86b35",
     "zustand": "^4.0.0-rc.1"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,6 +151,7 @@ module.exports = {
       new WebpackManifestPlugin({
         manifestPath: __dirname + '/tracker/ui-tracker.manifest.json',
         outputRoot: __dirname + '/tracker/static',
+        fileFilter: file => !/\.hot-update\.js$/.test(file),
       }),
     new MiniCssExtractPlugin({
       filename: PROD ? 'tracker-[name]-[contenthash].css' : 'tracker-[name].css',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7888,7 +7888,7 @@ __metadata:
     webpack: ^5.78.0
     webpack-cli: ^4.10.0
     webpack-dev-server: ^4.13.2
-    webpack-yam-plugin: ^1.0.1
+    webpack-yam-plugin: "portal:../../webpack-yam-plugin"
     zustand: ^4.0.0-rc.1
   languageName: unknown
   linkType: soft
@@ -19852,16 +19852,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-yam-plugin@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "webpack-yam-plugin@npm:1.0.1"
+"webpack-yam-plugin@portal:../../webpack-yam-plugin::locator=donation_tracker%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "webpack-yam-plugin@portal:../../webpack-yam-plugin::locator=donation_tracker%40workspace%3A."
   dependencies:
     lodash: ^4.17.11
     mkdirp: ^0.5.1
     strip-ansi: ^5.0.0
-  checksum: 095a15b3ece7af313fb8b97f6098540141b9a4c865c9eebb3904bcf9c2073ce2a2c3270957e8cee3d3c2c54bb8fb8ee5463a9ae667dd8a2be77491ae5cea5383
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "webpack@npm:^4.33.0, webpack@npm:^4.38.0":
   version: 4.41.2


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

**NOTE:** This PR is dependent on a commit going to https://github.com/GamesDoneQuick/webpack-yam-plugin that has not yet landed. It will be updated and marked ready for review once that happens.

Webpack hot reloading with `webpack-dev-server` ends up creating `*.hot-update.js` files that it sends to existing connections to get them the changed content and reload without requiring a full page refresh. This is great for development speed, especially when working on nested stuff that can take a while to navigate to. However, these files only exist when hot reloading is enabled and are not relevant to a clean page load, as then the original bundle file has been updated already and can be loaded directly.

But, `webpack-yam-plugin` ends up including these files in the `manifest.json` it emits anyway, because it doesn't know that they aren't relevant. When that happens (when webpack recompiles and serves a hot-update file), the next time a page is loaded from scratch (i.e., refreshed), it will crash because it tries to load the non-existent hot-update file that is listed in the manifest.

The plugin [hasn't been updated in about 4.5 years](https://github.com/markfinger/webpack-yam-plugin) and thankfully still works with webpack 5, but it doesn't have many options to manage things like this that have changed over time. Another plugin [`webpack-manifest-plugin`](https://www.npmjs.com/package/webpack-manifest-plugin) _does_ support this, but trying to change the integration of manifests with the django app is far more complicated.

So, this PR changes the dependency to our own fork that has an added option for a `fileFilter` that can ignore these hot-update files and ensure that page loads will always work even after hot updates.

### Verification Process

Checked that the page loads after webpack serves a hot update on a previous page load.