### PR TITLE
Enable viewing/adding moderator comments from processing pages

### DIFF
--- a/bundles/processing/DonationRow.tsx
+++ b/bundles/processing/DonationRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import Highlighter from 'react-highlight-words';
 import { useMutation } from 'react-query';
-import { Anchor, Stack, Text } from '@spyrothon/sparx';
+import { Anchor, Button, openModal, Spacer, Stack, Text } from '@spyrothon/sparx';
 
 import { usePermission } from '@public/api/helpers/auth';
 import APIClient from '@public/apiv2/APIClient';
@@ -10,11 +10,14 @@ import type { Donation, DonationBid } from '@public/apiv2/APITypes';
 import * as CurrencyUtils from '@public/util/currency';
 import TimeUtils from '@public/util/TimeUtils';
 import Approve from '@uikit/icons/Approve';
+import Comment from '@uikit/icons/Comment';
 import Deny from '@uikit/icons/Deny';
 import SendForward from '@uikit/icons/SendForward';
 
 import { loadDonations } from './DonationsStore';
 import getEstimatedReadingTime from './getEstimatedReadingTIme';
+import ModCommentModal from './ModCommentModal';
+import ModCommentTooltip from './ModCommentTooltip';
 import MutationButton from './MutationButton';
 import useProcessingStore from './ProcessingStore';
 import { AdminRoutes, useAdminRoute } from './Routes';
