### PR TITLE
Add `me` endpoint to api v2

### DIFF
--- a/bundles/processing/AuthStore.tsx
+++ b/bundles/processing/AuthStore.tsx
@@ -1,0 +1,25 @@
+import create from 'zustand';
+
+import { Me } from '@public/apiv2/APITypes';
+
+interface AuthStoreState {
+  me: Me | null;
+}
+
+const useAuthStore = create<AuthStoreState>()(() => ({
+  me: null,
+}));
+
+export default useAuthStore;
+
+export function useMe() {
+  return useAuthStore(state => state.me);
+}
+
+export function loadMe(me: Me) {
+  useAuthStore.setState({ me });
+}
+
+export function logout() {
+  useAuthStore.setState({ me: null });
+}

--- a/bundles/processing/PrimaryNavPopout.tsx
+++ b/bundles/processing/PrimaryNavPopout.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
-import { Anchor, Button, Card, Header, Spacer, Stack, usePopout } from '@spyrothon/sparx';
+import { useQuery } from 'react-query';
+import { Anchor, Button, Card, Header, Spacer, Stack, Text, usePopout } from '@spyrothon/sparx';
 
 import { useConstants } from '@common/Constants';
+import APIClient from '@public/apiv2/APIClient';
 import Bars from '@uikit/icons/Bars';
+
+import { loadMe, useMe } from './AuthStore';
+import { ThemeButton } from './Theming';
 
 import styles from './PrimaryNavPopout.mod.css';
 
