### PR TITLE
add a NotFound component for React routing [#185223254]

### DIFF
--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -14,6 +14,7 @@ import Spinner from '@public/spinner';
 
 import { setAPIRoot } from '@tracker/Endpoints';
 
+import NotFound from '../public/notFound';
 import ScheduleEditor from './scheduleEditor';
 
 const Interstitials = loadable(() => import('./interstitials' /* webpackChunkName: 'interstitials' */), {
@@ -198,6 +199,7 @@ function App() {
                 {canSeeHiddenBids && (
                   <Route path={`${match.url}/process_pending_bids/:event`} component={ProcessPendingBids} />
                 )}
+                <Route component={NotFound} />
               </Switch>
             </div>
           </Spinner>

--- a/bundles/public/notFound.tsx
+++ b/bundles/public/notFound.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function NotFound() {
+  return <div>That page either does not exist or you do not have access to it.</div>;
+}


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/185223254

### Description of the Change

Just a simple error message when the route either doesn't exist or can't be accessed by the current user.

### Verification Process

Put in a url that doesn't exist, and verified that the message showed up.