@@ -75,6 +78,11 @@ export default function DonationRow(props: DonationRowProps) {
   const readingTime = getEstimatedReadingTime(donation.comment);
   const amount = CurrencyUtils.asCurrency(donation.amount);
   const hasComment = donation.comment != null && donation.comment.length > 0;
+  const hasModComment = donation.modcomment != null && donation.modcomment.length > 0;
+
+  function handleEditModComment() {
+    openModal(props => <ModCommentModal donationId={donation.id} {...props} />);
+  }
 
   return (
     <div className={styles.container}>
@@ -95,6 +103,12 @@ export default function DonationRow(props: DonationRowProps) {
               </strong>
             </Text>
             <Text variant="text-xs/secondary">
+              {hasModComment ? (
+                <Text tag="span" variant="text-xs/normal">
+                  <ModCommentTooltip comment={donation.modcomment!} />
+                  {' · '}
+                </Text>
+              ) : null}
               <Anchor href={donationLink} newTab>
                 Edit Donation
               </Anchor>
@@ -113,6 +127,7 @@ export default function DonationRow(props: DonationRowProps) {
             </Text>
           </div>
           <Stack direction="horizontal">
+            <Button onClick={handleEditModComment} variant="link/filled" icon={Comment}></Button>
             <MutationButton
               mutation={mutation}
               donationId={donation.id}

--- a/bundles/processing/ModCommentModal.tsx
+++ b/bundles/processing/ModCommentModal.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { useMutation } from 'react-query';
+import { Button, Card, FormControl, Header, Stack, Text, TextArea } from '@spyrothon/sparx';
+
+import APIClient from '@public/apiv2/APIClient';
+import { Donation } from '@public/apiv2/APITypes';
+import * as CurrencyUtils from '@public/util/currency';
+import TimeUtils from '@public/util/TimeUtils';
+
+import { useDonation } from './DonationsStore';
+import RelativeTime from './RelativeTime';
+
+import styles from './CreateEditDonationGroupModal.mod.css';
+
+function renderDonationHeader(donation: Donation) {
+  const timestamp = TimeUtils.parseTimestamp(donation.timereceived);
+  const amount = CurrencyUtils.asCurrency(donation.amount);
+
+  return (
+    <Stack spacing="space-sm">
+      <Text variant="text-md/normal">
+        <strong>{amount}</strong>
+        {' from '}
+        <strong>{donation.donor_name}</strong>
+      </Text>
+      <Stack direction="horizontal" spacing="space-sm" align="center">
+        <Text variant="text-sm/normal">
+          #{donation.id}
+          {' · '}
+          <span>
+            <RelativeTime time={timestamp.toJSDate()} />
+          </span>
+        </Text>
+      </Stack>
+    </Stack>
+  );
+}
+
+interface ModCommentModalProps {
+  donationId: number;
+  onClose: () => unknown;
+}
+
+export default function ModCommentModal(props: ModCommentModalProps) {
+  const { donationId, onClose } = props;
+
+  const donation = useDonation(donationId);
+  const [comment, setComment] = React.useState(donation.modcomment ?? '');
+
+  const saveComment = useMutation((comment: string) => APIClient.editModComment(`${donationId}`, comment));
+
+  function handleSave(event: React.FormEvent) {
+    event.preventDefault();
+    saveComment.mutate(comment);
+    onClose();
+  }
+
+  return (
+    <Card floating className={styles.modal}>
+      <Stack as="form" spacing="space-lg" action="" onSubmit={handleSave}>
+        <Header tag="h1">Edit Mod Comment</Header>
+        <Card>{renderDonationHeader(donation)}</Card>
+        <FormControl label="Mod Comment">
+          <TextArea
+            value={comment}
+            // eslint-disable-next-line react/jsx-no-bind
+            onChange={event => setComment(event.target.value)}
+            name="comment"
+          />
+        </FormControl>
+        <Stack direction="horizontal" justify="space-between">
+          <Button variant="primary" type="submit">
+            Save Comment
+          </Button>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/bundles/processing/ModCommentTooltip.tsx
+++ b/bundles/processing/ModCommentTooltip.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Clickable, Text, useTooltip } from '@spyrothon/sparx';
+
+import InfoCircle from '@uikit/icons/InfoCircle';
+
+import styles from './Processing.mod.css';
+
+interface ModCommentTooltipProps {
+  comment: string;
+}
+
+export default function ModCommentTooltip(props: ModCommentTooltipProps) {
+  const { comment } = props;
+
+  const [tooltipProps] = useTooltip<HTMLSpanElement>(<Text className={styles.modcommentTooltip}>{comment}</Text>, {
+    attach: 'bottom',
+    align: 'start',
+  });
+
+  return (
+    <Clickable as="span" {...tooltipProps}>
+      <InfoCircle />
+    </Clickable>
+  );
+}

--- a/bundles/processing/Processing.mod.css
+++ b/bundles/processing/Processing.mod.css
@@ -63,6 +63,10 @@
   margin-right: auto;
 }
 
+.modcommentTooltip {
+  white-space: pre;
+}
+
 .donationDragHandle {
   flex: 0 0 auto;
   cursor: grab;

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -46,6 +46,7 @@ import useDonationGroupsStore, {
 import useDonationsStore, { loadDonations, useDonation, useDonations, useDonationsInState } from './DonationsStore';
 import getEstimatedReadingTime from './getEstimatedReadingTIme';
 import ModCommentModal from './ModCommentModal';
+import ModCommentTooltip from './ModCommentTooltip';
 import MutationButton from './MutationButton';
 import ProcessingSidebar from './ProcessingSidebar';
 import RelativeTime from './RelativeTime';
@@ -143,25 +144,6 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
         </Button>
       </Stack>
     </Card>
-  );
-}
-
-interface ModCommentTooltipProps {
-  comment: string;
-}
-
-function ModCommentTooltip(props: ModCommentTooltipProps) {
-  const { comment } = props;
-
-  const [tooltipProps] = useTooltip<HTMLSpanElement>(<Text className={styles.modcommentTooltip}>{comment}</Text>, {
-    attach: 'bottom',
-    align: 'start',
-  });
-
-  return (
-    <Clickable as="span" {...tooltipProps}>
-      <InfoCircle />
-    </Clickable>
   );
 }
 

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -33,6 +33,7 @@ import Approve from '@uikit/icons/Approve';
 import Deny from '@uikit/icons/Deny';
 import Dots from '@uikit/icons/Dots';
 import DragHandle from '@uikit/icons/DragHandle';
+import InfoCircle from '@uikit/icons/InfoCircle';
 import Plus from '@uikit/icons/Plus';
 
 import ConnectionStatus from './ConnectionStatus';
@@ -145,6 +146,25 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
   );
 }
 
+interface ModCommentTooltipProps {
+  comment: string;
+}
+
+function ModCommentTooltip(props: ModCommentTooltipProps) {
+  const { comment } = props;
+
+  const [tooltipProps] = useTooltip<HTMLSpanElement>(<Text className={styles.modcommentTooltip}>{comment}</Text>, {
+    attach: 'bottom',
+    align: 'start',
+  });
+
+  return (
+    <Clickable as="span" {...tooltipProps}>
+      <InfoCircle />
+    </Clickable>
+  );
+}
+
 interface DonationRowProps {
   donation: Donation;
   draggable: boolean;
@@ -159,6 +179,7 @@ function DonationRow(props: DonationRowProps) {
   const readingTime = getEstimatedReadingTime(donation.comment);
   const amount = CurrencyUtils.asCurrency(donation.amount);
   const hasComment = donation.comment != null && donation.comment.length > 0;
+  const hasModComment = donation.modcomment != null && donation.modcomment.length > 0;
 
   const removeDonationFromAllGroups = useDonationGroupsStore(state => state.removeDonationFromAllGroups);
   const groups = useGroupsForDonation(donation.id);
@@ -232,19 +253,27 @@ function DonationRow(props: DonationRowProps) {
                 </strong>
               </Text>
               <Stack direction="horizontal" spacing="space-sm" align="center">
-                {groups.map(group => (
-                  <Tag key={group.id} color={group.color}>
-                    {group.name}
-                  </Tag>
-                ))}
-                {groups.length > 0 ? ' · ' : null}
-                <Text variant="text-sm/normal">
-                  <span>
-                    <RelativeTime time={timestamp.toJSDate()} />
-                  </span>
-                  {' · '}
-                  {readingTime} to read
-                </Text>
+                {hasModComment ? (
+                  <Text variant="text-sm/normal">
+                    <ModCommentTooltip comment={donation.modcomment!} />
+                    {' · '}
+                  </Text>
+                ) : null}
+                <Stack direction="horizontal" spacing="space-sm" align="center">
+                  {groups.map(group => (
+                    <Tag key={group.id} color={group.color}>
+                      {group.name}
+                    </Tag>
+                  ))}
+                  {groups.length > 0 ? ' · ' : null}
+                  <Text variant="text-sm/normal">
+                    <span>
+                      <RelativeTime time={timestamp.toJSDate()} />
+                    </span>
+                    {' · '}
+                    {readingTime} to read
+                  </Text>
+                </Stack>
               </Stack>
             </Stack>
           </Stack>

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -44,6 +44,7 @@ import useDonationGroupsStore, {
 } from './DonationGroupsStore';
 import useDonationsStore, { loadDonations, useDonation, useDonations, useDonationsInState } from './DonationsStore';
 import getEstimatedReadingTime from './getEstimatedReadingTIme';
+import ModCommentModal from './ModCommentModal';
 import MutationButton from './MutationButton';
 import ProcessingSidebar from './ProcessingSidebar';
 import RelativeTime from './RelativeTime';
@@ -56,10 +57,11 @@ import styles from './Processing.mod.css';
 
 interface AddToGroupPopoutProps {
   donationId: number;
+  onClose: () => void;
 }
 
 function AddToGroupPopout(props: AddToGroupPopoutProps) {
-  const { donationId } = props;
+  const { donationId, onClose } = props;
   const donation = useDonation(donationId);
   const { groups, addDonationToGroup, removeDonationFromGroup, removeDonationFromAllGroups } = useDonationGroupsStore();
 
@@ -86,7 +88,13 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
   }
 
   function handleBlock() {
+    onClose();
     block.mutate();
+  }
+
+  function handleEditModComment() {
+    onClose();
+    openModal(props => <ModCommentModal donationId={donation.id} {...props} />);
   }
 
   return (
@@ -114,6 +122,10 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
         </div>
         <Spacer />
         <Checkbox label="Pin for Everyone" checked={donation.pinned} onChange={handlePinChange} />
+        <Button onClick={handleEditModComment} variant="default/outline">
+          Edit Mod Comment
+        </Button>
+        <Spacer />
         <Header tag="h2" variant="header-sm/normal">
           Add to Groups
         </Header>
@@ -124,7 +136,7 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
           }
           return <Checkbox key={group.id} label={group.name} checked={isIncluded} onChange={handleGroupChange} />;
         })}
-        <Spacer size="space-md" />
+        <Spacer />
         <Button variant="danger/outline" onClick={handleBlock}>
           Block
         </Button>
@@ -187,7 +199,7 @@ function DonationRow(props: DonationRowProps) {
   drop(preview(donationRef.current));
 
   function handleMoreActions(event: React.MouseEvent) {
-    openPopout(() => <AddToGroupPopout donationId={donation.id} />, event.currentTarget as HTMLElement);
+    openPopout(props => <AddToGroupPopout {...props} donationId={donation.id} />, event.currentTarget as HTMLElement);
   }
 
   return (

--- a/bundles/public/apiv2/APITypes.tsx
+++ b/bundles/public/apiv2/APITypes.tsx
@@ -8,7 +8,6 @@ export type Donation = {
   transactionstate: string;
   readstate: string;
   commentstate: string;
-  bidstate: string;
   amount: string;
   currency: string;
   timereceived: string;

--- a/bundles/public/apiv2/APITypes.tsx
+++ b/bundles/public/apiv2/APITypes.tsx
@@ -16,6 +16,7 @@ export type Donation = {
   commentlanguage: string;
   pinned: boolean;
   bids: DonationBid[];
+  modcomment?: string;
 };
 
 export type DonationBid = {

--- a/bundles/public/apiv2/Endpoints.tsx
+++ b/bundles/public/apiv2/Endpoints.tsx
@@ -16,6 +16,7 @@ const Endpoints = {
   DONATIONS_UNPIN: (donationId: string) => `donations/${donationId}/unpin/`,
   DONATIONS_READ: (donationId: string) => `donations/${donationId}/read/`,
   DONATIONS_IGNORE: (donationId: string) => `donations/${donationId}/ignore/`,
+  DONATIONS_COMMENT: (donationId: string) => `donations/${donationId}/comment/`,
   EVENTS: `events/`,
   EVENT: (eventId: string) => `events/${eventId}/`,
   ME: `me/`,

--- a/bundles/public/apiv2/routes/donations.tsx
+++ b/bundles/public/apiv2/routes/donations.tsx
@@ -86,3 +86,8 @@ export async function ignoreDonation(donationId: string) {
   const response = await HTTPUtils.post<Donation>(Endpoints.DONATIONS_IGNORE(donationId));
   return response.data;
 }
+
+export async function editModComment(donationId: string, comment: string) {
+  const response = await HTTPUtils.post<Donation>(Endpoints.DONATIONS_COMMENT(donationId), { comment });
+  return response.data;
+}

--- a/bundles/uikit/icons/Comment.tsx
+++ b/bundles/uikit/icons/Comment.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { faComment } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const Comment = (props: any) => {
+  return <FontAwesomeIcon {...props} icon={faComment} />;
+};
+
+export default Comment;

--- a/tests/apiv2/test_serializers.py
+++ b/tests/apiv2/test_serializers.py
@@ -29,7 +29,6 @@ class TestDonationSerializer(TransactionTestCase):
             'transactionstate',
             'readstate',
             'commentstate',
-            'bidstate',
             'amount',
             'currency',
             'timereceived',

--- a/tests/apiv2/test_serializers.py
+++ b/tests/apiv2/test_serializers.py
@@ -1,0 +1,54 @@
+import random
+
+from django.test import TransactionTestCase
+
+from tests.randgen import generate_donation, generate_donor, generate_event
+from tracker.api.serializers import DonationSerializer
+
+
+class TestDonationSerializer(TransactionTestCase):
+    rand = random.Random()
+
+    def setUp(self):
+        super(TestDonationSerializer, self).setUp()
+        self.event = generate_event(self.rand)
+        self.event.save()
+        self.donor = generate_donor(self.rand)
+        self.donor.save()
+        self.donation = generate_donation(self.rand, event=self.event, donor=self.donor)
+        self.donation.save()
+
+    def test_includes_all_public_fields(self):
+        expected_fields = [
+            'type',
+            'id',
+            'donor',
+            'donor_name',
+            'event',
+            'domain',
+            'transactionstate',
+            'readstate',
+            'commentstate',
+            'bidstate',
+            'amount',
+            'currency',
+            'timereceived',
+            'comment',
+            'commentlanguage',
+            'pinned',
+            'bids',
+        ]
+
+        serialized_donation = DonationSerializer(self.donation).data
+        for field in expected_fields:
+            self.assertIn(field, serialized_donation)
+
+    def test_does_not_include_modcomment_without_permission(self):
+        serialized_donation = DonationSerializer(self.donation).data
+        self.assertNotIn('modcomment', serialized_donation)
+
+    def test_includes_modcomment_with_permission(self):
+        serialized_donation = DonationSerializer(
+            self.donation, with_permissions=('tracker.change_donation',)
+        ).data
+        self.assertIn('modcomment', serialized_donation)

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -119,7 +119,9 @@ class TestProcessingConsumer(TransactionTestCase):
             event=self.event,
             transactionstate='COMPLETED',
         )
-        self.serialized_donation = DonationSerializer(self.donation).data
+        self.serialized_donation = DonationSerializer(
+            self.donation, with_permissions=('tracker.change_donation',)
+        ).data
 
     def tearDown(self):
         self.donation.delete()

--- a/tracker/analytics/events.py
+++ b/tracker/analytics/events.py
@@ -19,4 +19,5 @@ class AnalyticsEventTypes(str, enum.Enum):
     DONATION_COMMENT_UNPINNED = 'donation_comment_unpinned'
     DONATION_COMMENT_READ = 'donation_commment_read'
     DONATION_COMMENT_IGNORED = 'donation_commment_ignored'
+    DONATION_MOD_COMMENT_EDITED = 'donation_mod_comment_edited'
     REQUEST_SERVED = 'request_served'

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -44,6 +44,10 @@ class DonationSerializer(serializers.ModelSerializer):
     donor_name = serializers.SerializerMethodField()
     bids = DonationBidSerializer(many=True, read_only=True)
 
+    def __init__(self, instance, *, with_permissions=None, **kwargs):
+        self.permissions = with_permissions or []
+        super().__init__(instance, **kwargs)
+
     class Meta:
         model = Donation
         fields = (
@@ -64,7 +68,15 @@ class DonationSerializer(serializers.ModelSerializer):
             'commentlanguage',
             'pinned',
             'bids',
+            'modcomment',
         )
+
+    def get_fields(self):
+        fields = super().get_fields()
+        if 'tracker.change_donation' not in self.permissions:
+            del fields['modcomment']
+
+        return fields
 
     def get_donor_name(self, donation: Donation):
         if donation.donor is not None:

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -60,7 +60,6 @@ class DonationSerializer(serializers.ModelSerializer):
             'transactionstate',
             'readstate',
             'commentstate',
-            'bidstate',
             'amount',
             'currency',
             'timereceived',

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -348,7 +348,7 @@ class DonationViewSet(viewsets.GenericViewSet):
         """
         comment = request.data.get('comment', None)
         if comment is None:
-            return Response({'error': '`comment` was not be provided'}, status=422)
+            return Response({'error': '`comment` must be provided'}, status=422)
 
         manager = DonationChangeManager(request, pk, self.get_serializer)
         with manager.change_donation(

--- a/tracker/consumers/processing.py
+++ b/tracker/consumers/processing.py
@@ -34,6 +34,12 @@ class ProcessingConsumer(AsyncJsonWebsocketConsumer):
 User = get_user_model()
 
 
+def _serialize_donation(donation: Donation):
+    return DonationSerializer(
+        donation, with_permissions=('tracker.change_donation',)
+    ).data
+
+
 def broadcast_processing_action(user: User, donation: Donation, action: str):
     async_to_sync(get_channel_layer().group_send)(
         PROCESSING_GROUP_NAME,
@@ -42,7 +48,7 @@ def broadcast_processing_action(user: User, donation: Donation, action: str):
             'payload': {
                 'actor_name': user.username,
                 'actor_id': user.pk,
-                'donation': DonationSerializer(donation).data,
+                'donation': _serialize_donation(donation),
                 'action': action,
             },
         },
@@ -55,7 +61,7 @@ def broadcast_new_donation_to_processors(donation: Donation):
         {
             'type': 'donation_received',
             'payload': {
-                'donation': DonationSerializer(donation).data,
+                'donation': _serialize_donation(donation),
             },
         },
     )


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [x] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This adds the ability for processors and readers to both view and edit moderator comments on donations. The UI on each page is slightly different, mainly just for simplicity at this point. Once things are refactor and deduped, it will be more consistent.

<img width="461" alt="image" src="https://user-images.githubusercontent.com/783733/233169535-7a67d203-7a39-402c-8fb4-a93a302f1ddc.png">
<img width="590" alt="image" src="https://user-images.githubusercontent.com/783733/233169578-8062dafc-f189-4f0b-a69d-db77698a3ac4.png">
<img width="598" alt="image" src="https://user-images.githubusercontent.com/783733/233169643-cf0bb9f8-eb40-465d-ab30-54dbaf1959f4.png">


### Verification Process

Tested that adding mod comments on donations works from each page, and that live updates are sent including the comments to all processing consumers.