### PR TITLE
Improved dark theme styles for new processing pages

### DIFF
--- a/bundles/.design_system/generated/Themes.css
+++ b/bundles/.design_system/generated/Themes.css
@@ -7,7 +7,7 @@
   --accent-hover: var(--blue-400);
   --accent-active: var(--blue-500);
   --accent-text: var(--blue-300);
-  --accent-translucent: rgba(65, 111, 168, 15%);
+  --accent-translucent: rgba(65, 111, 168, 25%);
 }
 
 .theme-light.accent-blue {
@@ -27,7 +27,7 @@
   --accent-hover: var(--purple-400);
   --accent-active: var(--purple-500);
   --accent-text: var(--purple-300);
-  --accent-translucent: rgba(163, 67, 198, 15%);
+  --accent-translucent: rgba(163, 67, 198, 25%);
 }
 
 .theme-light.accent-purple {
@@ -67,22 +67,22 @@
   --status-success-foreground: var(--green-50);
   --status-success-hover: var(--green-500);
   --status-success-active: var(--green-600);
-  --status-success-translucent: rgba(48, 96, 36, 15%);
+  --status-success-translucent: rgba(48, 96, 36, 25%);
   --status-warning-background: var(--yellow-400);
   --status-warning-foreground: var(--yellow-50);
   --status-warning-hover: var(--yellow-500);
   --status-warning-active: var(--yellow-600);
-  --status-warning-translucent: rgba(152, 105, 18, 15%);
+  --status-warning-translucent: rgba(152, 105, 18, 25%);
   --status-danger-background: var(--red-500);
   --status-danger-foreground: var(--red-50);
   --status-danger-hover: var(--red-600);
   --status-danger-active: var(--red-700);
-  --status-danger-translucent: rgba(157, 30, 49, 15%);
+  --status-danger-translucent: rgba(157, 30, 49, 25%);
   --status-info-background: var(--teal-400);
   --status-info-foreground: var(--white);
   --status-info-hover: var(--teal-500);
   --status-info-active: var(--teal-600);
-  --status-info-translucent: rgba(62, 114, 109, 15%);
+  --status-info-translucent: rgba(62, 114, 109, 25%);
   --status-default-background: var(--grey-500);
   --status-default-foreground: var(--grey-50);
   --status-default-hover: var(--grey-600);

--- a/bundles/.design_system/generated/Themes.css
+++ b/bundles/.design_system/generated/Themes.css
@@ -41,14 +41,15 @@
 }
 
 .theme-dark {
-  --background-primary: var(--grey-900);
+  --background-primary: var(--grey-700);
   --background-secondary: var(--grey-800);
-  --background-tertiary: var(--grey-700);
+  --background-tertiary: var(--grey-900);
   --background-accent: var(--grey-900);
-  --background-floating: var(--grey-900);
+  --background-floating: var(--grey-800);
   --background-mod-subtle: rgba(27, 31, 36, 10%);
   --background-mod-backdrop: rgba(27, 31, 36, 70%);
   --background-highlight: rgba(234, 238, 241, 10%);
+  --border-color-primary: var(--grey-500);
   --text-normal: var(--grey-100);
   --text-secondary: var(--grey-400);
   --text-success: var(--green-400);
@@ -100,6 +101,7 @@
   --background-mod-subtle: rgba(23, 24, 25, 10%);
   --background-mod-backdrop: rgba(23, 24, 25, 70%);
   --background-highlight: rgba(23, 24, 25, 10%);
+  --border-color-primary: var(--grey-200);
   --text-normal: var(--grey-900);
   --text-secondary: var(--grey-400);
   --text-success: var(--green-500);

--- a/bundles/.design_system/themes.json
+++ b/bundles/.design_system/themes.json
@@ -8,7 +8,7 @@
       "hover": ["blue-400", "blue-600"],
       "active": ["blue-500", "blue-700"],
       "text": ["blue-300", "blue-500"],
-      "translucent": ["opacity(blue-500, 15%)", "opacity(blue-600, 15%)"]
+      "translucent": ["opacity(blue-500, 25%)", "opacity(blue-600, 15%)"]
     },
     "purple": {
       "primary": ["purple-400", "purple-500"],
@@ -17,7 +17,7 @@
       "hover": ["purple-400", "purple-600"],
       "active": ["purple-500", "purple-700"],
       "text": ["purple-300", "purple-500"],
-      "translucent": ["opacity(purple-500, 15%)", "opacity(purple-600, 15%)"]
+      "translucent": ["opacity(purple-500, 25%)", "opacity(purple-600, 15%)"]
     }
   },
   "tokens": {
@@ -50,25 +50,25 @@
     "status-success-foreground": ["green-50", "green-50"],
     "status-success-hover": ["green-500", "green-500"],
     "status-success-active": ["green-600", "green-500"],
-    "status-success-translucent": ["opacity(green-600, 15%)", "opacity(green-600, 15%)"],
+    "status-success-translucent": ["opacity(green-600, 25%)", "opacity(green-600, 15%)"],
 
     "status-warning-background": ["yellow-400", "yellow-400"],
     "status-warning-foreground": ["yellow-50", "yellow-50"],
     "status-warning-hover": ["yellow-500", "yellow-600"],
     "status-warning-active": ["yellow-600", "yellow-500"],
-    "status-warning-translucent": ["opacity(yellow-500, 15%)", "opacity(yellow-600, 15%)"],
+    "status-warning-translucent": ["opacity(yellow-500, 25%)", "opacity(yellow-600, 15%)"],
 
     "status-danger-background": ["red-500", "red-500"],
     "status-danger-foreground": ["red-50", "red-50"],
     "status-danger-hover": ["red-600", "red-600"],
     "status-danger-active": ["red-700", "red-500"],
-    "status-danger-translucent": ["opacity(red-600, 15%)", "opacity(red-600, 15%)"],
+    "status-danger-translucent": ["opacity(red-600, 25%)", "opacity(red-600, 15%)"],
 
     "status-info-background": ["teal-400", "teal-500"],
     "status-info-foreground": ["white", "teal-50"],
     "status-info-hover": ["teal-500", "teal-600"],
     "status-info-active": ["teal-600", "teal-500"],
-    "status-info-translucent": ["opacity(teal-500, 15%)", "opacity(teal-600, 15%)"],
+    "status-info-translucent": ["opacity(teal-500, 25%)", "opacity(teal-600, 15%)"],
 
     "status-default-background": ["grey-500", "grey-500"],
     "status-default-foreground": ["grey-50", "grey-50"],

--- a/bundles/.design_system/themes.json
+++ b/bundles/.design_system/themes.json
@@ -21,14 +21,16 @@
     }
   },
   "tokens": {
-    "background-primary": ["grey-900", "white"],
+    "background-primary": ["grey-700", "white"],
     "background-secondary": ["grey-800", "grey-100"],
-    "background-tertiary": ["grey-700", "grey-200"],
+    "background-tertiary": ["grey-900", "grey-200"],
     "background-accent": ["grey-900", "grey-50"],
-    "background-floating": ["grey-900", "white"],
+    "background-floating": ["grey-800", "white"],
     "background-mod-subtle": ["opacity(black, 10%)", "opacity(grey-900, 10%)"],
     "background-mod-backdrop": ["opacity(black, 70%)", "opacity(grey-900, 70%)"],
     "background-highlight": ["opacity(grey-100, 10%)", "opacity(grey-900, 10%)"],
+
+    "border-color-primary": ["grey-500", "grey-200"],
 
     "text-normal": ["grey-100", "grey-900"],
     "text-secondary": ["grey-400", "grey-400"],

--- a/bundles/processing/DonationRow.mod.css
+++ b/bundles/processing/DonationRow.mod.css
@@ -3,15 +3,16 @@
   margin: 16px 0;
   background-color: var(--background-primary);
   border-radius: 4px;
-  border: 1px solid var(--background-tertiary);
+  border: 1px solid var(--border-color-primary);
 }
 
 .header {
   position: sticky;
   top: 0;
-  border-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
   background-color: var(--background-primary);
-  border-bottom: 1px solid var(--background-tertiary);
+  border-bottom: 1px solid var(--border-color-primary);
 }
 
 .headerTop {
@@ -29,6 +30,8 @@
   padding: 8px;
   overflow-wrap: break-word;
   white-space: pre-wrap;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .noCommentHint {
@@ -55,7 +58,7 @@
   position: absolute;
   top: -8px;
   width: 100%;
-  border: 2px solid green;
+  border: 2px solid var(--status-success-background);
   border-radius: 100px;
 }
 

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -202,9 +202,11 @@ function DonationRow(props: DonationRowProps) {
         <Stack direction="horizontal" justify="space-between" align="center" className={donationStyles.headerTop}>
           <Stack direction="horizontal" align="center" spacing="space-lg">
             {draggable ? (
-              <Clickable ref={drag} className={styles.donationDragHandle} aria-label="Drag Donation">
-                <DragHandle />
-              </Clickable>
+              <Text variant="text-md/normal">
+                <Clickable ref={drag} className={styles.donationDragHandle} aria-label="Drag Donation">
+                  <DragHandle />
+                </Clickable>
+              </Text>
             ) : null}
             <Stack spacing="space-none">
               <Text variant="text-md/normal">


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

The darkness of the dark theme wasn't working too well with transparency, layering, and general clarity (donations seemed to roll into each other visually). Lightening it up just a little bit lets shadows and borders provide more distinction and separation.

<img width="1448" alt="image" src="https://user-images.githubusercontent.com/783733/233670252-0938c400-732c-4470-8004-3df705b77346.png">


### Verification Process

No functional changes.