### PR TITLE
Allow spaces in custom bid options on donate form

### DIFF
--- a/bundles/tracker/donation/components/DonationBidForm.tsx
+++ b/bundles/tracker/donation/components/DonationBidForm.tsx
@@ -151,21 +151,24 @@ const DonationBidForm = (props: DonationBidFormProps) => {
         : null}
 
       {incentive.custom ? (
-        <Checkbox
-          label="Nominate a new option!"
-          name="incentiveBidNewOption"
-          checked={customOptionSelected}
-          look={Checkbox.Looks.NORMAL}
-          onChange={handleNewChoice(null)}>
-          <TextInput
-            value={customOption}
-            name="incentiveBidCustomOption"
-            disabled={!customOptionSelected}
-            placeholder="Enter Option Here"
-            onChange={setCustomOption}
-            maxLength={incentive.maxlength}
+        <>
+          <Checkbox
+            label="Nominate a new option!"
+            name="incentiveBidNewOption"
+            checked={customOptionSelected}
+            look={Checkbox.Looks.DENSE}
+            onChange={handleNewChoice(null)}
           />
-        </Checkbox>
+          {customOptionSelected ? (
+            <TextInput
+              value={customOption}
+              name="incentiveBidCustomOption"
+              placeholder="Enter Option Here"
+              onChange={setCustomOption}
+              maxLength={incentive.maxlength}
+            />
+          ) : null}
+        </>
       ) : null}
 
       {!bidValidation.valid && <Text>{bidValidation.errors.map(error => error.message)}</Text>}

--- a/bundles/uikit/Checkbox.tsx
+++ b/bundles/uikit/Checkbox.tsx
@@ -35,7 +35,7 @@ type CheckboxProps = {
   disabled?: boolean;
   className?: string;
   contentClassName?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   onChange: (checked: boolean) => void;
 };
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Fixes #433 

Because of the way the bid form was structured on the donation page, attempting to put a space into a custom option name resulted in the `Checkbox` intercepting the keyboard event and preventing it from propagating to the `TextInput` (`Clickable` treats Enter and Spacebar as click actions for accessibility).

There are ways to fix this without having to change the DOM structure, but inherently having an Input within a Checkbox's label is fraught from an accessibility perspective and clearly leads to event propagation issues anyway. Instead, this PR just moves the input to _beneath_ the Checkbox instead and hides it until the custom option is selected.

| before | after |
|--------|--------|
| <img width="654" alt="image" src="https://user-images.githubusercontent.com/783733/233808470-5b468b3f-c9df-4072-b814-baa7f395874d.png"> | <img width="661" alt="image" src="https://user-images.githubusercontent.com/783733/233808447-90c80b7c-bb18-49d7-9d2c-d57f81106958.png"> |


### Verification Process

Tested that spaces are handled in custom bid options