### PR TITLE
tweak some Headset behavior

### DIFF
--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -869,3 +869,5 @@ class SpeedRunAdmin(CustomModelAdmin):
 @admin.register(models.Headset)
 class HeadsetAdmin(CustomModelAdmin):
     form = HeadsetAdminForm
+    search_fields = ('name',)
+    list_display = ('name', 'pronouns')

--- a/tracker/migrations/0026_add_hosts_commentators.py
+++ b/tracker/migrations/0026_add_hosts_commentators.py
@@ -20,18 +20,19 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(error_messages={'unique': 'Headset with this case-insensitive Name already exists.'}, max_length=64, unique=True)),
-                ('pronouns', models.CharField(blank=True, help_text='They/Them', max_length=20)),
-                ('runner', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='tracker.runner')),
+                ('pronouns', models.CharField(blank=True, help_text='Example: They/Them', max_length=20)),
+                ('runner', models.OneToOneField(blank=True, help_text='Optional Runner link', null=True, on_delete=django.db.models.deletion.SET_NULL, to='tracker.runner')),
             ],
+            options={'ordering': ('name',)},
         ),
         migrations.AddField(
             model_name='speedrun',
             name='hosts',
-            field=models.ManyToManyField(related_name='hosting_for', to='tracker.headset'),
+            field=models.ManyToManyField(blank=True, related_name='hosting_for', to='tracker.headset'),
         ),
         migrations.AddField(
             model_name='speedrun',
             name='commentators',
-            field=models.ManyToManyField(related_name='commentating_for', to='tracker.headset'),
+            field=models.ManyToManyField(blank=True, related_name='commentating_for', to='tracker.headset'),
         ),
     ]

--- a/tracker/models/event.py
+++ b/tracker/models/event.py
@@ -366,8 +366,10 @@ class SpeedRun(models.Model):
     run_time = TimestampField(always_show_h=True)
     setup_time = TimestampField(always_show_h=True)
     runners = models.ManyToManyField('Runner')
-    hosts = models.ManyToManyField('Headset', related_name='hosting_for')
-    commentators = models.ManyToManyField('Headset', related_name='commentating_for')
+    hosts = models.ManyToManyField('Headset', related_name='hosting_for', blank=True)
+    commentators = models.ManyToManyField(
+        'Headset', related_name='commentating_for', blank=True
+    )
     coop = models.BooleanField(
         default=False,
         help_text='Cooperative runs should be marked with this for layout purposes',
@@ -603,6 +605,9 @@ class Headset(models.Model):
         def get_by_natural_key(self, name):
             return self.get(name__iexact=name)
 
+    class Meta:
+        ordering = ('name',)
+
     objects = _Manager()
     name = models.CharField(
         max_length=64,
@@ -611,9 +616,15 @@ class Headset(models.Model):
             'unique': 'Headset with this case-insensitive Name already exists.'
         },
     )
-    pronouns = models.CharField(max_length=20, blank=True, help_text='They/Them')
+    pronouns = models.CharField(
+        max_length=20, blank=True, help_text='Example: They/Them'
+    )
     runner = models.OneToOneField(
-        'Runner', blank=True, null=True, on_delete=models.SET_NULL
+        'Runner',
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        help_text='Optional Runner link',
     )
 
     def __str__(self):


### PR DESCRIPTION
- allow hosts/commentators to be blank in the speedrun admin
- sort headsets by name by default
- tweak help text for headset fields
- add search field for headset admin

[#184926032 #184953984]

# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184926032
https://www.pivotaltracker.com/story/show/184953984

### Description of the Change

Various pieces of feedback gathered in Slack and some additional tweaks. Almost entirely display logic.

### Verification Process

Can save a run with no hosts/commentators in the admin page, and all the other strings show up as expected.