### PR TITLE
Fix permission name for pending donation feed

### DIFF
--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -59,7 +59,7 @@ class BidFeedPermission(BasePermission):
         return super().has_permission(request, view) and (
             feed is None
             or feed in self.PUBLIC_FEEDS
-            or request.user.has_perm('tracker.view_hidden_bids')
+            or request.user.has_perm('tracker.view_hidden_bid')
         )
 
 
@@ -71,5 +71,5 @@ class BidStatePermission(BasePermission):
     def has_object_permission(self, request: Request, view: t.Callable, obj: t.Any):
         return super().has_object_permission(request, view, obj) and (
             obj.state in self.PUBLIC_STATES
-            or request.user.has_perm('tracker.view_hidden_bids')
+            or request.user.has_perm('tracker.view_hidden_bid')
         )


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

Link to the issue from the [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1521291) that your change addresses. (Expand the story and click the link icon to copy the link to your clipboard.)

N/A


### Description of the Change

This PR fixes a bug with permissions preventing screeners from accessing pending donations.

Steps to reproduce:
1. Create a bid that allows for custom entries (like a character name)
2. Submit a new entry to the bid
3. Visit the "process pending bids" page from a normal user that has the `tracker.view_hidden_bid` permission applied to them.
4. Observe the browser console as the `bids/feed_pending` request returns a 403 status code


### Verification Process

This fix has been verified with @uraniumanchor who gave me the clue as to what was happening.