@@ -21,8 +26,8 @@ const NavRoutes = {
   MILESTONES: (eventId: string) => `/tracker/milestones/${eventId}`,
   PRIZES: (eventId: string) => `/tracker/prizes/${eventId}`,
   RUNS: (eventId: string) => `/tracker/runs/${eventId}`,
-  LOGOUT: `/tracker/logout/`,
-  SELF_SERVICE: `/user/index/`,
+  LOGOUT: `/tracker/user/logout/`,
+  SELF_SERVICE: `/tracker/user/index/`,
 
   ADMIN_HOME: `/`,
   INTERSTITIALS: (eventId: string) => `interstitials/${eventId}`,
@@ -41,6 +46,21 @@ function path(route: string) {
   return adminPath + route;
 }
 
+function CurrentUser() {
+  useQuery('auth.me', () => APIClient.getMe(), { onSuccess: me => loadMe(me), staleTime: 5 * 60 * 1000 });
+
+  const me = useMe();
+
+  return (
+    <div>
+      <Text variant="text-xs/normal">Logged in as</Text>
+      <Text>
+        <strong>{me?.username}</strong>
+      </Text>
+    </div>
+  );
+}
+
 interface PrimaryNavPopoutProps {
   eventId: string;
 }
@@ -53,6 +73,13 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
   return (
     <Card floating className={styles.container}>
       <Stack direction="horizontal" spacing="space-xl">
+        <Stack spacing="space-lg">
+          <CurrentUser />
+          <Anchor href={NavRoutes.SELF_SERVICE}>Self Service</Anchor>
+          <Anchor href={NavRoutes.LOGOUT}>Logout</Anchor>
+          <Spacer />
+          <ThemeButton />
+        </Stack>
         <Stack spacing="space-lg">
           <Header tag="h2" variant="header-md/normal">
             Admin
@@ -74,12 +101,6 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
           <Anchor href={NavRoutes.DONORS(eventId)}>Donors</Anchor>
           <Anchor href={NavRoutes.DONATIONS(eventId)}>Donations</Anchor>
           <Anchor href={NavRoutes.EVENTS}>All Events</Anchor>
-          <Spacer />
-          <Header tag="h2" variant="header-md/normal">
-            User
-          </Header>
-          <Anchor href={NavRoutes.SELF_SERVICE}>Self Service</Anchor>
-          <Anchor href={NavRoutes.LOGOUT}>Logout</Anchor>
         </Stack>
       </Stack>
     </Card>
@@ -88,7 +109,7 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
 
 export function PrimaryNavPopoutButton(props: PrimaryNavPopoutProps) {
   const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const [openPopout] = usePopout(() => <PrimaryNavPopout {...props} />, buttonRef, { attach: 'left' });
+  const [openPopout] = usePopout(() => <PrimaryNavPopout {...props} />, buttonRef, { attach: 'right' });
 
   return (
     <Button variant="default/outline" ref={buttonRef} onClick={openPopout}>

--- a/bundles/processing/ProcessingSidebar.tsx
+++ b/bundles/processing/ProcessingSidebar.tsx
@@ -4,7 +4,6 @@ import { Header, Stack, Text } from '@spyrothon/sparx';
 import { Event } from '@public/apiv2/APITypes';
 
 import { PrimaryNavPopoutButton } from './PrimaryNavPopout';
-import { ThemeButton } from './Theming';
 
 interface ProcessingHeaderProps {
   event: Event | undefined;
@@ -48,7 +47,6 @@ export default function ProcessingSidebar(props: ProcessingSidebarProps) {
   return (
     <Stack className={className} spacing="space-xl">
       <ProcessingHeader event={event} subtitle={subtitle} />
-      <ThemeButton />
       {children}
     </Stack>
   );

--- a/bundles/processing/ProcessingV2.tsx
+++ b/bundles/processing/ProcessingV2.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
+import { useQuery } from 'react-query';
 import { Route, Switch } from 'react-router';
 import { Accent, AppContainer, Theme } from '@spyrothon/sparx';
 
 import { usePermission } from '@public/api/helpers/auth';
+import APIClient from '@public/apiv2/APIClient';
 import { ProcessingSocket } from '@public/apiv2/sockets/ProcessingSocket';
 
+import { loadMe } from './AuthStore';
 import { loadDonations } from './DonationsStore';
 import ProcessDonations from './ProcessDonations';
 import useProcessingStore from './ProcessingStore';

--- a/bundles/public/apiv2/APIClient.tsx
+++ b/bundles/public/apiv2/APIClient.tsx
@@ -1,9 +1,11 @@
 import * as donations from './routes/donations';
 import * as events from './routes/events';
+import * as me from './routes/me';
 
 const client = {
   ...donations,
   ...events,
+  ...me,
 };
 
 export default client;

--- a/bundles/public/apiv2/APITypes.tsx
+++ b/bundles/public/apiv2/APITypes.tsx
@@ -37,3 +37,10 @@ export type Event = {
   timezone: string;
   use_one_step_screening: boolean;
 };
+
+export type Me = {
+  username: string;
+  superuser: boolean;
+  staff: boolean;
+  permissions: string[];
+};

--- a/bundles/public/apiv2/Endpoints.tsx
+++ b/bundles/public/apiv2/Endpoints.tsx
@@ -18,6 +18,7 @@ const Endpoints = {
   DONATIONS_IGNORE: (donationId: string) => `donations/${donationId}/ignore/`,
   EVENTS: `events/`,
   EVENT: (eventId: string) => `events/${eventId}/`,
+  ME: `me/`,
 };
 
 export default Endpoints;

--- a/bundles/public/apiv2/routes/me.tsx
+++ b/bundles/public/apiv2/routes/me.tsx
@@ -1,0 +1,8 @@
+import type { Me } from '../APITypes';
+import Endpoints from '../Endpoints';
+import HTTPUtils from '../HTTPUtils';
+
+export async function getMe() {
+  const response = await HTTPUtils.get<Me>(Endpoints.ME);
+  return response.data;
+}

--- a/tests/apiv2/test_me.py
+++ b/tests/apiv2/test_me.py
@@ -1,0 +1,101 @@
+from typing import List
+
+from django.contrib.auth.models import Group, Permission, User
+from rest_framework.test import APIClient
+
+from .util import APITestCase
+
+
+def me_response(*, username: str, staff: bool, superuser: bool, permissions: List[str]):
+    return {
+        'username': username,
+        'staff': staff,
+        'superuser': superuser,
+        'permissions': permissions,
+    }
+
+
+class TestMe(APITestCase):
+    def setUp(self):
+        super(TestMe, self).setUp()
+        self.client = APIClient()
+
+    def test_normal_user(self):
+        normal_user = User.objects.create(username='normal user')
+        self.client.force_authenticate(user=normal_user)
+        response = self.client.get('/tracker/api/v2/me/')
+
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=normal_user.username,
+                staff=False,
+                superuser=False,
+                permissions=[],
+            ),
+        )
+
+    def test_staff_user(self):
+        staff = User.objects.create(username='staff user', is_staff=True)
+        self.client.force_authenticate(user=staff)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=staff.username,
+                staff=True,
+                superuser=False,
+                permissions=[],
+            ),
+        )
+
+    def test_super_user(self):
+        super_user = User.objects.create(username='super user', is_superuser=True)
+        self.client.force_authenticate(user=super_user)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictContainsSubset(
+            {'username': super_user.username, 'staff': False, 'superuser': True},
+            response.data,
+        )
+        self.assertSetEqual(
+            set(response.data['permissions']), super_user.get_all_permissions()
+        )
+
+    def test_user_with_permissions(self):
+        user = User.objects.create(username='user with permissions')
+        user.user_permissions.add(Permission.objects.get(codename='add_user'))
+
+        self.client.force_authenticate(user=user)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=user.username,
+                staff=False,
+                superuser=False,
+                permissions=['auth.add_user'],
+            ),
+        )
+
+    def test_user_with_group_permissions(self):
+        normal_user = User.objects.create(username='normal user')
+
+        group = Group.objects.create(name='Test Group')
+        group.permissions.add(Permission.objects.get(codename='add_user'))
+        group.user_set.add(normal_user)
+
+        self.client.force_authenticate(user=normal_user)
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertDictEqual(
+            response.data,
+            me_response(
+                username=normal_user.username,
+                staff=False,
+                superuser=False,
+                permissions=['auth.add_user'],
+            ),
+        )
+
+    def test_anonymous_user(self):
+        response = self.client.get('/tracker/api/v2/me/')
+        self.assertEqual(response.status_code, 403)

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -4,7 +4,7 @@ from django.urls import include, path
 from rest_framework import routers
 
 from tracker.api import views
