### PR TITLE
remove Python 3.7 from supported versions [#184898712]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
           PYTHON_VERSION: '3.11'
           DJANGO_VERSION: '4.2'
         Oldest:
-          PYTHON_VERSION: '3.7'
+          PYTHON_VERSION: '3.8'
           DJANGO_VERSION: '3.2'
         Django32:
           PYTHON_VERSION: '3.11'
@@ -22,7 +22,6 @@ jobs:
         Django41:
           PYTHON_VERSION: '3.11'
           DJANGO_VERSION: '4.1'
-        # Python37: # does not need separate testing because python 3.8 is required for Django 4.x
         Python38:
           PYTHON_VERSION: '3.8'
           DJANGO_VERSION: '4.2'


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [X] I've added tests or modified existing tests for the change.~
~- [X] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184898712

### Description of the Change

Python 3.7 is EOL. We no longer support it. Changed the matrix to accommodate this change.

### Verification Process

Is the matrix green?
