### PR TITLE
Add keyword searching for donations to new Read Donations page

### DIFF
--- a/bundles/processing/DonationRow.tsx
+++ b/bundles/processing/DonationRow.tsx
@@ -18,6 +18,7 @@ import getEstimatedReadingTime from './getEstimatedReadingTIme';
 import MutationButton from './MutationButton';
 import useProcessingStore from './ProcessingStore';
 import { AdminRoutes, useAdminRoute } from './Routes';
+import { useSearchKeywords } from './SearchKeywordsStore';
 
 import styles from './DonationRow.mod.css';
 
@@ -63,7 +64,7 @@ export default function DonationRow(props: DonationRowProps) {
   const donorLink = useAdminRoute(AdminRoutes.DONOR(donation.donor));
   const canEditDonors = usePermission('tracker.change_donor');
 
-  const keywords = useProcessingStore(state => state.keywords);
+  const keywords = useSearchKeywords();
   const mutation = useDonationMutation((donationId: number) => action(`${donationId}`), actionName);
   const approve = useDonationMutation(
     (donationId: number) => APIClient.approveDonationComment(`${donationId}`),

--- a/bundles/processing/ProcessDonations.tsx
+++ b/bundles/processing/ProcessDonations.tsx
@@ -15,6 +15,7 @@ import DonationRow from './DonationRow';
 import { DonationState, loadDonations, useDonationsInState } from './DonationsStore';
 import ProcessingSidebar from './ProcessingSidebar';
 import useProcessingStore, { ProcessingMode } from './ProcessingStore';
+import { setSearchKeywords, useSearchKeywords } from './SearchKeywordsStore';
 
 import styles from './Processing.mod.css';
 
@@ -147,14 +148,14 @@ export default function ProcessDonations() {
     setPartitionCount,
     processingMode,
     setProcessingMode,
-    keywords,
-    setKeywords,
   } = useProcessingStore();
+
+  const searchKeywords = useSearchKeywords();
 
   // Keywords are stored as a split array with some additional formatting. To
   // pre-fill the input from local storage on page load, we need to un-format
   // and re-join the words back into a regular string.
-  const [initialKeywords] = React.useState(() => keywords.map(word => word.replace(/\\b/g, '')).join(', '));
+  const [initialKeywords] = React.useState(() => searchKeywords.map(word => word.replace(/\\b/g, '')).join(', '));
 
   const process = PROCESSES[processingMode];
 
@@ -180,7 +181,7 @@ export default function ProcessDonations() {
 
   function handleKeywordsChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
     const words = event.target.value.split(',').map(word => `\\b${word.trim()}\\b`);
-    setKeywords(words);
+    setSearchKeywords(words);
   }
 
   return (

--- a/bundles/processing/ProcessDonations.tsx
+++ b/bundles/processing/ProcessDonations.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useQuery, UseQueryResult } from 'react-query';
 import { useParams } from 'react-router';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
-import { FormControl, SelectInput, Stack, Text, TextArea, TextInput } from '@spyrothon/sparx';
+import { FormControl, SelectInput, Stack, Text, TextInput } from '@spyrothon/sparx';
 
 import { usePermission } from '@public/api/helpers/auth';
 import APIClient from '@public/apiv2/APIClient';
@@ -15,7 +15,7 @@ import DonationRow from './DonationRow';
 import { DonationState, loadDonations, useDonationsInState } from './DonationsStore';
 import ProcessingSidebar from './ProcessingSidebar';
 import useProcessingStore, { ProcessingMode } from './ProcessingStore';
-import { setSearchKeywords, useSearchKeywords } from './SearchKeywordsStore';
+import SearchKeywordsInput from './SearchKeywordsInput';
 
 import styles from './Processing.mod.css';
 
@@ -150,13 +150,6 @@ export default function ProcessDonations() {
     setProcessingMode,
   } = useProcessingStore();
 
-  const searchKeywords = useSearchKeywords();
-
-  // Keywords are stored as a split array with some additional formatting. To
-  // pre-fill the input from local storage on page load, we need to un-format
-  // and re-join the words back into a regular string.
-  const [initialKeywords] = React.useState(() => searchKeywords.map(word => word.replace(/\\b/g, '')).join(', '));
-
   const process = PROCESSES[processingMode];
 
   const { data: event } = useQuery(`events.${eventId}`, () => APIClient.getEvent(eventId));
@@ -177,11 +170,6 @@ export default function ProcessDonations() {
     if (!canSendToReader || mode == null) return;
 
     setProcessingMode(mode);
-  }
-
-  function handleKeywordsChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    const words = event.target.value.split(',').map(word => `\\b${word.trim()}\\b`);
-    setSearchKeywords(words);
   }
 
   return (
@@ -214,9 +202,7 @@ export default function ProcessDonations() {
               />
             </FormControl>
           </Stack>
-          <FormControl label="Keywords" note="Comma-separated list of words or phrases to highlight in donations">
-            <TextArea rows={2} defaultValue={initialKeywords} onChange={handleKeywordsChange} />
-          </FormControl>
+          <SearchKeywordsInput />
         </Stack>
         <ConnectionStatus refetch={donationsQuery.refetch} isFetching={donationsQuery.isRefetching} />
         <ActionLog />

--- a/bundles/processing/ProcessingStore.tsx
+++ b/bundles/processing/ProcessingStore.tsx
@@ -34,12 +34,6 @@ interface ProcessingStoreState {
   setProcessingMode: (processingMode: ProcessingMode) => void;
   processDonation(donation: Donation, action: string, log?: boolean): void;
   undoAction(actionId: number): void;
-  /**
-   * List of words to highlight in donations, often used for noting donations from
-   * a community or friends of the runner.
-   */
-  keywords: string[];
-  setKeywords(words: string[]): void;
 }
 
 const useProcessingStore = create<ProcessingStoreState>()(
@@ -49,7 +43,6 @@ const useProcessingStore = create<ProcessingStoreState>()(
       partition: 0,
       partitionCount: 1,
       processingMode: 'flag',
-      keywords: [],
       processDonation(donation: Donation, action: string, log = true) {
         set(state => {
           return {
@@ -78,9 +71,6 @@ const useProcessingStore = create<ProcessingStoreState>()(
           return { processingMode, unprocessed: new Set(), actionHistory: [] };
         });
       },
-      setKeywords(words: []) {
-        set({ keywords: words });
-      },
     }),
     {
       name: 'processing-state',
@@ -88,7 +78,6 @@ const useProcessingStore = create<ProcessingStoreState>()(
         partition: state.partition,
         partitionCount: state.partitionCount,
         processingMode: state.processingMode,
-        keywords: state.keywords,
       }),
     },
   ),

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import Highlighter from 'react-highlight-words';
 import { useMutation, useQuery } from 'react-query';
 import { useParams } from 'react-router';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -41,6 +42,8 @@ import MutationButton from './MutationButton';
 import ProcessingSidebar from './ProcessingSidebar';
 import RelativeTime from './RelativeTime';
 import { AdminRoutes, useAdminRoute } from './Routes';
+import SearchKeywordsInput from './SearchKeywordsInput';
+import { useSearchKeywords } from './SearchKeywordsStore';
 
 import donationStyles from './DonationRow.mod.css';
 import styles from './Processing.mod.css';
@@ -131,6 +134,7 @@ interface DonationRowProps {
 function DonationRow(props: DonationRowProps) {
   const { donation } = props;
   const timestamp = TimeUtils.parseTimestamp(donation.timereceived);
+  const searchKeywords = useSearchKeywords();
 
   const readingTime = getEstimatedReadingTime(donation.comment);
   const amount = CurrencyUtils.asCurrency(donation.amount);
@@ -165,7 +169,9 @@ function DonationRow(props: DonationRowProps) {
             <Text variant="text-md/normal">
               <strong>{amount}</strong>
               {' from '}
-              <strong>{donation.donor_name}</strong>
+              <strong>
+                <Highlighter searchWords={searchKeywords} textToHighlight={donation.donor_name}></Highlighter>
+              </strong>
             </Text>
             <Stack direction="horizontal" spacing="space-sm" align="center">
               {groups.map(group => (
@@ -208,7 +214,15 @@ function DonationRow(props: DonationRowProps) {
       <Text
         variant={hasComment ? 'text-md/normal' : 'text-md/secondary'}
         className={classNames(donationStyles.comment, { [donationStyles.noCommentHint]: !hasComment })}>
-        {hasComment ? donation.comment : 'No comment was provided'}
+        {hasComment ? (
+          <Highlighter
+            highlightClassName={styles.highlighted}
+            searchWords={searchKeywords}
+            textToHighlight={donation.comment || ''}
+          />
+        ) : (
+          'No comment was provided'
+        )}
       </Text>
     </div>
   );
@@ -416,6 +430,7 @@ export default function ReadDonations() {
     <div className={styles.container}>
       <ProcessingSidebar event={event} subtitle="Read Donations" className={styles.sidebar}>
         <ConnectionStatus refetch={donationsQuery.refetch} isFetching={donationsQuery.isRefetching} />
+        <SearchKeywordsInput />
         <Tabs.Group>
           <Tabs.Header label="Filters" />
           {filterTabItems.map(tab => (

--- a/bundles/processing/SearchKeywordsInput.tsx
+++ b/bundles/processing/SearchKeywordsInput.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { FormControl, TextArea } from '@spyrothon/sparx';
+
+import { setSearchKeywords, useSearchKeywords } from './SearchKeywordsStore';
+
+export default function SearchKeywordsInput() {
+  const searchKeywords = useSearchKeywords();
+
+  // Keywords are stored as a split array with some additional formatting. To
+  // pre-fill the input from local storage on page load, we need to un-format
+  // and re-join the words back into a regular string.
+  const [initialKeywords] = React.useState(() => searchKeywords.map(word => word.replace(/\\b/g, '')).join(', '));
+
+  function handleKeywordsChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
+    const words = event.target.value.split(',').map(word => `\\b${word.trim()}\\b`);
+    setSearchKeywords(words);
+  }
+
+  return (
+    <FormControl label="Keywords" note="Comma-separated list of words or phrases to highlight in donations">
+      <TextArea rows={2} defaultValue={initialKeywords} onChange={handleKeywordsChange} />
+    </FormControl>
+  );
+}

--- a/bundles/processing/SearchKeywordsStore.tsx
+++ b/bundles/processing/SearchKeywordsStore.tsx
@@ -1,0 +1,32 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface SearchKeywordsStoreState {
+  /**
+   * List of words to highlight in various searchable data and content,
+   * including donation comments, donor names, logs, and more. Often used for
+   * quickly noting donations from a community or friends of the runner.
+   */
+  keywords: string[];
+}
+
+const useSearchKeywordsStore = create<SearchKeywordsStoreState>()(
+  persist(
+    (): SearchKeywordsStoreState => ({
+      keywords: [],
+    }),
+    {
+      name: 'search-keywords-state',
+    },
+  ),
+);
+
+export default useSearchKeywordsStore;
+
+export function useSearchKeywords() {
+  return useSearchKeywordsStore(state => state.keywords);
+}
+
+export function setSearchKeywords(keywords: string[]) {
+  useSearchKeywordsStore.setState({ keywords });
+}


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This adds the keyword searching feature from the Process Donations page to the Read Donations page. To do that, the keywords are now managed in their own store and hooks instead of in ProcessingStore itself, and a SearchKeywordsInput ensures it will work consistently across pages.

There's still duplication across `DonationRow`, but that will be addressed by later refactoring.

<img width="1654" alt="image" src="https://user-images.githubusercontent.com/783733/233230794-cece8b3d-9f2e-4e6e-929b-67685ec30b39.png">


### Verification Process

Tested that keyword highlighting still works on both pages.