### PR TITLE
bid/donation event must match [#178840281]

### DIFF
--- a/tests/test_bid.py
+++ b/tests/test_bid.py
@@ -314,6 +314,20 @@ class TestBid(TestBidBase):
         with self.assertRaises(ValidationError):
             bid.clean()
 
+    def test_event_mismatch(self):
+        other_event = randgen.generate_event(self.rand)
+        other_event.save()
+        other_donation = randgen.generate_donation(self.rand, event=other_event)
+        other_donation.save()
+        donation_bid = models.DonationBid.objects.create(
+            donation=other_donation, bid=self.opened_bid, amount=other_donation.amount
+        )
+
+        with self.assertRaises(
+            ValidationError, msg='Donation/Bid event mismatch should fail validation'
+        ):
+            donation_bid.clean()
+
     def test_repeat_challenge(self):
         with self.subTest('should not raise on divisors'):
             self.challenge.repeat = 5

--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -534,6 +534,10 @@ class DonationBid(models.Model):
         if not self.bid.istarget:
             raise ValidationError('Target bid must be a leaf node')
         self.donation.clean(self)
+        if self.donation.event != self.bid.event:
+            raise ValidationError(
+                'Target bid and target donation must be part of the same event'
+            )
         from .. import viewutil
 
         bidsTree = (


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/178840281

### Description of the Change

Simple validation check. This came up during some recent event when somebody accidentally picked an old Bid while assigning things manually. I forget what the actual effect was, but it's simple enough to prevent.

### Verification Process

Tried to attach a DonationBid with a mismatch in the admin, got the expected error.