### PR TITLE
update Django version compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.7 to 3.11
-- Django 3.2 to 4.1
+- Django 3.2, 4.1, or 4.2
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 
@@ -103,7 +103,7 @@ Allows you to place a logo asset in the navbar for public facing pages.
 
 Start up a new Django Project like the [Django Tutorial](https://docs.djangoproject.com/en/2.2/intro/tutorial01/).
 
-- `pip install django~=2.2`
+- `pip install django~=3.2`
 - `django-admin startproject tracker_development`
 - `cd tracker_development`
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,26 +12,26 @@ jobs:
       matrix:
         Latest:
           PYTHON_VERSION: '3.11'
-          DJANGO_VERSION: '4.1'
+          DJANGO_VERSION: '4.2'
         Oldest:
           PYTHON_VERSION: '3.7'
           DJANGO_VERSION: '3.2'
         Django32:
           PYTHON_VERSION: '3.11'
           DJANGO_VERSION: '3.2'
-        Django40:
+        Django41:
           PYTHON_VERSION: '3.11'
-          DJANGO_VERSION: '4.0'
-        # Python37: # does not need separate testing because python 3.8 is required for Django 4.0
+          DJANGO_VERSION: '4.1'
+        # Python37: # does not need separate testing because python 3.8 is required for Django 4.x
         Python38:
           PYTHON_VERSION: '3.8'
-          DJANGO_VERSION: '4.1'
+          DJANGO_VERSION: '4.2'
         Python39:
           PYTHON_VERSION: '3.9'
-          DJANGO_VERSION: '4.1'
+          DJANGO_VERSION: '4.2'
         Python3A:
           PYTHON_VERSION: '3.10'
-          DJANGO_VERSION: '4.1'
+          DJANGO_VERSION: '4.2'
 
     steps:
       - task: UsePythonVersion@0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         'celery~=5.0',
         'channels>=2.0',
-        'Django>=3.2,<4.2',
+        'Django>=3.2,!=4.0.*,<4.3',
         'django-ajax-selects~=2.2',
         'django-ical~=1.7',
         'django-mptt~=0.10',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ django-paypal==1.1.2
 django-mptt==0.13.4
 django-post-office==3.6.0
 django-timezone-field==5.0
-djangorestframework==3.13.1
+djangorestframework==3.14.0
 # can be removed when either 3.7 is not supported or once we upgrade Celery
 importlib_metadata==4.13.0 ; python_version<"3.8"
 pre-commit==3.2.2 ; python_version>="3.8"


### PR DESCRIPTION
[#184898692]

# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184898692

### Description of the Change

Django 4.2 is out, 4.0 is EOL. Update our dependencies accordingly.

### Verification Process

Locally everything seems good on 4.2. Is the matrix still green?