### PR TITLE
Support reordering of donations within groups on Read Donations

### DIFF
--- a/bundles/processing/DonationGroupsStore.tsx
+++ b/bundles/processing/DonationGroupsStore.tsx
@@ -114,3 +114,36 @@ export function useGroupsForDonation(donationId: number) {
   const groups = useDonationGroupsStore(state => state.groups);
   return React.useMemo(() => groups.filter(group => group.donationIds.includes(donationId)), [groups, donationId]);
 }
+
+/**
+ * Change the position of a donation within a group.
+ *
+ * @param groupId The group to move the donation within.
+ * @param movingDonationId The donation being moved to a new position
+ * @param targetDonationId The donation above which the moving donation will be placed.
+ * @param below When true, the moving donation will be placed below the target instead.
+ */
+export function moveDonationWithinGroup(
+  groupId: string,
+  movingDonationId: number,
+  targetDonationId: number,
+  below = false,
+) {
+  useDonationGroupsStore.setState(({ groups }) => {
+    const groupIndex = groups.findIndex(group => group.id === groupId);
+    const oldGroup = groups[groupIndex];
+    const newDonationIds = [...oldGroup.donationIds];
+    // Remove the moving donation from the list first
+    newDonationIds.splice(newDonationIds.indexOf(movingDonationId), 1);
+    // Then find the index of the target and insert the moving donation above it.
+    // If below is true, add one to the index to get the _following_ index.
+    const offset = below ? 1 : 0;
+    newDonationIds.splice(newDonationIds.indexOf(targetDonationId) + offset, 0, movingDonationId);
+
+    const group = { ...oldGroup, donationIds: newDonationIds };
+    // Update the group in the state
+    const newGroups = [...groups];
+    newGroups.splice(groupIndex, 1, group);
+    return { groups: newGroups };
+  });
+}

--- a/bundles/processing/DonationRow.mod.css
+++ b/bundles/processing/DonationRow.mod.css
@@ -1,20 +1,21 @@
 .container {
+  position: relative;
   margin: 16px 0;
-  background-color: var(--background-secondary);
+  background-color: var(--background-primary);
   border-radius: 4px;
   border: 1px solid var(--background-tertiary);
-  overflow: clip;
 }
 
 .header {
   position: sticky;
   top: 0;
+  border-radius: 4px;
+  background-color: var(--background-primary);
   border-bottom: 1px solid var(--background-tertiary);
 }
 
 .headerTop {
   padding: 8px;
-  background-color: var(--background-primary);
 }
 
 .bids {
@@ -24,6 +25,7 @@
 }
 
 .comment {
+  background-color: var(--background-secondary);
   padding: 8px;
   overflow-wrap: break-word;
   white-space: pre-wrap;
@@ -36,4 +38,29 @@
 .highlighted {
   background-color: #ff0;
   color: #000;
+}
+
+.dragging {
+  opacity: 0.6;
+}
+
+.emptyDropTarget {
+  position: relative;
+  display: block;
+  height: 64px;
+}
+
+.dropIndicator {
+  display: none;
+  position: absolute;
+  top: -8px;
+  width: 100%;
+  border: 2px solid green;
+  border-radius: 100px;
+}
+
+.isDropOver {
+  & .dropIndicator {
+    display: block;
+  }
 }

--- a/bundles/processing/Processing.mod.css
+++ b/bundles/processing/Processing.mod.css
@@ -62,3 +62,8 @@
 .groupsHeaderTitle {
   margin-right: auto;
 }
+
+.donationDragHandle {
+  flex: 0 0 auto;
+  cursor: grab;
+}

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -114,7 +114,7 @@ function AddToGroupPopout(props: AddToGroupPopoutProps) {
         {groups.map(group => {
           const isIncluded = group.donationIds.includes(donation.id);
           function handleGroupChange() {
-            isIncluded ? removeDonationFromGroup(group.name, donation.id) : addDonationToGroup(group.name, donation.id);
+            isIncluded ? removeDonationFromGroup(group.id, donation.id) : addDonationToGroup(group.id, donation.id);
           }
           return <Checkbox key={group.id} label={group.name} checked={isIncluded} onChange={handleGroupChange} />;
         })}

--- a/bundles/uikit/icons/DragHandle.tsx
+++ b/bundles/uikit/icons/DragHandle.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { faGripVertical } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const DragHandle = (props: any) => {
+  return <FontAwesomeIcon {...props} icon={faGripVertical} />;
+};
+
+export default DragHandle;


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Description of the Change

This adds support for drag-and-drop reordering of donations within a group on the Read Donations page. Using this, hosts can more easily set up their blocks for reading without having to memorize orders or where donations are in the list.

This does _not_ add support for reordering groups in the sidebar.


https://user-images.githubusercontent.com/783733/233256210-65c0e9da-7f80-49fa-888e-95a9a242cbaf.mov

This will likely be refactored along with moving things out of the single Read Donations file...in the future.

### Verification Process

Test that moving donations from anywhere in the list of donations within a group to any other position works as expected. Test that only donations within groups are draggable and filter lists are not able to be reordered.