### PR TITLE
Feedback and improvements on new Read Donations page

### DIFF
--- a/bundles/processing/CreateEditDonationGroupModal.mod.css
+++ b/bundles/processing/CreateEditDonationGroupModal.mod.css
@@ -1,3 +1,3 @@
 .modal {
-  min-width: 440px;
+  min-width: 540px;
 }

--- a/bundles/processing/CreateEditDonationGroupModal.tsx
+++ b/bundles/processing/CreateEditDonationGroupModal.tsx
@@ -37,22 +37,34 @@ interface CreateEditDonationGroupModalProps {
 
 export default function CreateEditDonationGroupModal(props: CreateEditDonationGroupModalProps) {
   const { group, onClose } = props;
+  const isEditing = group != null;
+
+  const newId = React.useId();
   const [name, setName] = React.useState(group?.name || 'New Group');
   const [color, setColor] = React.useState<GroupColorItem>(() => {
-    return GROUP_COLOR_ITEMS.find(g => g.name === group?.name) || GROUP_COLOR_ITEMS[0];
+    return GROUP_COLOR_ITEMS.find(item => item.value === group?.color) || GROUP_COLOR_ITEMS[0];
   });
-  const { createDonationGroup, updateDonationGroup } = useDonationGroupsStore();
+
+  const { createDonationGroup, deleteDonationGroup, updateDonationGroup } = useDonationGroupsStore();
 
   function handleCreate() {
-    const action = group != null ? updateDonationGroup : createDonationGroup;
-    action({ name, color: color.value });
+    const action = isEditing ? updateDonationGroup : createDonationGroup;
+    action({ id: isEditing ? group.id : newId, name, color: color.value });
+    onClose();
+  }
+
+  function handleDelete() {
+    if (group == null) return;
+    deleteDonationGroup(group.id);
     onClose();
   }
 
   return (
     <Card floating className={styles.modal}>
       <Stack spacing="space-lg">
-        <Header tag="h1">Create Donation Group</Header>
+        <Header tag="h1">{isEditing ? 'Edit Donation Group' : 'Create Donation Group'}</Header>
+        <Tabs.Tab color={color.value} label={name || '\b'} badge={15} selected></Tabs.Tab>
+        <Spacer />
         <FormControl label="Group Name">
           <TextInput
             value={name}
@@ -68,9 +80,16 @@ export default function CreateEditDonationGroupModal(props: CreateEditDonationGr
             selectedItem={color}
           />
         </FormControl>
-        <Button onClick={handleCreate}>Create Group</Button>
-        <Spacer />
-        <Tabs.Tab color={color.value} label={name || '\b'} badge={15} selected></Tabs.Tab>
+        <Stack direction="horizontal" justify="space-between">
+          <Button variant="primary" onClick={handleCreate}>
+            {isEditing ? 'Save Group' : 'Create Group'}
+          </Button>
+          {isEditing ? (
+            <Button variant="danger/outline" onClick={handleDelete}>
+              Delete Group
+            </Button>
+          ) : null}
+        </Stack>
       </Stack>
     </Card>
   );

--- a/bundles/processing/PrimaryNavPopout.mod.css
+++ b/bundles/processing/PrimaryNavPopout.mod.css
@@ -1,3 +1,3 @@
 .container {
-  width: 500px;
+  min-width: 580px;
 }

--- a/bundles/processing/PrimaryNavPopout.tsx
+++ b/bundles/processing/PrimaryNavPopout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useQuery } from 'react-query';
-import { Anchor, Button, Card, Header, Spacer, Stack, Text, usePopout } from '@spyrothon/sparx';
+import { Anchor, Button, Card, FormSwitch, Header, Spacer, Stack, Text, usePopout } from '@spyrothon/sparx';
 
 import { useConstants } from '@common/Constants';
 import APIClient from '@public/apiv2/APIClient';
@@ -8,6 +8,7 @@ import Bars from '@uikit/icons/Bars';
 
 import { loadMe, useMe } from './AuthStore';
 import { ThemeButton } from './Theming';
+import { setUseRelativeTimestamps, useUserPreferencesStore } from './UserPreferencesStore';
 
 import styles from './PrimaryNavPopout.mod.css';
 
@@ -61,6 +62,27 @@ function CurrentUser() {
   );
 }
 
+function RelativeTimeSwitch() {
+  const useRelativeTimestamps = useUserPreferencesStore(state => state.useRelativeTimestamps);
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setUseRelativeTimestamps(event.target.checked);
+  }
+
+  return (
+    <FormSwitch
+      label="Use Relative Timestamps"
+      note={
+        <>
+          {new Date().toDateString()} vs {'"1 hour ago"'}
+        </>
+      }
+      checked={useRelativeTimestamps}
+      onChange={handleChange}
+    />
+  );
+}
+
 interface PrimaryNavPopoutProps {
   eventId: string;
 }
