### PR TITLE
fix permissions on Bid v2 endpoint [#186384302]

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -120,6 +120,9 @@ class TestRemoveNullsMigrations(MigrationsTestCase):
 
 class APITestCase(TransactionTestCase):
     model_name = None
+    view_user_permissions = []  # trickles to add_user and locked_user
+    add_user_permissions = []  # trickles to locked_user
+    locked_user_permissions = []
     encoder = DjangoJSONEncoder()
 
     def parseJSON(self, response, status_code=200):
@@ -515,6 +518,7 @@ class APITestCase(TransactionTestCase):
             self.view_user.user_permissions.add(
                 Permission.objects.get(name=f'Can view {self.model_name}'),
             )
+
             self.add_user.user_permissions.add(
                 Permission.objects.get(name=f'Can add {self.model_name}'),
                 Permission.objects.get(name=f'Can change {self.model_name}'),
@@ -525,6 +529,25 @@ class APITestCase(TransactionTestCase):
                 Permission.objects.get(name=f'Can change {self.model_name}'),
                 Permission.objects.get(name=f'Can view {self.model_name}'),
             )
+        self.view_user.user_permissions.add(
+            *(Permission.objects.filter(codename__in=self.view_user_permissions))
+        )
+        self.add_user.user_permissions.add(
+            *(
+                Permission.objects.filter(
+                    codename__in=self.view_user_permissions + self.add_user_permissions
+                )
+            )
+        )
+        self.locked_user.user_permissions.add(
+            *(
+                Permission.objects.filter(
+                    codename__in=self.view_user_permissions
+                    + self.add_user_permissions
+                    + self.locked_user_permissions
+                )
+            )
+        )
         self.super_user = User.objects.create(username='super', is_superuser=True)
         self.maxDiff = None
 
@@ -581,7 +604,7 @@ class TrackerSeleniumTestCase(StaticLiveServerTestCase, metaclass=_TestFailedMet
                 f'./test-results/TEST-{self.id()}.{int(time.time())}.png'
             )
             raise Exception(
-                f'data:image/png;base64,{self.webdriver.get_screenshot_as_base64()}'
+                f'{self.webdriver.current_url}\ndata:image/png;base64,{self.webdriver.get_screenshot_as_base64()}'
             )
 
     def tracker_login(self, username, password='password'):

--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -37,7 +37,7 @@ class EventLockedPermission(DjangoModelPermissionsOrAnonReadOnly):
     def has_permission(self, request: Request, view: t.Callable):
         return super().has_permission(request, view) and (
             request.method in SAFE_METHODS
-            or request.user.has_perm('tracker.edit_locked_events')
+            or request.user.has_perm('tracker.can_edit_locked_events')
             or not view.is_event_locked(request)
         )
 
@@ -59,7 +59,7 @@ class BidFeedPermission(BasePermission):
         return super().has_permission(request, view) and (
             feed is None
             or feed in self.PUBLIC_FEEDS
-            or request.user.has_perm('tracker.view_hidden_bids')
+            or request.user.has_perm('tracker.view_hidden_bid')
         )
 
 
@@ -71,5 +71,5 @@ class BidStatePermission(BasePermission):
     def has_object_permission(self, request: Request, view: t.Callable, obj: t.Any):
         return super().has_object_permission(request, view, obj) and (
             obj.state in self.PUBLIC_STATES
-            or request.user.has_perm('tracker.view_hidden_bids')
+            or request.user.has_perm('tracker.view_hidden_bid')
         )


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186384302

### Description of the Change

This is a more complete version of #604, I couldn't merge that one for two reasons:

- our CI doesn't let the tests pass because of a permissions check that non-collabs can't pass (we'll need to address this later)
- no tests were added or fixed that would have exposed the problem

This was fixed on the hotfix branch a while back but a) I forgot to merge it back into master and b) I never updated the tests to actually do the test correctly (they were spuriously passing because superuser, I need to go through and make sure no other tests are doing that).

### Verification Process

The fix has been on the real server for a while, plus I manually verified it again locally.