-from tracker.api.views import donations
+from tracker.api.views import donations, me
 
 # routers generate URLs based on the view sets, so that we don't need to do a bunch of stuff by hand
 router = routers.DefaultRouter()
@@ -12,6 +12,7 @@ router.register(r'events', views.EventViewSet)
 router.register(r'runners', views.RunnerViewSet)
 router.register(r'runs', views.SpeedRunViewSet)
 router.register(r'donations', donations.DonationViewSet, basename='donations')
+router.register(r'me', me.MeViewSet, basename='me')
 
 # use the router-generated URLs, and also link to the browsable API
 urlpatterns = [

--- a/tracker/api/views/me.py
+++ b/tracker/api/views/me.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+
+
+class MeSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    superuser = serializers.BooleanField()
+    staff = serializers.BooleanField()
+    permissions = serializers.ListField(child=serializers.CharField())
+
+
+class MeViewSet(viewsets.GenericViewSet):
+    def list(self, request):
+        """
+        Return information about the user that made the request.
+        """
+
+        if request.user.is_anonymous or not request.user.is_active:
+            return Response(status=403)
+
+        me = MeSerializer(
+            {
+                'username': request.user.username,
+                'superuser': request.user.is_superuser,
+                'staff': request.user.is_staff,
+                'permissions': list(request.user.get_all_permissions()),
+            }
+        )
+
+        return Response(me.data)


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This adds a `me` endpoint into apiv2 that's almost exactly the same as the v1 version. Both are sticking around because the v1 stuff is still in use. I wanted to show the current user on the new processing pages, but I want to keep them strictly on the v2 api, so copying over made sense.

<img width="698" alt="image" src="https://user-images.githubusercontent.com/783733/230794264-d3208c85-085c-47a3-814d-36060600cd42.png">


### Verification Process

Confirmed that requesting the endpoint returns the right info, raises when not logged in/active, and shows up correctly in the v2 UI.