### PR TITLE
Fix schedule editor dragging data

### DIFF
--- a/bundles/admin/scheduleEditor/dragDrop/emptyTableDropTarget.tsx
+++ b/bundles/admin/scheduleEditor/dragDrop/emptyTableDropTarget.tsx
@@ -16,8 +16,8 @@ export default function EmptyTableDropTarget(props: EmptyTableDropTargetProps) {
 
   const [{ isOver, canDrop }, drop] = useDrop<DragItem, unknown, { isOver: boolean; canDrop: boolean }>(() => ({
     accept: ['speedrun'],
-    drop({ pk }) {
-      moveSpeedrun(pk);
+    drop(item) {
+      moveSpeedrun(item.pk);
     },
     collect: monitor => ({
       canDrop: monitor.canDrop(),

--- a/bundles/admin/scheduleEditor/speedrun.js
+++ b/bundles/admin/scheduleEditor/speedrun.js
@@ -190,25 +190,10 @@ Speedrun.propTypes = {
   editModel: PropTypes.func,
 };
 
-const speedrunSource = {
-  beginDrag: function (props) {
-    return { source_pk: props.speedrun.pk };
-  },
-
-  endDrag: function (props, monitor) {
-    const result = monitor.getDropResult();
-    if (result && result.action) {
-      result.action(props.speedrun.pk);
-    }
-  },
-};
-
 export default function DraggableSpeedrun(props) {
   const [{ isDragging }, drag, preview] = useDrag(() => ({
     type: 'speedrun',
-    beginDrag(props) {
-      return { source_pk: props.speedrun.pk };
-    },
+    item: { pk: props.speedrun.pk },
     endDrag(props, monitor) {
       const result = monitor.getDropResult();
       if (result && result.action) {


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

During one of the earlier upgrades when I refactored the drag and drop code to work with new versions of `react-dnd`, I messed up the dragging on the Schedule Editor. The drag item was _created_ using a property called `source_pk`, but all of the drop handlers referenced just `pk`. This makes the drag item match the drop handler, so now sorting runs works again.

### Verification Process

Tested that moving runs around was correctly updating the schedule.