### PR TITLE
Fix partitions being ignored on new processing page

### DIFF
--- a/bundles/processing/pages/ProcessDonations.tsx
+++ b/bundles/processing/pages/ProcessDonations.tsx
@@ -88,7 +88,7 @@ export default function ProcessDonations() {
   const params = useParams<{ eventId: string }>();
   const { eventId } = params;
 
-  const { processingMode } = useProcessingStore();
+  const { partition, partitionCount, processingMode } = useProcessingStore();
   const process = PROCESSES[processingMode];
 
   const { data: event } = useQuery(`events.${eventId}`, () => APIClient.getEvent(eventId));
@@ -96,7 +96,14 @@ export default function ProcessDonations() {
     onSuccess: donations => loadDonations(donations),
   });
 
-  const donations = useDonationsInState(process.donationState);
+  const partitionFilter = React.useCallback(
+    (donation: Donation) => {
+      return donation.id % partitionCount === partition;
+    },
+    [partition, partitionCount],
+  );
+
+  const donations = useDonationsInState(process.donationState, partitionFilter);
 
   const renderDonationRow = React.useCallback(
     (donation: Donation) => (


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

A side effect of the refactoring, partitions weren't being applied to the donation list on the donation processing page. This re-adds the partitioning with a slightly more generic implementation (any kind of filter on the list of donations in a state)

### Verification Process

Tested that donations show up in the list only when they match the currently selected partitation.