### PR TITLE
donation postbacks include bid information

### DIFF
--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -58,8 +58,24 @@ class TestDonationConsumer(TransactionTestCase):
             event=self.event,
             transactionstate='COMPLETED',
         )
+        self.challenge = models.Bid.objects.create(
+            event=self.event, istarget=True, goal=500
+        )
+        self.choice = models.Bid.objects.create(event=self.event)
+        self.option = models.Bid.objects.create(parent=self.choice, istarget=True)
+        self.challenge_bid = models.DonationBid.objects.create(
+            donation=self.donation, bid=self.challenge, amount=1
+        )
+        self.option_bid = models.DonationBid.objects.create(
+            donation=self.donation, bid=self.option, amount=0.5
+        )
 
     def tearDown(self):
+        self.option_bid.delete()
+        self.challenge_bid.delete()
+        self.option.delete()
+        self.choice.delete()
+        self.challenge.delete()
         self.donation.delete()
         self.donor.delete()
         self.event.delete()
@@ -76,6 +92,7 @@ class TestDonationConsumer(TransactionTestCase):
         expected = {
             'type': 'donation',
             'id': self.donation.id,
+            'event': self.event.id,
             'timereceived': str(self.donation.timereceived),
             'comment': self.donation.comment,
             'amount': self.donation.amount,
@@ -83,6 +100,26 @@ class TestDonationConsumer(TransactionTestCase):
             'donor__visiblename': self.donor.visible_name(),
             'new_total': self.donation.amount,
             'domain': self.donation.domain,
+            'bids': [
+                {
+                    'id': self.challenge.id,
+                    'total': self.challenge_bid.amount,
+                    'parent': None,
+                    'name': self.challenge.name,
+                    'goal': self.challenge.goal,
+                    'state': self.challenge.state,
+                    'speedrun': self.challenge.speedrun_id,
+                },
+                {
+                    'id': self.option.id,
+                    'total': self.option_bid.amount,
+                    'parent': self.option.parent_id,
+                    'name': self.option.name,
+                    'goal': self.option.goal,
+                    'state': self.option.state,
+                    'speedrun': self.option.speedrun_id,
+                },
+            ],
         }
         self.assertEqual(result, expected)
 

--- a/tracker/eventutil.py
+++ b/tracker/eventutil.py
@@ -21,6 +21,7 @@ def post_donation_to_postbacks(donation):
 
     data = {
         'id': donation.id,
+        'event': donation.event_id,
         'timereceived': str(donation.timereceived),
         'comment': donation.comment,
         'amount': float(donation.amount),
@@ -28,6 +29,18 @@ def post_donation_to_postbacks(donation):
         'donor__visiblename': donation.donor.visible_name(),
         'new_total': float(total),
         'domain': donation.domain,
+        'bids': [
+            {
+                'id': db.bid.id,
+                'total': float(db.bid.total),
+                'parent': db.bid.parent_id,
+                'name': db.bid.name,
+                'goal': float(db.bid.goal) if db.bid.goal else None,
+                'state': db.bid.state,
+                'speedrun': db.bid.speedrun_id,
+            }
+            for db in donation.bids.select_related('bid')
+        ],
     }
 
     async_to_sync(get_channel_layer().group_send)(


### PR DESCRIPTION
[#185152880]

# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/185152880

### Description of the Change

The live branch has included bid information in the websocket donation payload for quite a while now. This is just that.

### Verification Process

It's been on the live branch for quite some time.