### PR TITLE
rework how locked events affect admin pages [#184898680]

### DIFF
--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -1553,8 +1553,6 @@ class TestPrizeAdmin(TestCase):
         self.client.login(username='admin', password='password')
         response = self.client.get(reverse('admin:tracker_prizekey_changelist'))
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(reverse('admin:tracker_prizekey_add'))
-        self.assertEqual(response.status_code, 200)
         response = self.client.get(
             reverse('admin:tracker_prizekey_change', args=(self.prize_key.id,))
         )

--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -31,7 +31,7 @@ from .forms import (
     StartRunForm,
     TestEmailForm,
 )
-from .util import CustomModelAdmin
+from .util import CustomModelAdmin, EventLockedMixin
 
 
 @register(models.Event)
@@ -708,7 +708,7 @@ class RunnerAdmin(CustomModelAdmin):
 
 
 @register(models.SpeedRun)
-class SpeedRunAdmin(CustomModelAdmin):
+class SpeedRunAdmin(EventLockedMixin, CustomModelAdmin):
     form = SpeedRunAdminForm
     search_fields = [
         'name',
@@ -849,8 +849,6 @@ class SpeedRunAdmin(CustomModelAdmin):
 
     def get_queryset(self, request):
         params = {}
-        if not request.user.has_perm('tracker.can_edit_locked_events'):
-            params['locked'] = False
         return search_filters.run_model_query(
             'run', params, user=request.user
         ).prefetch_related('runners', 'hosts', 'commentators')

--- a/tracker/admin/forms.py
+++ b/tracker/admin/forms.py
@@ -9,7 +9,6 @@ from .util import latest_event_id
 
 class DonationBidForm(djforms.ModelForm):
     bid = make_ajax_field(models.DonationBid, 'bid', 'bidtarget')
-    donation = make_ajax_field(models.DonationBid, 'donation', 'donation')
 
 
 class BidForm(djforms.ModelForm):

--- a/tracker/admin/util.py
+++ b/tracker/admin/util.py
@@ -1,4 +1,5 @@
 from ajax_select.admin import AjaxSelectAdmin
+from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
 
@@ -41,3 +42,92 @@ def api_urls():
         'addURL': reverse('tracker:api_v1:add'),
         'deleteURL': reverse('tracker:api_v1:delete'),
     }
+
+
+class EventLockedMixin:
+    def _has_locked_permission(self, request, obj):
+        event = self.get_event(obj)
+        return (
+            obj is None
+            or not (event and event.locked)
+            or (
+                request.user and request.user.has_perm('tracker.can_edit_locked_events')
+            )
+        )
+
+    def has_change_permission(self, request, obj=None):
+        return super().has_change_permission(
+            request, obj
+        ) and self._has_locked_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        return super().has_delete_permission(
+            request, obj
+        ) and self._has_locked_permission(request, obj)
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+
+        # this prevents the event field, if any, from showing locked events as a choice
+
+        if not request.user.has_perm('tracker.can_edit_locked_events'):
+            queryset = getattr(form.base_fields.get('event', None), 'queryset', None)
+            if queryset:
+                form.base_fields['event'].queryset = queryset.filter(locked=False)
+            for field in self.get_event_child_fields():
+                queryset = getattr(form.base_fields.get(field, None), 'queryset', None)
+                if queryset:
+                    form.base_fields[field].queryset = queryset.filter(
+                        event__locked=False
+                    )
+        return form
+
+    def save_form(self, request, form, change):
+        if not request.user.has_perm('tracker.can_edit_locked_events'):
+            event = form.cleaned_data.get('event', None)
+            # this is a truly degenerate case
+            # a user either has to be:
+            # - adding a new child to event N
+            # - changing an existing child to point to event N when it wasn't before
+            # in addition to the following two conditions:
+            # - event N was not locked when the user opened the form, but got locked before the user could save
+            # - was not caught by existing machinery (choice validation, etc)
+            if event.locked:
+                raise PermissionDenied
+            for field in self.get_event_child_fields():
+                model = form.cleaned_data.get('field', None)
+                if model and model.event.locked:
+                    raise PermissionDenied
+        return super().save_form(request, form, change)
+
+    def get_event(self, obj):
+        return obj and obj.event
+
+    def get_event_child_fields(self):
+        return getattr(self, 'event_child_fields', [])
+
+
+class DonationStatusMixin:
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        if not request.user.has_perm('tracker.view_pending_donation'):
+            queryset = queryset.filter(donation__transactionstate='COMPLETED')
+        if not request.user.has_perm('tracker.view_test'):
+            queryset = queryset.filter(donation__testdonation=False)
+        return queryset
+
+    def get_list_display(self, request):
+        list_display = list(super().get_list_display(request))
+        if not request.user.has_perm('tracker.view_pending_donation'):
+            list_display.remove('transactionstate')
+        if not request.user.has_perm('tracker.view_test'):
+            list_display.remove('testdonation')
+        return list_display
+
+    def get_list_filter(self, request):
+        list_filter = list(super().get_list_filter(request))
+        if not request.user.has_perm('tracker.view_pending_donation'):
+            list_filter.remove('donation__transactionstate')
+        if not request.user.has_perm('tracker.view_pending_donation'):
+            list_filter.remove('donation__testdonation')
+        return list_filter

--- a/tracker/lookups.py
+++ b/tracker/lookups.py
@@ -86,6 +86,7 @@ class CountryRegionLookup(LookupChannel):
 
 class GenericLookup(LookupChannel):
     useLock = False
+    useEvent = True
     extra_params = {}
 
     def get_extra_params(self, request):
@@ -95,7 +96,7 @@ class GenericLookup(LookupChannel):
         params = {'q': q}
         params.update(self.get_extra_params(request))
         model = getattr(self, 'modelName', self.model)
-        if self.useLock and not request.user.has_perm('tracker.can_edit_locked_events'):
+        if self.useLock:
             params['locked'] = False
         return filters.run_model_query(model, params, request.user)
 
@@ -160,6 +161,7 @@ class RunLookup(GenericLookup):
 class EventLookup(GenericLookup):
     model = Event
     useLock = True
+    useEvent = False
 
 
 class RunnerLookup(GenericLookup):

--- a/tracker/models/prize.py
+++ b/tracker/models/prize.py
@@ -550,6 +550,7 @@ class PrizeKey(models.Model):
         app_label = 'tracker'
         verbose_name = 'Prize Key'
         ordering = ['prize']
+        # TODO: permissions are currently useless, consider removing
         permissions = (
             ('edit_prize_key_keys', 'Can edit existing prize keys'),
             ('remove_prize_key_winners', 'Can remove winners from prize keys'),
@@ -815,6 +816,10 @@ class PrizeWinner(models.Model):
         self.sumcount = self.pendingcount + self.acceptcount + self.declinecount
         super(PrizeWinner, self).save(*args, **kwargs)
 
+    @property
+    def event(self):
+        return self.prize.event
+
     def __str__(self):
         return f'{self.prize} -- {self.winner}'
 
@@ -867,6 +872,10 @@ class DonorPrizeEntry(models.Model):
             'prize',
             'donor',
         )
+
+    @property
+    def event(self):
+        return self.prize.event
 
     def __str__(self):
         return f'{self.donor} entered to win {self.prize}'


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184898680

### Description of the Change

After some feedback from RPGLB, I realized that locked events should still allow viewing the related models. Some of that code predates when 'view' permissions existed on Django so it as very overdue for some cleanup.

I moved as much as I could to a Mixin to avoid repetition.

The one big gotcha is that `list_editable` doesn't respect `has_change_permission` (or at least it still displays the edit fields) but the only place that mattered was the Donation list, which has a much better way of editing those field en masse anyway.

Since I was doing a pass on the admin pages anyway I also cleaned up a couple of other misc things that had been hanging around, like `bidstate` (which as far as I can tell is unused but I'm not willing to delete it outright yet)

### Verification Process

Wrote some tests to cover the new behavior, and went through each model that has Event as either a parent or grandparent to make sure that stuff was uneditable when appropriate, as well as being unable to tie something to a locked event, unless you had the special permission.
