### PR TITLE
Determine ProcessingSocket url dynamically

### DIFF
--- a/bundles/processing/App.tsx
+++ b/bundles/processing/App.tsx
@@ -4,8 +4,8 @@ import { Accent, AppContainer, Theme } from '@spyrothon/sparx';
 
 import { useConstants } from '@common/Constants';
 import { usePermission } from '@public/api/helpers/auth';
+import APIClient from '@public/apiv2/APIClient';
 import { setAPIRoot } from '@public/apiv2/HTTPUtils';
-import { ProcessingSocket } from '@public/apiv2/sockets/ProcessingSocket';
 
 import { loadDonations } from './modules/donations/DonationsStore';
 import useProcessingStore from './modules/processing/ProcessingStore';
@@ -28,14 +28,14 @@ export default function App() {
   }, [APIV2_ROOT]);
 
   React.useEffect(() => {
-    const unsubActions = ProcessingSocket.on('processing_action', event => {
+    const unsubActions = APIClient.sockets.processingSocket.on('processing_action', event => {
       loadDonations([event.donation]);
       if (event.action !== 'unprocessed') {
         processDonation(event.donation, event.action, false);
       }
     });
 
-    const unsubNewDonations = ProcessingSocket.on('donation_received', event => {
+    const unsubNewDonations = APIClient.sockets.processingSocket.on('donation_received', event => {
       loadDonations([event.donation]);
     });
 

--- a/bundles/processing/index.tsx
+++ b/bundles/processing/index.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import Constants from '@common/Constants';
 import { createTrackerStore } from '@public/api';
+import APIClient from '@public/apiv2/APIClient';
 import { setAPIRoot, setCSRFToken } from '@public/apiv2/HTTPUtils';
 import ErrorBoundary from '@public/errorBoundary';
 
@@ -29,6 +30,7 @@ window.AdminApp = function (props: any) {
 
   setCSRFToken(props.csrfToken);
   setAdminPath(props.ROOT_PATH);
+  APIClient.sockets.setSocketRoot(`${props.TRACKER_PATH}/ws/`);
   setAPIRoot(props.CONSTANTS.APIV2_ROOT);
 
   const root = createRoot(document.getElementById('container')!);

--- a/bundles/processing/modules/processing/ConnectionStatus.tsx
+++ b/bundles/processing/modules/processing/ConnectionStatus.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Callout, Header, Stack, Text } from '@spyrothon/sparx';
 
-import { ProcessingSocket } from '@public/apiv2/sockets/ProcessingSocket';
+import APIClient from '@public/apiv2/APIClient';
 
 interface ConnectionStatusProps {
   refetch: () => Promise<unknown>;
@@ -21,10 +21,10 @@ const STATUS_CONTENT = {
 };
 
 export default function ConnectionStatus({ refetch, isFetching }: ConnectionStatusProps) {
-  const [isConnected, setConnected] = React.useState(() => ProcessingSocket.isConnected);
+  const [isConnected, setConnected] = React.useState(() => APIClient.sockets.processingSocket.isConnected);
 
   React.useEffect(() => {
-    const unsubscribe = ProcessingSocket.on('connection_changed', event => {
+    const unsubscribe = APIClient.sockets.processingSocket.on('connection_changed', event => {
       setConnected(event.isConnected);
     });
 

--- a/bundles/public/apiv2/APIClient.tsx
+++ b/bundles/public/apiv2/APIClient.tsx
@@ -1,11 +1,13 @@
 import * as donations from './routes/donations';
 import * as events from './routes/events';
 import * as me from './routes/me';
+import { sockets } from './sockets';
 
 const client = {
   ...donations,
   ...events,
   ...me,
+  sockets,
 };
 
 export default client;

--- a/bundles/public/apiv2/sockets/ProcessingSocket.tsx
+++ b/bundles/public/apiv2/sockets/ProcessingSocket.tsx
@@ -87,5 +87,3 @@ export class ProcessingSocketImpl {
     }
   }
 }
-
-export const ProcessingSocket = new ProcessingSocketImpl('ws://localhost:8000/tracker/ws/processing/');

--- a/bundles/public/apiv2/sockets/index.tsx
+++ b/bundles/public/apiv2/sockets/index.tsx
@@ -1,0 +1,28 @@
+import { ProcessingSocketImpl } from './ProcessingSocket';
+
+let socketRoot: string | undefined;
+let processingSocket: ProcessingSocketImpl | undefined;
+
+function getAbsoluteSocketURL(path: string) {
+  if (socketRoot == null) {
+    throw 'setSocketRoot must be called with a value for the common websocket path before requesting a websocket.';
+  }
+
+  // If the root doesn't start with a slash, assume it's a fully-formed URL already.
+  if (!socketRoot.startsWith('/')) return socketRoot;
+
+  const protocol = window.location.protocol === 'https' ? 'wss' : 'ws';
+
+  return `${protocol}://${window.location.host}${socketRoot}${path}`;
+}
+
+export const sockets = new (class {
+  setSocketRoot(path: string) {
+    socketRoot = path;
+  }
+
+  get processingSocket(): ProcessingSocketImpl {
+    processingSocket ??= new ProcessingSocketImpl(getAbsoluteSocketURL('processing/'));
+    return processingSocket;
+  }
+})();

--- a/tracker/templates/ui/minimal.html
+++ b/tracker/templates/ui/minimal.html
@@ -9,6 +9,7 @@
     {{ app_name|json_script:'app_name' }}
     {{ CONSTANTS|json_script:'CONSTANTS' }}
     {{ ROOT_PATH|json_script:'ROOT_PATH' }}
+    {{ TRACKER_PATH|json_script:'TRACKER_PATH' }}
 
     <%= htmlWebpackPlugin.tags.headTags %>
 
@@ -20,6 +21,7 @@
             {
               CONSTANTS: JSON.parse(document.getElementById('CONSTANTS').textContent),
               ROOT_PATH: JSON.parse(document.getElementById('ROOT_PATH').textContent),
+              TRACKER_PATH: JSON.parse(document.getElementById('TRACKER_PATH').textContent),
               csrfToken: document.querySelector('input[name=csrfmiddlewaretoken]').value,
             }
         );

--- a/tracker/ui/views.py
+++ b/tracker/ui/views.py
@@ -77,12 +77,13 @@ def admin(request, ROOT_PATH=None, **kwargs):
 @never_cache
 @no_querystring
 @staff_member_required
-def admin_v2(request, ROOT_PATH=None, **kwargs):
+def admin_v2(request, ROOT_PATH=None, TRACKER_PATH=None, **kwargs):
     """
     This is the same as `admin`, but with a blank template so that the page has
     full control over styling without having to override bootstrap's styles.
     """
     ROOT_PATH = ROOT_PATH or reverse('tracker:ui:admin')
+    TRACKER_PATH = TRACKER_PATH or reverse('tracker:index_all')
 
     return render(
         request,
@@ -90,6 +91,7 @@ def admin_v2(request, ROOT_PATH=None, **kwargs):
         {
             'CONSTANTS': constants(request.user),
             'ROOT_PATH': ROOT_PATH,
+            'TRACKER_PATH': TRACKER_PATH,
             'app_name': 'AdminApp',
         },
     )


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

When I added the ProcessingSocket implementation, I left it hardcoded to reference `localhost:8000` since that's the default development setting. I was positive that I had already replaced that and made it dynamic, but apparently not.

This reconfigures how the Socket gets created and enforces that `setSocketRoot` is called first. That is then set up to call with a new page param `TRACKER_PATH`, which is just where the tracker is mounted as a URL. I debated adding a named route for `tracker:ws` or something, but for simplicity now I just went with `tracker:index_all` and then append `ws` on the frontend.

### Verification Process

Ensured that the sockets still connected on local development and received events. Will test that `https` switching happens once this can be deployed.