### PR TITLE
Fix invalid keyword regexes crashing processing pages

### DIFF
--- a/bundles/processing/modules/donations/HighlightKeywords.tsx
+++ b/bundles/processing/modules/donations/HighlightKeywords.tsx
@@ -5,6 +5,19 @@ import { useSearchKeywords } from './SearchKeywordsStore';
 
 import styles from './HighlightKeywords.mod.css';
 
+/**
+ * Wraps the keyword with word boundary tokens and ensures that the result is a
+ * valid regex. If the keyword is not valid as a regex, it is ignored.
+ */
+function makeKeywordRegex(keyword: string): string | undefined {
+  try {
+    const regex = new RegExp(`\\b${keyword}\\b`);
+    return regex.source;
+  } catch (e) {
+    return undefined;
+  }
+}
+
 interface HighlightKeywordsProps {
   children: string;
 }
@@ -13,5 +26,9 @@ export default function HighlightKeywords(props: HighlightKeywordsProps) {
   const { children } = props;
   const keywords = useSearchKeywords();
 
-  return <Highlighter highlightClassName={styles.highlighted} searchWords={keywords} textToHighlight={children} />;
+  const regexKeywords = React.useMemo(() => {
+    return keywords.map(makeKeywordRegex).filter((word): word is string => word != null);
+  }, [keywords]);
+
+  return <Highlighter highlightClassName={styles.highlighted} searchWords={regexKeywords} textToHighlight={children} />;
 }

--- a/bundles/processing/modules/donations/SearchKeywordsInput.tsx
+++ b/bundles/processing/modules/donations/SearchKeywordsInput.tsx
@@ -12,7 +12,7 @@ export default function SearchKeywordsInput() {
   const [initialKeywords] = React.useState(() => searchKeywords.map(word => word.replace(/\\b/g, '')).join(', '));
 
   function handleKeywordsChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    const words = event.target.value.split(',').map(word => `\\b${word.trim()}\\b`);
+    const words = event.target.value.split(',');
     setSearchKeywords(words);
   }
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Keywords were being blindly interpreted as regexes, meaning any invalid characters would throw an `Invalid regex expression` error. This moves the regexification to the Highlighter component, where it also does some additional validation and ignores invalid regexes from the split list.

You still can't use a comma _within_ a search keyword, but that's fine for now. You can do basically anything else with a regex, though, and that's plenty powerful for what we're doing.

### Verification Process

Tested that multiple types of invalid regexes (like `openparen(`) don't crash the page.