### PR TITLE
Publish package artifacts to internal artifact feed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft tracker/templates
+graft tracker/static
+graft tracker/locale
+graft tracker/fixtures

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include README.md
+
 graft tracker/templates
 graft tracker/static
 graft tracker/locale

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,9 +101,16 @@ jobs:
         displayName: 'Cache yarn'
 
       - script: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel twine
           python setup.py package
         displayName: 'Build Package'
+
+      - task: TwineAuthenticate@1
+        inputs:
+          artifactFeed: gamesdonequick
+
+      - script: |
+          python -m twine upload -r gamesdonequick --config-file $(PYPIRC_PATH) dist/*.whl
 
   - job: precommit_check
     displayName: Run pre-commit hooks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
           python setup.py package
         displayName: 'Build Package'
         env:
-          PACKAGE_VERSION_SUFFIX: $(Build.SourceVersion)
+          PACKAGE_NAME_SUFFIX: $(Build.SourceVersion)
 
       - task: TwineAuthenticate@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,6 +104,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel twine
           python setup.py package
         displayName: 'Build Package'
+        env:
+          PACKAGE_VERSION: $(Build.SourceVersion)
 
       - task: TwineAuthenticate@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,10 +107,11 @@ jobs:
 
       - task: TwineAuthenticate@1
         inputs:
-          artifactFeed: gamesdonequick
+          artifactFeed: donation-tracker/donation-tracker-packages
 
       - script: |
-          python -m twine upload -r gamesdonequick --config-file $(PYPIRC_PATH) dist/*.whl
+          python -m twine upload -r donation-tracker-packages --config-file $(PYPIRC_PATH) dist/*.whl
+        displayName: Upload Package Artifact
 
   - job: precommit_check
     displayName: Run pre-commit hooks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
           python setup.py package
         displayName: 'Build Package'
         env:
-          PACKAGE_VERSION: $(Build.SourceVersion)
+          PACKAGE_VERSION_SUFFIX: $(Build.SourceVersion)
 
       - task: TwineAuthenticate@1
         inputs:

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ setup(
     description='A Django app to assist in tracking donations for live broadcast events.',
     long_description=open('README.md').read(),
     zip_safe=False,
-    package_data={
-        '': ['README.md'],
-        # tracker package data is defined in MANIFEST.in
-    },
+    # Included files are defined in MANIFEST.in, which will be automatically
+    # picked up by setuptools.
+    include_package_data=True,
     cmdclass={
         'package': PackageCommand,
     },

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import subprocess
 
 from setuptools import Command, find_packages, setup
 
+PACKAGE_VERSION = '3.1'
+
 
 class PackageCommand(Command):
     user_options = []
@@ -37,7 +39,7 @@ os.chdir(old_dir)
 
 setup(
     name='django-donation-tracker',
-    version='3.1',
+    version=os.environ.get('PACKAGE_VERSION', PACKAGE_VERSION),
     author='Games Done Quick',
     author_email='tracker@gamesdonequick.com',
     packages=find_packages(include=['tracker', 'tracker.*']),

--- a/setup.py
+++ b/setup.py
@@ -24,20 +24,6 @@ class PackageCommand(Command):
         self.run_command('bdist_wheel')
 
 
-package_data = []
-
-old_dir = os.getcwd()
-
-os.chdir('tracker')
-
-for path in ['templates', 'static', 'locale', 'fixtures']:
-    for root, dirs, files in os.walk(path):
-        for f in files:
-            package_data.append(os.path.join(root, f))
-
-os.chdir(old_dir)
-
-
 def get_package_name(name):
     if not PACKAGE_NAME_SUFFIX:
         return name
@@ -55,7 +41,10 @@ setup(
     description='A Django app to assist in tracking donations for live broadcast events.',
     long_description=open('README.md').read(),
     zip_safe=False,
-    package_data={'': ['README.md'], 'tracker': package_data},
+    package_data={
+        '': ['README.md'],
+        # tracker package data is defined in MANIFEST.in
+    },
     cmdclass={
         'package': PackageCommand,
     },

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import subprocess
 from setuptools import Command, find_packages, setup
 
 PACKAGE_VERSION = '3.1'
+PACKAGE_VERSION_SUFFIX = os.environ.get('PACKAGE_VERSION_SUFFIX', None)
 
 
 class PackageCommand(Command):
@@ -37,9 +38,16 @@ for path in ['templates', 'static', 'locale', 'fixtures']:
 
 os.chdir(old_dir)
 
+
+def get_package_version():
+    if not PACKAGE_VERSION_SUFFIX:
+        return PACKAGE_VERSION
+    return f'{PACKAGE_VERSION}+{PACKAGE_VERSION_SUFFIX}'
+
+
 setup(
     name='django-donation-tracker',
-    version=os.environ.get('PACKAGE_VERSION', PACKAGE_VERSION),
+    version=get_package_version(),
     author='Games Done Quick',
     author_email='tracker@gamesdonequick.com',
     packages=find_packages(include=['tracker', 'tracker.*']),

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ import subprocess
 
 from setuptools import Command, find_packages, setup
 
-PACKAGE_VERSION = '3.1'
-PACKAGE_VERSION_SUFFIX = os.environ.get('PACKAGE_VERSION_SUFFIX', None)
+PACKAGE_NAME_SUFFIX = os.environ.get('PACKAGE_NAME_SUFFIX', None)
 
 
 class PackageCommand(Command):
@@ -39,15 +38,15 @@ for path in ['templates', 'static', 'locale', 'fixtures']:
 os.chdir(old_dir)
 
 
-def get_package_version():
-    if not PACKAGE_VERSION_SUFFIX:
-        return PACKAGE_VERSION
-    return f'{PACKAGE_VERSION}+{PACKAGE_VERSION_SUFFIX}'
+def get_package_name(name):
+    if not PACKAGE_NAME_SUFFIX:
+        return name
+    return f'{name}-{PACKAGE_NAME_SUFFIX}'
 
 
 setup(
-    name='django-donation-tracker',
-    version=get_package_version(),
+    name=get_package_name('django-donation-tracker'),
+    version='3.1',
     author='Games Done Quick',
     author_email='tracker@gamesdonequick.com',
     packages=find_packages(include=['tracker', 'tracker.*']),


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Description of the Change

In doing a lot of local testing, I want to be able to create new deployments of the tracker based on versions other than what is publicly published, and in cases where I won't necessarily have the source code immediately available (e.g., in a staging deployment).

The easiest way to do this is to build packages from various commits and branches and have them available from a URL. With that, projects can link the tracker as a dependency using a URL, and freely swap out that URL with different versions to easily update their deployments.

This PR sets up the CI pipeline to automatically upload the built package artifact from the Tracker Package job to an Artifact Feed in Azure, which should then be downloadable from elsewhere.

As it turns out, the package wasn't actually building correctly anyway, as the generated assets (`tracker/static/gen` and `tracker/templates/ui/generated`) weren't being picked up by setuptools when building the final wheel. Through a chain of discoveries, it turns out the only reliable way to get generated files into the wheel is using `MANIFEST.in`, which runs _after_ the `cmdclass` command runs, meaning it will properly discover the generated files. This also means we _don't_ need the `package_data` key in setup.py, which simplifies it a little bit in return.

One other thing I noticed as part of this was that the `ProcessingSocket` URL was still hardcoded for local development, so this PR also updates that code to dynamically load a `SOCKET_PATH` from the server and resolve a full URL dynamically.

All of that together means that we should have a proper publishable package again with no hardcoded paths.

### Verification Process

Test that the package gets built, published to the feed, and is available to download, and that the processing socket is able to connect properly.