### PR TITLE
remove Django 4.1 from supported matrix, add Python 3.12 and Django 5.0 [#185819424]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Requirements
 
-- Python 3.7 to 3.11
-- Django 3.2, 4.1, or 4.2
+- Python 3.8 to 3.12
+- Django 3.2, 4.2, or 5.0
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 
@@ -27,7 +27,7 @@ Or after downloading or checking out locally:
 
 For further reading on what else your server needs to look like:
 
-- [Deploying Django](https://docs.djangoproject.com/en/4.2/howto/deployment/)
+- [Deploying Django](https://docs.djangoproject.com/en/dev/howto/deployment/)
 - [Deploying Django Channels](https://channels.readthedocs.io/en/latest/deploying.html)
 - [Configuring Post Office](https://github.com/ui/django-post_office#management-commands) (needed to send emails)
 - [Using Celery with Django](https://docs.celeryproject.org/en/stable/django/first-steps-with-django.html) (optional)
@@ -113,16 +113,15 @@ question if it's in the list.
 
 ## Development Quick Start
 
-Start up a new Django Project like the [Django Tutorial](https://docs.djangoproject.com/en/2.2/intro/tutorial01/).
-
-- `pip install django~=3.2`
-- `django-admin startproject tracker_development`
-- `cd tracker_development`
-
 Clone the Git repo and install it in edit mode:
 
 - `git clone git@github.com:GamesDoneQuick/donation-tracker`
 - `pip install -e donation-tracker`
+
+Start up a new Django Project like the [Django Tutorial](https://docs.djangoproject.com/en/dev/intro/tutorial01/).
+
+- `pip install django~=5.0` (if you need a specific version of Django)
+- `django-admin startproject tracker_development`
 
 Install remaining development dependencies:
 
@@ -217,6 +216,12 @@ Additionally, you should be able to open the [Websocket Test Page](http://localh
 see the heartbeat. If the page loads but the pings don't work, Channels isn't set up correctly. The
 [Channels Documentation](https://channels.readthedocs.io/en/latest/installation.html) may be helpful.
 
+## Note for PyCharm users
+
+There is a known bug with PyCharm as of PyCharm 2023.2.4 and Django 5.0. See
+[this YouTrack ticket](https://youtrack.jetbrains.com/issue/PY-53355) for details. There is a workaround that
+requires you hand-editing the bundled test runner script before you can run unit tests within the IDE.
+
 ## Contributing
 
 This project uses [`pre-commit`](https://pre-commit.com/) to run linters and other checks before every commit.
@@ -224,4 +229,5 @@ This project uses [`pre-commit`](https://pre-commit.com/) to run linters and oth
 If you followed the instructions above, `pre-commit` should run the appropriate hooks every time you commit or push.
 
 _Note:_ You _can_ bypass these checks by adding `--no-verify` when you commit or push, though this is highly
-discouraged in most cases. In the future, CI tests may fail if any of these checks are not satisfied.
+discouraged in most cases. CI runs the same checks as the hooks do, and will cause pipeline to fail if you bypass
+a genuine failure.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,18 +11,15 @@ jobs:
     displayName: Tracker Backend
     strategy:
       matrix:
-        Latest:
-          PYTHON_VERSION: '3.11'
-          DJANGO_VERSION: '4.2'
         Oldest:
           PYTHON_VERSION: '3.8'
           DJANGO_VERSION: '3.2'
         Django32:
-          PYTHON_VERSION: '3.11'
+          PYTHON_VERSION: '3.10'
           DJANGO_VERSION: '3.2'
-        Django41:
-          PYTHON_VERSION: '3.11'
-          DJANGO_VERSION: '4.1'
+        Django42:
+          PYTHON_VERSION: '3.12'
+          DJANGO_VERSION: '4.2'
         Python38:
           PYTHON_VERSION: '3.8'
           DJANGO_VERSION: '4.2'
@@ -31,7 +28,13 @@ jobs:
           DJANGO_VERSION: '4.2'
         Python3A:
           PYTHON_VERSION: '3.10'
-          DJANGO_VERSION: '4.2'
+          DJANGO_VERSION: '5.0'
+        Python3B:
+          PYTHON_VERSION: '3.11'
+          DJANGO_VERSION: '5.0'
+        Latest:
+          PYTHON_VERSION: '3.12'
+          DJANGO_VERSION: '5.0'
 
     steps:
       - task: UsePythonVersion@0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_package_name(name):
 
 setup(
     name=get_package_name('django-donation-tracker'),
-    version='3.1',
+    version='3.2',
     author='Games Done Quick',
     author_email='tracker@gamesdonequick.com',
     packages=find_packages(include=['tracker', 'tracker.*']),
@@ -48,11 +48,10 @@ setup(
         'package': PackageCommand,
     },
     install_requires=[
-        'backports.cached-property~=1.0.2;python_version<"3.8"',
         'backports.zoneinfo;python_version<"3.9"',
         'celery~=5.0',
         'channels>=2.0',
-        'Django>=3.2,!=4.0.*,<4.3',
+        'Django>=3.2,!=4.0.*,!=4.1.*,<5.1',
         'django-ajax-selects~=2.1',  # publish error, see: https://github.com/crucialfelix/django-ajax-selects/issues/306
         'django-ical~=1.7',
         'django-mptt~=0.10',
@@ -63,7 +62,7 @@ setup(
         'python-dateutil~=2.8.1;python_version<"3.11"',
         'requests>=2.27.1,<2.32.0',
     ],
-    python_requires='>=3.7, <3.12',
+    python_requires='>=3.8, <3.13',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -73,11 +72,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/apiv2/test_donations.py
+++ b/tests/apiv2/test_donations.py
@@ -95,7 +95,7 @@ class TestDonations(APITestCase):
 
         self.assertEqual(len(response.data), len(donations))
         for index, donation in enumerate(donations):
-            self.assertEquals(response.data[index]['id'], donation.pk)
+            self.assertEqual(response.data[index]['id'], donation.pk)
 
     def test_unprocessed_returns_only_after_timestamp(self):
         date = datetime.utcnow()
@@ -166,7 +166,7 @@ class TestDonations(APITestCase):
 
         self.assertEqual(len(response.data), len(donations))
         for index, donation in enumerate(donations):
-            self.assertEquals(response.data[index]['id'], donation.pk)
+            self.assertEqual(response.data[index]['id'], donation.pk)
 
     def test_flagged_returns_only_after_timestamp(self):
         date = datetime.utcnow()
@@ -218,14 +218,14 @@ class TestDonations(APITestCase):
     def test_unprocess_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/unprocess/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_unprocess_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/unprocess/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_unprocess_resets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='approved')[0]
@@ -257,14 +257,14 @@ class TestDonations(APITestCase):
     def test_approve_comment_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/approve_comment/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_approve_comment_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/approve_comment/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_approve_comment_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='pending')[0]
@@ -299,14 +299,14 @@ class TestDonations(APITestCase):
     def test_deny_comment_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/deny_comment/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_deny_comment_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/deny_comment/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_deny_comment_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='pending')[0]
@@ -341,14 +341,14 @@ class TestDonations(APITestCase):
     def test_flag_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/flag/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_flag_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/flag/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_flag_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='')[0]
@@ -381,7 +381,7 @@ class TestDonations(APITestCase):
     def test_send_to_reader_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/send_to_reader/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_send_to_reader_requires_permissions(self):
         user = User.objects.create()
@@ -392,7 +392,7 @@ class TestDonations(APITestCase):
         self.client.force_authenticate(user=user)
 
         response = self.client.patch(f'/tracker/api/v2/donations/1234/send_to_reader/')
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def test_send_to_reader_fails_with_only_send_to_reader_permission(self):
         user = User.objects.create()
@@ -400,7 +400,7 @@ class TestDonations(APITestCase):
         self.client.force_authenticate(user=user)
 
         response = self.client.patch(f'/tracker/api/v2/donations/1234/send_to_reader/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_send_to_reader_checks_for_one_step_screening(self):
         user = User.objects.create()
@@ -414,7 +414,7 @@ class TestDonations(APITestCase):
         response = self.client.patch(
             f'/tracker/api/v2/donations/{donation.pk}/send_to_reader/'
         )
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
         self.event.use_one_step_screening = True
         self.event.save()
@@ -422,7 +422,7 @@ class TestDonations(APITestCase):
         response = self.client.patch(
             f'/tracker/api/v2/donations/{donation.pk}/send_to_reader/'
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         donation.refresh_from_db()
         self.assertEqual(donation.commentstate, 'APPROVED')
@@ -461,14 +461,14 @@ class TestDonations(APITestCase):
     def test_pin_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/pin/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_pin_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/pin/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_pin_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='ready')[0]
@@ -499,14 +499,14 @@ class TestDonations(APITestCase):
     def test_unpin_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/unpin/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_unpin_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/unpin/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_unpin_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='ready')[0]
@@ -539,14 +539,14 @@ class TestDonations(APITestCase):
     def test_read_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/read/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_read_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/read/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_read_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='ready')[0]
@@ -576,14 +576,14 @@ class TestDonations(APITestCase):
     def test_ignore_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/ignore/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_ignore_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/ignore/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_ignore_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='ready')[0]
@@ -613,14 +613,14 @@ class TestDonations(APITestCase):
     def test_comment_fails_without_login(self):
         self.client.force_authenticate(user=None)
         response = self.client.post(f'/tracker/api/v2/donations/1234/comment/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_comment_fails_without_change_donation_permission(self):
         user = User.objects.create()
         self.client.force_authenticate(user=user)
 
         response = self.client.post(f'/tracker/api/v2/donations/1234/comment/')
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_comment_sets_donation_state(self):
         donation = self.generate_donations(self.event, count=1, state='ready')[0]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,12 +9,10 @@ django-mptt==0.14.0
 django-post-office==3.6.0
 django-timezone-field==6.1.0
 djangorestframework==3.14.0
+pre-commit==3.5.0
+python-dateutil==2.8.2
 backports.zoneinfo==0.2.1 ; python_version<"3.9"
 python-dateutil==2.8.2 ; python_version<"3.11"
-# can be removed when either 3.7 is not supported or once we upgrade Celery
-importlib_metadata==4.13.0 ; python_version<"3.8"
-pre-commit==3.5.0 ; python_version>="3.8"
-pre-commit==2.21.0 ; python_version<"3.8"
 webpack-manifest==2.1.1
 # only for testing
 responses~=0.24.1

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -352,7 +352,7 @@ class TestDonorAlias(TestCase):
             models.Donor.objects.create(alias='Raelcun', alias_num=i)
         with self.assertLogs(level=logging.WARNING) as logs:
             donor = models.Donor.objects.create(alias='Raelcun')
-        self.assertRegexpMatches(logs.output[0], 'namespace was full')
+        self.assertRegex(logs.output[0], 'namespace was full')
         self.assertEqual(donor.alias, None, msg='Alias was not cleared')
         self.assertEqual(donor.alias_num, None, msg='Alias was not cleared')
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -177,13 +177,13 @@ class TestEventManager(TransactionTestCase):
     def test_donation_count_annotation(self):
         manager = models.Event.objects.with_annotations()
         event = manager.get(pk=self.event.pk)
-        self.assertEquals(event.donation_count, len(self.completed_donations))
+        self.assertEqual(event.donation_count, len(self.completed_donations))
 
     def test_amount_annotation(self):
         manager = models.Event.objects.with_annotations()
         event = manager.get(pk=self.event.pk)
         total_amount = sum(donation.amount for donation in self.completed_donations)
-        self.assertAlmostEquals(event.amount, total_amount)
+        self.assertAlmostEqual(event.amount, total_amount)
 
 
 class TestEventViews(TransactionTestCase):

--- a/tests/util.py
+++ b/tests/util.py
@@ -407,6 +407,12 @@ class APITestCase(TransactionTestCase):
                 results.append(f'index #{n} was unequal: {pair[0]:r} != {pair[1]:r}')
         return results
 
+    def assertDictContainsSubset(self, subset, dictionary, msg=None):
+        if sys.version_info < (3, 12):
+            super().assertDictContainsSubset(subset, dictionary, msg)
+        else:
+            self.assertEqual(dictionary, {**dictionary, **subset}, msg)
+
     def assertModelPresent(self, expected_model, data, partial=False, msg=None):
         try:
             found_model = next(

--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -388,7 +388,10 @@ class Bid(mptt.models.MPTTModel):
         same_name = Bid.objects.filter(
             speedrun=self.speedrun,
             event=self.event,
-            parent=self.parent,
+            # FIXME: Django 5.0 started complaining about self.parent during tests, if a child tried to clean itself
+            #  before the parent was saved, but this might not ever happen in the real world, so spend some time
+            #  looking into this when possible
+            parent=self.parent_id,
             name__iexact=self.name,
         ).exclude(pk=self.pk)
         if same_name.exists():


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/185819424

### Description of the Change

Django 4.1 is EOL. Also, Python 3.12 and Django 5.0 are a thing since the last time the matrix got updated. Do all the tests pass on the new matrix?

### Verification Process

Do all the tests pass on the new matrix?