### PR TITLE
move common tracker settings out to a helper [#184871888]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Docker should also work but support is still in the experimental phases.
 
 The Donation Tracker adds a few configuration options.
 
-#### HAS_CELERY
+#### TRACKER_HAS_CELERY (deprecated alias: HAS_CELERY)
 
 Type: `bool`
 
@@ -48,15 +48,15 @@ Default: `False`
 Controls whether or not to try and use Celery. Certain tasks will be queued up as asynchronous if this setting is
 turned on, but it requires extra setup and for smaller events the performance impact is pretty minor.
 
-#### GIANTBOMB_API_KEY
+#### TRACKER_GIANTBOMB_API_KEY (deprecated alias: GIANTBOMB_API_KEY)
 
 Type: `str`
 
-Default: `None`
+Default: `''`
 
 Used for the `cache_giantbomb_info` management command. See that command for further details.
 
-#### PRIVACY_POLICY_URL
+#### TRACKER_PRIVACY_POLICY_URL (deprecated alias: PRIVACY_POLICY_URL)
 
 Type: `str`
 
@@ -64,7 +64,7 @@ Default: `''`
 
 If present, shown on the Donation page. You should probably have one of these, but this README is not legal advice.
 
-#### SWEEPSTAKES_URL
+#### TRACKER_SWEEPSTAKES_URL (deprecated alias: SWEEPSTAKES_URL)
 
 Type: `str`
 
@@ -126,6 +126,7 @@ Add the following apps to the `INSTALLED_APPS` section of `tracker_development/s
     'post_office',
     'paypal.standard.ipn',
     'tracker',
+    'rest_framework',
     'timezone_field',
     'ajax_select',
     'mptt',

--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -173,7 +173,7 @@ class TestDonorAdmin(TestCase):
         self.assertEqual(response.status_code, 200)
 
     @patch('tracker.tasks.post_donation_to_postbacks')
-    @override_settings(HAS_CELERY=True)
+    @override_settings(TRACKER_HAS_CELERY=True)
     def test_donation_postback_with_celery(self, task):
         self.client.force_login(self.super_user)
         response = self.client.post(
@@ -188,7 +188,7 @@ class TestDonorAdmin(TestCase):
         task.assert_not_called()
 
     @patch('tracker.tasks.post_donation_to_postbacks')
-    @override_settings(HAS_CELERY=False)
+    @override_settings(TRACKER_HAS_CELERY=False)
     def test_donation_postback_without_celery(self, task):
         self.client.force_login(self.super_user)
         response = self.client.post(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -6,12 +6,11 @@ import random
 
 import post_office.models
 import pytz
-from django.conf import settings
 from django.contrib.auth.models import Group, Permission, User
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 
-from tracker import models
+from tracker import models, settings
 
 from . import randgen
 from .util import long_ago_noon, today_noon, tomorrow_noon

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -69,8 +69,10 @@ CACHES = {
 }
 ASGI_APPLICATION = 'tests.routing.application'
 CHANNEL_LAYERS = {'default': {'BACKEND': 'channels.layers.InMemoryChannelLayer'}}
-SWEEPSTAKES_URL = 'https://example.com/'
 TEST_OUTPUT_DIR = 'test-results'
+
+TRACKER_SWEEPSTAKES_URL = 'https://example.com/sweepstakes'
+
 # uncomment this for some additional logging during testing
 # LOGGING = {
 #     'version': 1,

--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -2,12 +2,12 @@ import datetime
 import random
 
 import pytz
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 from django.urls import reverse
 
 import tracker.models as models
+from tracker import settings
 
 from . import randgen
 from .util import today_noon

--- a/tests/test_tracker_settings.py
+++ b/tests/test_tracker_settings.py
@@ -1,0 +1,38 @@
+from django.test import TestCase, override_settings
+
+from tracker import settings
+
+
+class TestTrackerSettings(TestCase):
+    @override_settings(TRACKER_SWEEPSTAKES_URL=None, TOTAL_NONSENSE='flibbertygibbit')
+    def test_defaults(self):
+        self.assertEqual(settings.TRACKER_PAGINATION_LIMIT, 500)
+        self.assertEqual(settings.TRACKER_HAS_CELERY, False)
+        self.assertEqual(settings.TRACKER_GIANTBOMB_API_KEY, '')
+        self.assertEqual(settings.TRACKER_LOGO, '')
+        self.assertEqual(settings.TRACKER_PRIVACY_POLICY_URL, '')
+        self.assertEqual(settings.TRACKER_SWEEPSTAKES_URL, '')
+        self.assertEqual(settings.TOTAL_NONSENSE, 'flibbertygibbit')
+
+    @override_settings(
+        HAS_CELERY=True,
+        GIANTBOMB_API_KEY='deadbeef',
+        PRIVACY_POLICY_URL='http://example.com/privacy',
+        TRACKER_SWEEPSTAKES_URL=None,
+        SWEEPSTAKES_URL='http://example.com/sweepstakes',
+    )
+    def test_deprecated_settings(self):
+        self.assertTrue(settings.TRACKER_HAS_CELERY, msg='HAS_CELERY')
+        self.assertEqual(
+            settings.TRACKER_GIANTBOMB_API_KEY, 'deadbeef', msg='GIANTBOMB_API_KEY'
+        )
+        self.assertEqual(
+            settings.TRACKER_PRIVACY_POLICY_URL,
+            'http://example.com/privacy',
+            msg='PRIVACY_POLICY_URL',
+        )
+        self.assertEqual(
+            settings.TRACKER_SWEEPSTAKES_URL,
+            'http://example.com/sweepstakes',
+            msg='SWEEPSTAKES_URL',
+        )

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,6 @@ import time
 import unittest
 
 import pytz
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.serializers.json import DjangoJSONEncoder
@@ -20,7 +19,7 @@ from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
-from tracker import models
+from tracker import models, settings
 
 
 def parse_test_mail(mail):

--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -1,1 +1,5 @@
+from .settings import TrackerSettings
+
+settings = TrackerSettings()
+
 default_app_config = 'tracker.apps.TrackerAppConfig'

--- a/tracker/admin/donation.py
+++ b/tracker/admin/donation.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from django.conf import settings
 from django.contrib.admin import register
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponseRedirect
@@ -8,7 +7,7 @@ from django.shortcuts import render
 from django.urls import path, reverse
 from django.utils.html import format_html
 
-from tracker import forms, logutil, models, search_filters, viewutil
+from tracker import forms, logutil, models, search_filters, settings, viewutil
 
 from .filters import DonationListFilter
 from .forms import DonationForm, DonorForm
@@ -140,7 +139,7 @@ class DonationAdmin(CustomModelAdmin):
 
         queryset = queryset.filter(transactionstate='COMPLETED')
         for donation in queryset:
-            if getattr(settings, 'HAS_CELERY', False):
+            if settings.TRACKER_HAS_CELERY:
                 tasks.post_donation_to_postbacks.delay(donation.id)
             else:
                 tasks.post_donation_to_postbacks(donation.id)

--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -18,7 +18,7 @@ from django.utils.html import format_html
 from django.views.decorators.csrf import csrf_protect
 
 import tracker.models.fields
-from tracker import forms, models, search_filters
+from tracker import forms, models, search_filters, settings
 
 from ..auth import send_registration_mail
 from .filters import RunListFilter
@@ -324,7 +324,6 @@ class EventAdmin(CustomModelAdmin):
     @csrf_protect
     @user_passes_test(lambda u: u.is_superuser)
     def diagnostics(request):
-        from django.conf import settings
         from post_office import mail
 
         ping_socket_url = (
@@ -373,7 +372,7 @@ class EventAdmin(CustomModelAdmin):
                 'ping_socket_url': ping_socket_url,
                 'celery_socket_url': celery_socket_url,
                 'storage_works': storage_works,
-                'HAS_CELERY': getattr(settings, 'HAS_CELERY', False),
+                'TRACKER_HAS_CELERY': settings.TRACKER_HAS_CELERY,
             },
         )
 

--- a/tracker/admin/prize.py
+++ b/tracker/admin/prize.py
@@ -238,7 +238,7 @@ class PrizeAdmin(CustomModelAdmin):
         for prize in queryset:
             from ..tasks import draw_prize
 
-            if getattr(settings, 'HAS_CELERY', False):
+            if settings.TRACKER_HAS_CELERY:
                 draw_prize.delay(prize.pk)
                 total_queued += 1
             else:

--- a/tracker/analytics/__init__.py
+++ b/tracker/analytics/__init__.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
-from django.conf import settings
-
+from tracker import settings
 from tracker.analytics.client import AnalyticsClient
 from tracker.analytics.events import AnalyticsEventTypes  # noqa: F401
 

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -1,14 +1,13 @@
 import enum
 from contextlib import contextmanager
 
-from django.conf import settings
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from tracker import logutil
+from tracker import logutil, settings
 from tracker.analytics import AnalyticsEventTypes, analytics
 from tracker.api.permissions import tracker_permission
 from tracker.api.serializers import DonationSerializer
@@ -18,8 +17,6 @@ from tracker.models import Donation
 CanChangeDonation = tracker_permission('tracker.change_donation')
 CanSendToReader = tracker_permission('tracker.send_to_reader')
 CanViewComments = tracker_permission('tracker.view_comments')
-
-DEFAULT_PAGINATION_LIMIT = 500
 
 
 class DonationProcessingActionTypes(str, enum.Enum):
@@ -142,7 +139,7 @@ class DonationViewSet(viewsets.GenericViewSet):
         If no IDs are provided, an empty list is returned.
         """
         donation_ids = self.request.query_params.getlist('ids[]')
-        limit = getattr(settings, 'TRACKER_PAGINATION_LIMIT', DEFAULT_PAGINATION_LIMIT)
+        limit = settings.TRACKER_PAGINATION_LIMIT
         if len(donation_ids) == 0:
             return Response([])
         if len(donation_ids) > limit:
@@ -163,7 +160,7 @@ class DonationViewSet(viewsets.GenericViewSet):
         not yet been processed in any way (e.g., are still PENDING for comment
         moderation), up to a maximum of TRACKER_PAGINATION_LIMIT donations.
         """
-        limit = getattr(settings, 'TRACKER_PAGINATION_LIMIT', DEFAULT_PAGINATION_LIMIT)
+        limit = settings.TRACKER_PAGINATION_LIMIT
         donations = (
             self.get_queryset()
             .filter(Q(commentstate='PENDING') | Q(readstate='PENDING'))
@@ -179,7 +176,7 @@ class DonationViewSet(viewsets.GenericViewSet):
         been flagged for head review (e.g., are FLAGGED for read moderation),
         up to a maximum of TRACKER_PAGINATION_LIMIT donations.
         """
-        limit = getattr(settings, 'TRACKER_PAGINATION_LIMIT', DEFAULT_PAGINATION_LIMIT)
+        limit = settings.TRACKER_PAGINATION_LIMIT
         donations = (
             self.get_queryset()
             .filter(Q(commentstate='APPROVED') & Q(readstate='FLAGGED'))
@@ -195,7 +192,7 @@ class DonationViewSet(viewsets.GenericViewSet):
         been approved and sent to the reader (e.g., have a READY readstate),
         up to a maximum of TRACKER_PAGINATION_LIMIT donations.
         """
-        limit = getattr(settings, 'TRACKER_PAGINATION_LIMIT', DEFAULT_PAGINATION_LIMIT)
+        limit = settings.TRACKER_PAGINATION_LIMIT
         donations = (
             self.get_queryset()
             .filter(Q(commentstate='APPROVED') & Q(readstate='READY'))

--- a/tracker/auth.py
+++ b/tracker/auth.py
@@ -1,10 +1,11 @@
 import post_office.mail
 import post_office.models
-from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+
+from tracker import settings
 
 from . import mailutil, viewutil
 

--- a/tracker/commandutil.py
+++ b/tracker/commandutil.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 
 
 class TrackerCommand(BaseCommand):
-    requires_system_checks = False
+    requires_system_checks = []
 
     def __init__(self, *args, **kwargs):
         super(TrackerCommand, self).__init__(*args, **kwargs)

--- a/tracker/management/commands/cache_giantbomb_info.py
+++ b/tracker/management/commands/cache_giantbomb_info.py
@@ -6,15 +6,9 @@ import time
 import urllib
 
 import dateutil.parser
-from django.conf import settings
 from django.core.management.base import CommandError
 
-import tracker.commandutil as commandutil
-import tracker.models as models
-import tracker.util as util
-import tracker.viewutil as viewutil
-
-_settingsKey = 'GIANTBOMB_API_KEY'
+from tracker import commandutil, models, settings, util, viewutil
 
 
 class Command(commandutil.TrackerCommand):
@@ -29,9 +23,7 @@ class Command(commandutil.TrackerCommand):
         parser.add_argument(
             '-k',
             '--api-key',
-            help='specify the api key to use (You can also set "{0}" in settings.py)'.format(
-                _settingsKey
-            ),
+            help='specify the api key to use (You can also set "TRACKER_GIANTBOMB_API_KEY" in settings.py)',
             required=False,
             default=None,
         )
@@ -335,13 +327,11 @@ class Command(commandutil.TrackerCommand):
 
         self.apiKey = options['api_key']
         if options['api_key'] is None:
-            self.apiKey = getattr(settings, _settingsKey, None)
+            self.apiKey = settings.TRACKER_GIANTBOMB_API_KEY
 
         if not self.apiKey:
             raise CommandError(
-                'No API key was supplied, and {0} was not set in settings.py, cannot continue.'.format(
-                    _settingsKey
-                )
+                'No API key was supplied, and TRACKER_GIANTBOMB_API_KEY was not set in settings.py, cannot continue.'
             )
 
         filterRegex = None
@@ -423,7 +413,7 @@ class Command(commandutil.TrackerCommand):
                                 run.giantbomb_id, cleanedName
                             )
                         )
-                    self.message('Searching for {0}'.format(cleanedName))
+                    self.message('Searching for "{0}"'.format(cleanedName))
                     self.message('(url={0})'.format(searchUrl), 2)
                     data = json.loads(urllib.request.urlopen(searchUrl).read())
                     lastApiCallTime = datetime.datetime.now()
@@ -431,7 +421,7 @@ class Command(commandutil.TrackerCommand):
                     if self.response_good(data):
                         self.process_search(run, cleanedName, data['results'])
             else:
-                self.message('Run {0} does not match filters.'.format(run.name), 2)
+                self.message('Run "{0}" does not match filters.'.format(run.name), 2)
 
         if self.foundAmbigiousSearched:
             self.message(

--- a/tracker/models/prize.py
+++ b/tracker/models/prize.py
@@ -2,7 +2,6 @@ import datetime
 from decimal import Decimal
 
 import pytz
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites import shortcuts as sites
 from django.core.exceptions import ImproperlyConfigured, ValidationError
@@ -12,7 +11,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.urls import reverse
 
-from tracker import util
+from tracker import settings, util
 from tracker.models import Donation, Event, SpeedRun
 from tracker.validators import nonzero, positive
 
@@ -216,9 +215,9 @@ class Prize(models.Model):
         return str(self.name)
 
     def clean(self, winner=None):
-        if not getattr(settings, 'SWEEPSTAKES_URL', None):
+        if not settings.TRACKER_SWEEPSTAKES_URL:
             raise ValidationError(
-                'Cannot create prizes without a SWEEPSTAKES_URL in settings'
+                'Cannot create prizes without a TRACKER_SWEEPSTAKES_URL in settings'
             )
         if self.maxmultiwin > 1 and self.category is not None:
             raise ValidationError(
@@ -257,9 +256,9 @@ class Prize(models.Model):
             )
 
     def save(self, *args, **kwargs):
-        if not getattr(settings, 'SWEEPSTAKES_URL', None):
+        if not settings.TRACKER_SWEEPSTAKES_URL:
             raise ImproperlyConfigured(
-                'Cannot create prizes without a SWEEPSTAKES_URL in settings'
+                'Cannot create prizes without a TRACKER_SWEEPSTAKES_URL in settings'
             )
 
         using = kwargs.get('using', None)

--- a/tracker/settings.py
+++ b/tracker/settings.py
@@ -1,0 +1,103 @@
+from django.conf import settings
+from django.core.checks import Error, Warning, register
+
+
+# noinspection PyPep8Naming
+class TrackerSettings(object):
+    @property
+    def TRACKER_HAS_CELERY(self):
+        return getattr(
+            settings, 'TRACKER_HAS_CELERY', getattr(settings, 'HAS_CELERY', False)
+        )
+
+    @property
+    def TRACKER_GIANTBOMB_API_KEY(self):
+        return getattr(
+            settings,
+            'TRACKER_GIANTBOMB_API_KEY',
+            getattr(settings, 'GIANTBOMB_API_KEY', ''),
+        )
+
+    @property
+    def TRACKER_PRIVACY_POLICY_URL(self):
+        return getattr(
+            settings,
+            'TRACKER_PRIVACY_POLICY_URL',
+            getattr(settings, 'PRIVACY_POLICY_URL', ''),
+        )
+
+    @property
+    def TRACKER_SWEEPSTAKES_URL(self):
+        # TODO: fix the test suite so that this can be more canonical
+        return (
+            getattr(settings, 'TRACKER_SWEEPSTAKES_URL', '')
+            or getattr(settings, 'SWEEPSTAKES_URL', '')
+            or ''
+        )
+
+    @property
+    def TRACKER_PAGINATION_LIMIT(self):
+        return getattr(settings, 'TRACKER_PAGINATION_LIMIT', 500)
+
+    @property
+    def TRACKER_LOGO(self):
+        return getattr(settings, 'TRACKER_LOGO', '')
+
+    # pass everything else through for convenience
+    def __getattr__(self, item):
+        return getattr(settings, item)
+
+
+@register
+def tracker_settings_checks(app_configs, **kwargs):
+    errors = []
+    if hasattr(settings, 'HAS_CELERY'):
+        errors.append(
+            Warning(
+                'HAS_CELERY is deprecated, use TRACKER_HAS_CELERY instead',
+                id='tracker.W100',
+            )
+        )
+    if type(TrackerSettings().TRACKER_HAS_CELERY) != bool:
+        errors.append(Error('TRACKER_HAS_CELERY should be a bool', id='tracker.E100'))
+    if hasattr(settings, 'GIANTBOMB_API_KEY'):
+        errors.append(
+            Warning(
+                'GIANTBOMB_API_KEY is deprecated, use TRACKER_GIANTBOMB_API_KEY instead',
+                id='tracker.W101',
+            )
+        )
+    if type(TrackerSettings().TRACKER_GIANTBOMB_API_KEY) != str:
+        errors.append(
+            Error('TRACKER_GIANTBOMB_API_KEY should be a string', id='tracker.E101')
+        )
+    # TODO: validate Giant Bomb key?
+    if hasattr(settings, 'PRIVACY_POLICY_URL'):
+        errors.append(
+            Warning(
+                'PRIVACY_POLICY_URL is deprecated, use TRACKER_PRIVACY_POLICY_URL instead',
+                id='tracker.W102',
+            )
+        )
+    if type(TrackerSettings().TRACKER_PRIVACY_POLICY_URL) != str:
+        errors.append(
+            Error('TRACKER_PRIVACY_POLICY_URL should be a string', id='tracker.E102')
+        )
+    if hasattr(settings, 'SWEEPSTAKES_URL'):
+        errors.append(
+            Warning(
+                'SWEEPSTAKES_URL is deprecated, use TRACKER_SWEEPSTAKES_URL instead',
+                id='tracker.W103',
+            )
+        )
+    if type(TrackerSettings().TRACKER_SWEEPSTAKES_URL) != str:
+        errors.append(
+            Error('TRACKER_SWEEPSTAKES_URL should be a string', id='tracker.E103')
+        )
+    if type(TrackerSettings().TRACKER_PAGINATION_LIMIT) != int:
+        errors.append(
+            Error('TRACKER_PAGINATION_LIMIT should be an integer', id='tracker.E104')
+        )
+    if type(TrackerSettings().TRACKER_LOGO) != str:
+        errors.append(Error('TRACKER_LOGO should be a string', id='tracker.E105'))
+    return errors

--- a/tracker/templates/admin/tracker/diagnostics.html
+++ b/tracker/templates/admin/tracker/diagnostics.html
@@ -117,7 +117,7 @@
     <div id="ping_counter"></div>
     <div id="ping_timestamp"></div>
     <div style="grid-column: 1">Test Celery Websocket</div>
-    {% if not HAS_CELERY %}
+    {% if not TRACKER_HAS_CELERY %}
       <div>Celery Not Configured</div>
     {% else %}
       <div>

--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -46,7 +46,7 @@
                     {% if event.short %}
                         <li><a href="{% url 'tracker:index' event=event.short %}">{% trans "Home" %}</a></li>
                         <li><a href="{% url 'tracker:runindex' event=event.short %}">{% trans "Runs" %}</a></li>
-                        {% if settings.SWEEPSTAKES_URL %}
+                        {% if settings.TRACKER_SWEEPSTAKES_URL %}
                             <li><a href="{% url 'tracker:prizeindex' event=event.short %}">{% trans "Prizes" %}</a></li>
                         {% endif %}
                         <li><a href="{% url 'tracker:bidindex' event=event.short %}">{% trans "Bids" %}</a></li>
@@ -56,7 +56,7 @@
                     {% else %}
                         <li><a href="{% url 'tracker:index_all' %}">{% trans "Home" %}</a></li>
                         <li><a href="{% url 'tracker:runindex' %}">{% trans "Runs" %}</a></li>
-                        {% if settings.SWEEPSTAKES_URL %}
+                        {% if settings.TRACKER_SWEEPSTAKES_URL %}
                             <li><a href="{% url 'tracker:prizeindex' %}">{% trans "Prizes" %}</a></li>
                         {% endif %}
                         <li><a href="{% url 'tracker:bidindex' %}">{% trans "Bids" %}</a></li>

--- a/tracker/templates/tracker/index.html
+++ b/tracker/templates/tracker/index.html
@@ -26,7 +26,7 @@
         <p class="center-block"><br /></p>
         {% if event.short %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:runindex' event=event.short %}">{% trans "View Runs" %} ({{ count.runs }})</a></p>
-            {% if settings.SWEEPSTAKES_URL %}
+            {% if settings.TRACKER_SWEEPSTAKES_URL %}
                 <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:prizeindex' event=event.short %}">{% trans "View Prizes" %} ({{ count.prizes }})</a></p>
             {% endif %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:bidindex' event=event.short %}">{% trans "View Bids" %} ({{ count.bids }})</a></p>
@@ -35,7 +35,7 @@
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:donationindex' event=event.short %}">{% trans "View Donations" %} ({{ agg.count }})</a></p>
         {% else %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:runindex' %}">{% trans "View Runs" %} ({{ count.runs }})</a></p>
-            {% if settings.SWEEPSTAKES_URL %}
+            {% if settings.TRACKER_SWEEPSTAKES_URL %}
                 <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:prizeindex' %}">{% trans "View Prizes" %} ({{ count.prizes }})</a></p>
             {% endif %}
             <p class="center-block"><a class="btn btn-default btn-block" href="{% url 'tracker:bidindex' %}">{% trans "View Bids" %} ({{ count.bids }})</a></p>

--- a/tracker/templates/tracker/prize.html
+++ b/tracker/templates/tracker/prize.html
@@ -5,9 +5,9 @@
 {% block title %}{% trans "Prize Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
-    {% if settings.SWEEPSTAKES_URL %}
+    {% if settings.TRACKER_SWEEPSTAKES_URL %}
       <div>No donation necessary for a chance to win.
-        See <a href="{{ settings.SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
+        See <a href="{{ settings.TRACKER_SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
         details and instructions.
       </div>
     {% endif %}

--- a/tracker/templates/tracker/prizeindex.html
+++ b/tracker/templates/tracker/prizeindex.html
@@ -15,9 +15,9 @@
 
     {% include "tracker/partials/event_links.html" with index='tracker:prizeindex' %}
 
-    {% if settings.SWEEPSTAKES_URL %}
+    {% if settings.TRACKER_SWEEPSTAKES_URL %}
       <div class="text-center">No donation necessary for a chance to win.
-        See <a href="{{ settings.SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
+        See <a href="{{ settings.TRACKER_SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
         details and instructions.
       </div>
     {% endif %}

--- a/tracker/ui/views.py
+++ b/tracker/ui/views.py
@@ -1,7 +1,6 @@
 import json
 from decimal import Decimal
 
-from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.models import AnonymousUser
 from django.core import serializers
@@ -12,7 +11,7 @@ from django.urls import reverse
 from django.views.decorators.cache import cache_page, never_cache
 from django.views.decorators.csrf import csrf_protect
 
-from tracker import search_filters, viewutil
+from tracker import search_filters, settings, viewutil
 from tracker.decorators import no_querystring
 from tracker.models import Event
 from tracker.views.donateviews import process_form
@@ -21,8 +20,8 @@ from tracker.views.donateviews import process_form
 def constants(user=None):
     user = user or AnonymousUser
     return {
-        'PRIVACY_POLICY_URL': getattr(settings, 'PRIVACY_POLICY_URL', ''),
-        'SWEEPSTAKES_URL': getattr(settings, 'SWEEPSTAKES_URL', ''),
+        'PRIVACY_POLICY_URL': settings.TRACKER_PRIVACY_POLICY_URL,
+        'SWEEPSTAKES_URL': settings.TRACKER_SWEEPSTAKES_URL,
         'ANALYTICS_URL': reverse('tracker:analytics'),
         'API_ROOT': reverse('tracker:api_v1:root'),
         'APIV2_ROOT': reverse('tracker:api-root'),
@@ -151,9 +150,9 @@ def donate(request, event):
     )
 
     # You have to try really hard to get into this state so it's reasonable to blow up spectacularly when it happens
-    if prizes and not getattr(settings, 'SWEEPSTAKES_URL', None):
+    if prizes and not settings.TRACKER_SWEEPSTAKES_URL:
         raise ImproperlyConfigured(
-            'There are prizes available but no SWEEPSTAKES_URL is set'
+            'There are prizes available but no TRACKER_SWEEPSTAKES_URL is set'
         )
 
     bidsArray = [bid_info(o) for o in bids]

--- a/tracker/views/api.py
+++ b/tracker/views/api.py
@@ -1,6 +1,5 @@
 import json
 
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.decorators import permission_required, user_passes_test
 from django.contrib.auth.models import AnonymousUser
@@ -33,7 +32,7 @@ from django.views.decorators.cache import cache_page, never_cache
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_GET, require_POST
 
-from tracker import logutil, search_filters
+from tracker import logutil, search_filters, settings
 from tracker.models import (
     Ad,
     Bid,
@@ -395,10 +394,10 @@ def search(request):
             raise PermissionDenied
 
     offset = int(single(search_params, 'offset', 0))
-    limit = getattr(settings, 'TRACKER_PAGINATION_LIMIT', DEFAULT_PAGINATION_LIMIT)
+    limit = settings.TRACKER_PAGINATION_LIMIT
     limit_param = int(single(search_params, 'limit', limit))
     if limit_param > limit:
-        raise ValueError('limit can not be above %d' % limit)
+        raise ValueError(f'limit can not be above {limit}')
     if limit_param < 1:
         raise ValueError('limit must be at least 1')
     limit = min(limit, limit_param)

--- a/tracker/views/common.py
+++ b/tracker/views/common.py
@@ -4,7 +4,6 @@ import sys
 import time
 
 import django
-from django.conf import settings
 from django.db import connection
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -13,6 +12,7 @@ from django.utils.cache import patch_cache_control
 
 import tracker.models
 import tracker.viewutil as viewutil
+from tracker import settings
 
 
 def dv():
@@ -60,9 +60,8 @@ def tracker_context(request, qdict=None):
             'starttime': starttime,
             'events': tracker.models.Event.objects.all(),
             'settings': {
-                'GOOGLE_ANALYTICS': getattr(settings, 'GOOGLE_ANALYTICS', ''),
-                'SWEEPSTAKES_URL': getattr(settings, 'SWEEPSTAKES_URL', ''),
-                'TRACKER_LOGO': getattr(settings, 'TRACKER_LOGO', ''),
+                'TRACKER_SWEEPSTAKES_URL': settings.TRACKER_SWEEPSTAKES_URL,
+                'TRACKER_LOGO': settings.TRACKER_LOGO,
             },
         }
     )

--- a/tracker/views/public.py
+++ b/tracker/views/public.py
@@ -1,14 +1,13 @@
 import json
 
 import django.core.paginator as paginator
-from django.conf import settings
 from django.db.models import Avg, Count, F, FloatField, Max, Sum
 from django.db.models.functions import Cast, Coalesce
 from django.http import Http404, HttpResponse
 from django.views.decorators.cache import cache_page
 
 from tracker import search_filters as filters
-from tracker import util, viewutil
+from tracker import settings, util, viewutil
 from tracker.models import (
     Bid,
     Donation,
@@ -488,7 +487,7 @@ def run_detail(request, pk):
 
 @cache_page(60)
 def prizeindex(request, event=None):
-    if not getattr(settings, 'SWEEPSTAKES_URL', None):
+    if not settings.TRACKER_SWEEPSTAKES_URL:
         raise Http404
 
     event = viewutil.get_event(event)
@@ -516,7 +515,7 @@ def prizeindex(request, event=None):
 
 @cache_page(60)
 def prize_detail(request, pk):
-    if not getattr(settings, 'SWEEPSTAKES_URL', None):
+    if not settings.TRACKER_SWEEPSTAKES_URL:
         raise Http404
     try:
         prize = Prize.objects.get(pk=pk)

--- a/tracker/viewutil.py
+++ b/tracker/viewutil.py
@@ -2,14 +2,13 @@ import operator
 import re
 from functools import reduce
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404
 from django.urls import reverse
 
-from tracker import search_filters
+from tracker import search_filters, settings
 from tracker.models import Donor, Event, Log
 
 


### PR DESCRIPTION

# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184871888

### Description of the Change

Rather than sprinkle `getattr` all over the place for things that have default values, this packages those up into a helper class.

As a bonus is migrates/warns about old settings that should be prefixed to avoid potential future collisions.

Also, apparently the Giant Bomb command was busted in Django 4.x because of a change to the checks framework, so I addressed that as well.

### Verification Process

Most of the references are internal so the test suite catches them anyway, but some of them are referenced in templates and therefore had to be checked by hand.

`TRACKER_SWEEPSTAKES_URL` in particular is a bit weird because currently the test suite provides a value, which made testing the default require doing something slightly different in the settings fetcher. It acts properly if you're doing things in a normal fashion, so I'm willing to let it slide for now.