### PR TITLE
Enable ordering of donation groups on Read page

### DIFF
--- a/bundles/processing/modules/donation-groups/CreateEditDonationGroupModal.tsx
+++ b/bundles/processing/modules/donation-groups/CreateEditDonationGroupModal.tsx
@@ -39,7 +39,7 @@ export default function CreateEditDonationGroupModal(props: CreateEditDonationGr
   const { group, onClose } = props;
   const isEditing = group != null;
 
-  const newId = React.useId();
+  const [newId] = React.useState(() => (Math.random() + 1).toString(36).substring(7));
   const [name, setName] = React.useState(group?.name || 'New Group');
   const [color, setColor] = React.useState<GroupColorItem>(() => {
     return GROUP_COLOR_ITEMS.find(item => item.value === group?.color) || GROUP_COLOR_ITEMS[0];

--- a/bundles/processing/modules/donation-groups/DonationGroupsStore.tsx
+++ b/bundles/processing/modules/donation-groups/DonationGroupsStore.tsx
@@ -120,7 +120,7 @@ export function useGroupsForDonation(donationId: number) {
  *
  * @param groupId The group to move the donation within.
  * @param movingDonationId The donation being moved to a new position
- * @param targetDonationId The donation above which the moving donation will be placed.
+ * @param targetDonationId The donation around which the moving donation will be placed.
  * @param below When true, the moving donation will be placed below the target instead.
  */
 export function moveDonationWithinGroup(
@@ -144,6 +144,28 @@ export function moveDonationWithinGroup(
     // Update the group in the state
     const newGroups = [...groups];
     newGroups.splice(groupIndex, 1, group);
+    return { groups: newGroups };
+  });
+}
+
+/**
+ * Change the position of a group within the list of groups.
+ *
+ * @param movingGroupId The group being moved to a new position
+ * @param targetGroupId The group around which the moving group will be placed.
+ * @param below When true, the moving group will be placed below the target instead.
+ */
+export function moveDonationGroup(movingGroupId: string, targetGroupId: string, below = false) {
+  useDonationGroupsStore.setState(({ groups }) => {
+    const newGroups = [...groups];
+    const movingGroupIndex = groups.findIndex(group => group.id === movingGroupId);
+    const [movedGroup] = newGroups.splice(movingGroupIndex, 1);
+    // Then find the index of the target and insert the moving donation above it.
+    // If below is true, add one to the index to get the _following_ index.
+    const offset = below ? 1 : 0;
+    const targetGroupIndex = newGroups.findIndex(group => group.id === targetGroupId);
+    newGroups.splice(targetGroupIndex + offset, 0, movedGroup);
+
     return { groups: newGroups };
   });
 }

--- a/bundles/processing/modules/donations/DonationRow.tsx
+++ b/bundles/processing/modules/donations/DonationRow.tsx
@@ -90,10 +90,10 @@ export default function DonationRow(props: DonationRowProps) {
   );
 
   const renderedByline = getBylineElements(donation).map((element, index) => (
-    <>
+    <React.Fragment key={index}>
       {index > 0 ? ' · ' : null}
       {element}
-    </>
+    </React.Fragment>
   ));
 
   const [{ isDragging, isOver, canDrop }, rowRef, handleRef] = useDonationDragAndDrop(donation, onDrop, checkDrop);

--- a/bundles/processing/modules/reading/FilterGroupTab.mod.css
+++ b/bundles/processing/modules/reading/FilterGroupTab.mod.css
@@ -1,0 +1,28 @@
+.draggableTabContainer {
+  position: relative;
+}
+
+.dragging {
+  opacity: 0.6;
+}
+
+.emptyDropTarget {
+  position: relative;
+  display: block;
+  height: 32px;
+}
+
+.dropIndicator {
+  display: none;
+  position: absolute;
+  top: -4px;
+  width: 100%;
+  border: 2px solid var(--status-success-background);
+  border-radius: 100px;
+}
+
+.isDropOver {
+  & .dropIndicator {
+    display: block;
+  }
+}


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Donation groups on the Read Donatinos page are now sortable via drag and drop within the sidebar, just like donations are on the main content page.

This also fixed a bug where group ids would collide between page loads since `React.useId` is a finite incrementing number and not random. Using random digits should ensure enough uniqueness.


https://user-images.githubusercontent.com/783733/233877574-beab9718-4cbe-4374-bf64-74e1c5f08ad5.mov



### Verification Process

Sorting donation groups works as expected. Dropping on each extreme of the list works, and dropping on either side of the dragged donation works (nothing is out of order).