### PR TITLE
temporarily remove processing MutationButton tooltips to avoid persistence issue

### DIFF
--- a/bundles/processing/modules/processing/MutationButton.tsx
+++ b/bundles/processing/modules/processing/MutationButton.tsx
@@ -14,11 +14,14 @@ interface MutationButtonProps<T> {
 export default function MutationButton<T>(props: MutationButtonProps<T>) {
   const { mutation, donationId, variant = 'default', label, icon: Icon, disabled = false } = props;
 
-  const [tooltipProps] = useTooltip<HTMLButtonElement>(label);
+  // const [tooltipProps] = useTooltip<HTMLButtonElement>(label);
 
   return (
     <Button
-      {...tooltipProps}
+      // NOTE(faulty): Hiding these tooltips for now because they incidentally
+      // persist on the screen after a donation is actioned and cover up other buttons.
+      // {...tooltipProps}
+      title={label}
       // eslint-disable-next-line react/jsx-no-bind
       onClick={() => mutation.mutate(donationId)}
       disabled={disabled || mutation.isLoading}


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Description of the Change

At the event, hosts specifically were having an issue where the tooltips on the mutation buttons for reading/ignored/editing donations would persist after the donation row was removed, which started covering up all of the button area after a few actions.

This removes those tooltips for now and just uses the HTML `title` attribute while a better fix can be made to the design system to avoid it entirely.
