### PR TITLE
fix Selenium tests to work with 4.15.2 [#186624652]

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,6 +20,6 @@ tzdata==2022.2
 webpack-manifest==2.1.1
 # only for testing
 responses~=0.24.1
-selenium==4.2.0
+selenium==4.15.2
 tblib==3.0.0
 unittest-xml-reporting==3.2.0

--- a/tests/util.py
+++ b/tests/util.py
@@ -588,7 +588,7 @@ class TrackerSeleniumTestCase(StaticLiveServerTestCase, metaclass=_TestFailedMet
     def setUpClass(cls):
         super().setUpClass()
         options = Options()
-        options.headless = True
+        options.add_argument('--headless')
         cls.webdriver = webdriver.Firefox(options=options)
         cls.webdriver.implicitly_wait(5)
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186624652

### Description of the Change

Selenium auto-bump has been failing for a while but I finally got blocked by it, so I dug in to figure out why, and an option we were using went away after being deprecated for a while. Replaced it with the new, non-deprecated version, and now I think things are good again.

No changes to the actual code were needed, just the test setup.

### Verification Process

Do the tests pass on the version matrix?