### PR TITLE
fix processing socket protocol resolution

### DIFF
--- a/bundles/public/apiv2/sockets/index.tsx
+++ b/bundles/public/apiv2/sockets/index.tsx
@@ -11,9 +11,9 @@ function getAbsoluteSocketURL(path: string) {
   // If the root doesn't start with a slash, assume it's a fully-formed URL already.
   if (!socketRoot.startsWith('/')) return socketRoot;
 
-  const protocol = window.location.protocol === 'https' ? 'wss' : 'ws';
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 
-  return `${protocol}://${window.location.host}${socketRoot}${path}`;
+  return `${protocol}//${window.location.host}${socketRoot}${path}`;
 }
 
 export const sockets = new (class {


### PR DESCRIPTION
I forgot window.location.protocol includes the colon, so the check would always fail and use `ws:` instead.

# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

I forgot window.location.protocol includes the colon, so the check would always fail and use `ws:` instead.


### Verification Process

I can't easily test `https` locally atm, but I did run the function through the console and it was resolving correctly.