@@ -72,12 +94,16 @@ export function PrimaryNavPopout(props: PrimaryNavPopoutProps) {
 
   return (
     <Card floating className={styles.container}>
-      <Stack direction="horizontal" spacing="space-xl">
+      <Stack direction="horizontal" spacing="space-xl" justify="stretch">
         <Stack spacing="space-lg">
           <CurrentUser />
           <Anchor href={NavRoutes.SELF_SERVICE}>Self Service</Anchor>
           <Anchor href={NavRoutes.LOGOUT}>Logout</Anchor>
           <Spacer />
+          <Header tag="h2" variant="header-md/normal">
+            Settings
+          </Header>
+          <RelativeTimeSwitch />
           <ThemeButton />
         </Stack>
         <Stack spacing="space-lg">

--- a/bundles/processing/Processing.mod.css
+++ b/bundles/processing/Processing.mod.css
@@ -14,7 +14,7 @@
   overflow-y: scroll;
 }
 
-.partitionSelector > * {
+.partitionSelector.partitionSelector > * {
   /* Ensure the form inputs look balanced and don't squish the text */
   flex: 1 1 min-content;
 }

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -318,7 +318,7 @@ function FilterGroupTab(props: FilterGroupTabProps) {
       onClick={handleSelect}
       selected={isSelected}
       badge={
-        <Stack direction="horizontal">
+        <Stack direction="horizontal" spacing="space-lg">
           {item.group != null && active ? (
             <Clickable onClick={handleEdit}>
               <Dots />

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Card,
   Checkbox,
+  Clickable,
   Header,
   openModal,
   openPopout,
@@ -17,6 +18,7 @@ import {
   Tabs,
   Tag,
   Text,
+  useHoverFocus,
   useTooltip,
 } from '@spyrothon/sparx';
 
@@ -32,11 +34,12 @@ import Plus from '@uikit/icons/Plus';
 
 import ConnectionStatus from './ConnectionStatus';
 import CreateEditDonationGroupModal from './CreateEditDonationGroupModal';
-import useDonationGroupsStore, { useGroupsForDonation } from './DonationGroupsStore';
-import { loadDonations, useDonation, useDonations, useDonationsInState } from './DonationsStore';
+import useDonationGroupsStore, { DonationGroup, useGroupsForDonation } from './DonationGroupsStore';
+import useDonationsStore, { loadDonations, useDonation, useDonations, useDonationsInState } from './DonationsStore';
 import getEstimatedReadingTime from './getEstimatedReadingTIme';
 import MutationButton from './MutationButton';
 import ProcessingSidebar from './ProcessingSidebar';
+import RelativeTime from './RelativeTime';
 import { AdminRoutes, useAdminRoute } from './Routes';
 
 import donationStyles from './DonationRow.mod.css';
@@ -49,7 +52,7 @@ interface AddToGroupPopoutProps {
 function AddToGroupPopout(props: AddToGroupPopoutProps) {
   const { donationId } = props;
   const donation = useDonation(donationId);
-  const { groups, addDonationToGroup, removeDonationFromGroup } = useDonationGroupsStore();
+  const { groups, addDonationToGroup, removeDonationFromGroup, removeDonationFromAllGroups } = useDonationGroupsStore();
 
   const amount = CurrencyUtils.asCurrency(donation.amount);
   const donationLink = useAdminRoute(AdminRoutes.DONATION(donation.id));
@@ -62,9 +65,19 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
   const unpin = useMutation(() => APIClient.unpinDonation(`${donation.id}`), {
     onSuccess: donation => loadDonations([donation]),
   });
+  const block = useMutation(() => APIClient.denyDonationComment(`${donation.id}`), {
+    onSuccess: donation => {
+      loadDonations([donation]);
+      removeDonationFromAllGroups(donation.id);
+    },
+  });
 
   function handlePinChange() {
     donation.pinned ? unpin.mutate() : pin.mutate();
+  }
+
+  function handleBlock() {
+    block.mutate();
   }
 
   return (
@@ -100,8 +113,12 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
           function handleGroupChange() {
             isIncluded ? removeDonationFromGroup(group.name, donation.id) : addDonationToGroup(group.name, donation.id);
           }
-          return <Checkbox key={group.name} label={group.name} checked={isIncluded} onChange={handleGroupChange} />;
+          return <Checkbox key={group.id} label={group.name} checked={isIncluded} onChange={handleGroupChange} />;
         })}
+        <Spacer size="space-md" />
+        <Button variant="danger/outline" onClick={handleBlock}>
+          Block
+        </Button>
       </Stack>
     </Card>
   );
@@ -152,13 +169,15 @@ function DonationRow(props: DonationRowProps) {
             </Text>
             <Stack direction="horizontal" spacing="space-sm" align="center">
               {groups.map(group => (
-                <Tag key={group.name} color={group.color}>
+                <Tag key={group.id} color={group.color}>
                   {group.name}
                 </Tag>
               ))}
               {groups.length > 0 ? ' · ' : null}
               <Text variant="text-sm/normal">
-                <span>{timestamp.toFormat('yyyy-MM-dd hh:mm:ss a')}</span>
+                <span>
+                  <RelativeTime time={timestamp.toJSDate()} />
+                </span>
                 {' · '}
                 {readingTime} to read
               </Text>
@@ -263,10 +282,54 @@ function useFilteredDonationGroups(donations: Donation[]) {
 }
 
 interface FilterGroupItem {
+  id: string;
   label: string;
   count: number;
   color: TabColor;
   donationIds: number[];
+  group?: DonationGroup;
+}
+
+interface FilterGroupTabProps {
+  item: FilterGroupItem;
+  isSelected: boolean;
+  onSelected: (name: string) => void;
+}
+
+function FilterGroupTab(props: FilterGroupTabProps) {
+  const { item, isSelected, onSelected } = props;
+
+  const [hoverFocusProps, active] = useHoverFocus();
+
+  function handleSelect() {
+    onSelected(item.id);
+  }
+
+  function handleEdit(event: React.MouseEvent) {
+    event.stopPropagation();
+    openModal(modalProps => <CreateEditDonationGroupModal group={item.group} {...modalProps} />);
+  }
+
+  return (
+    <Tabs.Tab
+      key={item.label}
+      label={item.label}
+      color={item.color}
+      onClick={handleSelect}
+      selected={isSelected}
+      badge={
+        <Stack direction="horizontal">
+          {item.group != null && active ? (
+            <Clickable onClick={handleEdit}>
+              <Dots />
+            </Clickable>
+          ) : null}
+          {item.count}
+        </Stack>
+      }
+      {...hoverFocusProps}
+    />
+  );
 }
 
 export default function ReadDonations() {
@@ -284,24 +347,28 @@ export default function ReadDonations() {
 
   const filterTabItems: FilterGroupItem[] = [
     {
+      id: 'all',
       label: 'All Donations',
       count: donations.length,
       donationIds: donations.map(donation => donation.id),
       color: 'default',
     },
     {
+      id: 'no-comment',
       label: 'No Comment',
       count: noCommentDonationIds.length,
       donationIds: noCommentDonationIds,
       color: 'default',
     },
     {
+      id: 'anonymous',
       label: 'Anonymous',
       count: anonymousDonationIds.length,
       donationIds: anonymousDonationIds,
       color: 'default',
     },
     {
+      id: 'pinned',
       label: 'Pinned',
       count: pinnedDonationIds.length,
       donationIds: pinnedDonationIds,
@@ -310,34 +377,40 @@ export default function ReadDonations() {
   ];
 
   const groupTabItems: FilterGroupItem[] = groups.map(group => ({
+    id: group.id,
     label: group.name,
     count: group.donationIds.length,
     color: group.color,
     donationIds: group.donationIds,
+    group,
   }));
-  const [selectedGroupName, setSelectedGroupName] = React.useState<string>(filterTabItems[0].label);
+  const [selectedGroupId, setSelectedGroupId] = React.useState<string>(filterTabItems[0].label);
   const selectedGroup =
-    filterTabItems.find(tab => tab.label === selectedGroupName) ||
-    groupTabItems.find(tab => tab.label === selectedGroupName) ||
+    filterTabItems.find(tab => tab.id === selectedGroupId) ||
+    groupTabItems.find(tab => tab.id === selectedGroupId) ||
     filterTabItems[0];
 
   // When the page first loads, force a refresh of all donations that have been
-  // saved into groups to ensure they are present and up-to-date.
+  // saved into groups to ensure they are present and up-to-date, then filter
+  // out any donations that were in groups but have since been processed.
   React.useEffect(() => {
     (async () => {
-      const { groups } = useDonationGroupsStore.getState();
-      const ids = new Set<string>();
+      const { groups, removeDonationFromAllGroups } = useDonationGroupsStore.getState();
+      const ids = new Set<number>();
       for (const group of Object.values(groups)) {
-        group.donationIds.forEach(id => ids.add(String(id)));
+        group.donationIds.forEach(id => ids.add(id));
       }
-      const donations = await APIClient.getDonations(Array.from(ids));
+      const donations = await APIClient.getDonations(Array.from(ids).map(String));
       loadDonations(donations);
+
+      const { ready } = useDonationsStore.getState();
+      for (const id of ids) {
+        if (!ready.has(id)) {
+          removeDonationFromAllGroups(id);
+        }
+      }
     })();
   }, []);
-
-  function getGroupSelectHandler(groupName: string) {
-    return () => setSelectedGroupName(groupName);
-  }
 
   return (
     <div className={styles.container}>
@@ -346,13 +419,11 @@ export default function ReadDonations() {
         <Tabs.Group>
           <Tabs.Header label="Filters" />
           {filterTabItems.map(tab => (
-            <Tabs.Tab
+            <FilterGroupTab
               key={tab.label}
-              label={tab.label}
-              color={tab.color}
-              onClick={getGroupSelectHandler(tab.label)}
-              selected={selectedGroupName === tab.label}
-              badge={tab.count}
+              item={tab}
+              isSelected={selectedGroupId === tab.id}
+              onSelected={setSelectedGroupId}
             />
           ))}
           <Tabs.Header
@@ -364,19 +435,17 @@ export default function ReadDonations() {
             }
           />
           {groupTabItems.map(tab => (
-            <Tabs.Tab
+            <FilterGroupTab
               key={tab.label}
-              label={tab.label}
-              color={tab.color}
-              onClick={getGroupSelectHandler(tab.label)}
-              selected={selectedGroupName === tab.label}
-              badge={tab.count}
+              item={tab}
+              isSelected={selectedGroupId === tab.id}
+              onSelected={setSelectedGroupId}
             />
           ))}
         </Tabs.Group>
       </ProcessingSidebar>
       <main className={styles.main}>
-        <DonationList key={selectedGroupName} donationIds={selectedGroup.donationIds} />
+        <DonationList key={selectedGroupId} donationIds={selectedGroup.donationIds} />
       </main>
     </div>
   );

--- a/bundles/processing/RelativeTime.tsx
+++ b/bundles/processing/RelativeTime.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import { useUserPreferencesStore } from './UserPreferencesStore';
+
+const timeFormatter = new Intl.RelativeTimeFormat('en', { style: 'narrow' });
+
+const UPDATE_INTERVAL = 5 * 1000;
+
+function getRelativeTimeString(diff: number, formatter: Intl.RelativeTimeFormat) {
+  if (diff > -5) {
+    return 'just now';
+  } else if (diff <= -4000) {
+    return formatter.format(Math.round(diff / 3600), 'hours');
+  } else if (diff <= -90) {
+    return formatter.format(Math.round(diff / 60), 'minutes');
+  } else {
+    return formatter.format(Math.round(diff), 'seconds');
+  }
+}
+
+interface RelativeTimeProps {
+  time: Date;
+  now?: Date;
+  formatter?: Intl.RelativeTimeFormat;
+}
+
+export default function RelativeTime(props: RelativeTimeProps) {
+  const { time, now, formatter = timeFormatter } = props;
+
+  const useRelativeTimestamps = useUserPreferencesStore(state => state.useRelativeTimestamps);
+
+  const diff = -((now ?? new Date()).getTime() - time.getTime()) / 1000;
+  const [timeString, setTimeString] = React.useState(() => getRelativeTimeString(diff, formatter));
+
+  React.useEffect(() => {
+    if (!useRelativeTimestamps) return;
+
+    function update() {
+      const realNow = now ?? new Date();
+      const diff = -(realNow.getTime() - time.getTime()) / 1000;
+      setTimeString(getRelativeTimeString(diff, formatter));
+    }
+
+    const intervalId = setInterval(update, UPDATE_INTERVAL);
+    return () => clearInterval(intervalId);
+  }, [time, now, formatter, useRelativeTimestamps]);
+
+  return <>{useRelativeTimestamps ? timeString : time.toLocaleString()}</>;
+}

--- a/bundles/processing/UserPreferencesStore.tsx
+++ b/bundles/processing/UserPreferencesStore.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface UserPreferencesStoreState {
+  useRelativeTimestamps: boolean;
+}
+
+export const useUserPreferencesStore = create<UserPreferencesStoreState>()(
+  persist(
+    _set => ({
+      useRelativeTimestamps: false,
+    }),
+    {
+      name: 'user-preferences',
+    },
+  ),
+);
+
+export function setUseRelativeTimestamps(useRelativeTimestamps: boolean) {
+  useUserPreferencesStore.setState({ useRelativeTimestamps });
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@loadable/component": "^5.15.3",
     "@react-dnd/invariant": "^4.0.2",
     "@redux-devtools/extension": "^3.2.5",
-    "@spyrothon/sparx": "^0.3.4",
+    "@spyrothon/sparx": "0.5.0",
     "axios": "^1.3.5",
     "classnames": "^2.3.2",
     "connected-react-router": "^6.9.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@loadable/component": "^5.15.3",
     "@react-dnd/invariant": "^4.0.2",
     "@redux-devtools/extension": "^3.2.5",
-    "@spyrothon/sparx": "0.5.0",
+    "@spyrothon/sparx": "0.5.1",
     "axios": "^1.3.5",
     "classnames": "^2.3.2",
     "connected-react-router": "^6.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,22 +2317,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spyrothon/sparx@npm:^0.3.4":
-  version: 0.3.4
-  resolution: "@spyrothon/sparx@npm:0.3.4"
+"@spyrothon/sparx@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@spyrothon/sparx@npm:0.5.0"
   dependencies:
     "@iconscout/react-unicons": ^1.1.6
     "@iconscout/react-unicons-solid": ^0.0.3
     autonumeric: ^4.6.0
     classnames: ^2.3.1
     downshift: ^6.1.7
+    react-polymorphic-types: ^2.0.0
     react-remark: ^2.1.0
     uuid: ^8.3.2
     zustand: ^3.7.2
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: f5e55d56ff3852b4019a3bd730fc3eb0e2262ceb6f1b64e95980d34240aa1023f06623c55afea489332362baec353c8eae55753bff8c400d354bdff146b5f0c9
+  checksum: c438be9f9388b0d02e8fb68033aec272bfe13cb13962d2adf7783d12d761a37d9ffcd6a0be240edab273e232abed5fe0a6281fd25d22177ac097fca519a64f7d
   languageName: node
   linkType: hard
 
@@ -7920,7 +7921,7 @@ __metadata:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.10
     "@react-dnd/invariant": ^4.0.2
     "@redux-devtools/extension": ^3.2.5
-    "@spyrothon/sparx": ^0.3.4
+    "@spyrothon/sparx": 0.5.0
     "@storybook/addon-actions": ^5.1.3
     "@storybook/addon-links": ^5.1.3
     "@storybook/addons": ^5.1.3
@@ -16356,6 +16357,15 @@ __metadata:
     prop-types: ^15.6.1
     react: "*"
   checksum: 8b2708151b9a53cfd86e17e23374417798a8c995de15a293e998e24a06561e8f222557a5d713ce243c5c2c8840e62942f194330fee257c2576856963fa3f7d87
+  languageName: node
+  linkType: hard
+
+"react-polymorphic-types@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "react-polymorphic-types@npm:2.0.0"
+  peerDependencies:
+    "@types/react": ">=16.8.6"
+  checksum: 02cd487d00a75c4f1557532c21556eac6ca6f6204faa4b373ba4b3be47f75e3de3db1a987a1df430d66987dddb74228f5f05b52d84e2adc333456d172ad5465d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,23 +2317,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spyrothon/sparx@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@spyrothon/sparx@npm:0.5.0"
+"@spyrothon/sparx@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@spyrothon/sparx@npm:0.5.1"
   dependencies:
     "@iconscout/react-unicons": ^1.1.6
     "@iconscout/react-unicons-solid": ^0.0.3
     autonumeric: ^4.6.0
     classnames: ^2.3.1
     downshift: ^6.1.7
-    react-polymorphic-types: ^2.0.0
+    react-polymorphic-types: "github:GamesDoneQuick/react-polymorphic-types#bd1e8388c1d02d919dd038a5d5690ff7bb62da88"
     react-remark: ^2.1.0
     uuid: ^8.3.2
     zustand: ^3.7.2
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: c438be9f9388b0d02e8fb68033aec272bfe13cb13962d2adf7783d12d761a37d9ffcd6a0be240edab273e232abed5fe0a6281fd25d22177ac097fca519a64f7d
+  checksum: 5c673fd8d089c1c101f709f99bce9d130cfa18c5efd05e470d636ff52ce2228fa50e9a4e07ca163bb058b65ae97c5d79918bdf537dcc10c0aaa4ec9f22d893e3
   languageName: node
   linkType: hard
 
@@ -7921,7 +7921,7 @@ __metadata:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.10
     "@react-dnd/invariant": ^4.0.2
     "@redux-devtools/extension": ^3.2.5
-    "@spyrothon/sparx": 0.5.0
+    "@spyrothon/sparx": 0.5.1
     "@storybook/addon-actions": ^5.1.3
     "@storybook/addon-links": ^5.1.3
     "@storybook/addons": ^5.1.3
@@ -16360,12 +16360,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-polymorphic-types@npm:^2.0.0":
+"react-polymorphic-types@github:GamesDoneQuick/react-polymorphic-types#bd1e8388c1d02d919dd038a5d5690ff7bb62da88":
   version: 2.0.0
-  resolution: "react-polymorphic-types@npm:2.0.0"
+  resolution: "react-polymorphic-types@https://github.com/GamesDoneQuick/react-polymorphic-types.git#commit=bd1e8388c1d02d919dd038a5d5690ff7bb62da88"
   peerDependencies:
     "@types/react": ">=16.8.6"
-  checksum: 02cd487d00a75c4f1557532c21556eac6ca6f6204faa4b373ba4b3be47f75e3de3db1a987a1df430d66987dddb74228f5f05b52d84e2adc333456d172ad5465d
+  checksum: a91bd4f4d3b90aa1782375ba774f0dc77cfec1ac2aecf5ac96335a4b97469e6f341fd3612d7d781ebd4d104629ebfbeaf3207ab81449897ee64cfcf2e64eee64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This PR adds some additional features on the new hosts page from some quick feedback:
- Allow users to switch between absolute and relative timestamps. This will be ported to the processing pages as well.
  <img width="352" alt="image" src="https://user-images.githubusercontent.com/783733/232872924-384c0590-d37c-40ab-841a-5271044f75ed.png">
- Make Groups fully manageable (editable and deletable) with a dot menu that opens a modal for changing information about the group.
  <img width="324" alt="image" src="https://user-images.githubusercontent.com/783733/232872877-31782d4e-9bfc-4348-a534-ca4efb557937.png">
- Allow hosts to block donations
  <img width="245" alt="image" src="https://user-images.githubusercontent.com/783733/232873528-d623dfea-4d70-489b-8dc8-ef3eb656612f.png">

As the structure of the new pages finally starts to settle, I'll be refactoring these into more reusable components and modules rather than duplicating code between processing and hosts, but that will come afterward.

### Verification Process

Confirmed all new features work and old pages still function as expected.
