### PR TITLE
Show highlight around donations on processing pages when they are focused

### DIFF
--- a/bundles/.design_system/generated/Themes.css
+++ b/bundles/.design_system/generated/Themes.css
@@ -48,6 +48,7 @@
   --background-floating: var(--grey-800);
   --background-mod-subtle: rgba(27, 31, 36, 10%);
   --background-mod-backdrop: rgba(27, 31, 36, 70%);
+  --background-shadow: rgba(27, 31, 36, 80%);
   --background-highlight: rgba(234, 238, 241, 10%);
   --border-color-primary: var(--grey-500);
   --text-normal: var(--grey-100);
@@ -100,6 +101,7 @@
   --background-floating: var(--white);
   --background-mod-subtle: rgba(23, 24, 25, 10%);
   --background-mod-backdrop: rgba(23, 24, 25, 70%);
+  --background-shadow: rgba(27, 31, 36, 60%);
   --background-highlight: rgba(23, 24, 25, 10%);
   --border-color-primary: var(--grey-200);
   --text-normal: var(--grey-900);

--- a/bundles/.design_system/themes.json
+++ b/bundles/.design_system/themes.json
@@ -28,6 +28,7 @@
     "background-floating": ["grey-800", "white"],
     "background-mod-subtle": ["opacity(black, 10%)", "opacity(grey-900, 10%)"],
     "background-mod-backdrop": ["opacity(black, 70%)", "opacity(grey-900, 70%)"],
+    "background-shadow": ["opacity(black, 80%)", "opacity(black, 60%)"],
     "background-highlight": ["opacity(grey-100, 10%)", "opacity(grey-900, 10%)"],
 
     "border-color-primary": ["grey-500", "grey-200"],

--- a/bundles/processing/DonationRow.mod.css
+++ b/bundles/processing/DonationRow.mod.css
@@ -4,6 +4,14 @@
   background-color: var(--background-primary);
   border-radius: 4px;
   border: 1px solid var(--border-color-primary);
+
+  &:hover {
+    box-shadow: 0 1px 16px var(--background-shadow);
+  }
+
+  &:focus-within {
+    outline: 2px solid var(--status-accent-background);
+  }
 }
 
 .header {

--- a/bundles/processing/DonationRow.tsx
+++ b/bundles/processing/DonationRow.tsx
@@ -85,7 +85,7 @@ export default function DonationRow(props: DonationRowProps) {
   }
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} tabIndex={-1}>
       <div className={styles.header}>
         <Stack direction="horizontal" justify="space-between" align="center" className={styles.headerTop}>
           <div>

--- a/bundles/processing/Processing.mod.css
+++ b/bundles/processing/Processing.mod.css
@@ -1,6 +1,5 @@
 .container {
   display: flex;
-  gap: 16px;
   font-weight: initial;
   background-color: var(--background-primary);
   color: var(--text-primary);
@@ -23,7 +22,7 @@
   flex: 1 1 auto;
   position: relative;
   overflow-y: scroll;
-  padding-right: 16px;
+  padding: 0 16px;
 }
 
 .endOfList {

--- a/bundles/processing/ReadDonations.tsx
+++ b/bundles/processing/ReadDonations.tsx
@@ -207,6 +207,7 @@ function DonationRow(props: DonationRowProps) {
 
   return (
     <div
+      tabIndex={-1}
       className={classNames(donationStyles.container, {
         [donationStyles.isDropOver]: isOver && canDrop,
         [donationStyles.dragging]: isDragging,


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This adds a highlight ring around donation rows when they receive focus from the user. They are not _tabbable_, but they can receive focus, and the ring also shows up whenever anything _within_ the row is focused, like the action buttons.

<img width="990" alt="image" src="https://user-images.githubusercontent.com/783733/233754996-807ce799-a5e8-4d3c-a42b-fb9b5433db24.png">

### Verification Process

No functional changes, the ring shows up.