### PR TITLE
add setting for removing Browsable API from v2 endpoints [#186670646]

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Default: `''`
 
 Allows you to place a logo asset in the navbar for public facing pages.
 
+#### TRACKER_ENABLE_BROWSABLE_API
+
+Type: `bool`
+
+Default: `settings.DEBUG`
+
+Allows you to enable or disable the DRF browsable API renderer on the v2 endpoints. By default, it's disabled in
+production mode and enabled in development.
+
+This can potentially override DRF's own explicit or default settings, but only in that it will remove the renderer in
+question if it's in the list.
+
 ### Testing Your Deploy (incomplete)
 
 - PayPal currently requires the receiver account to have IPNs turned on so that payment can be confirmed

--- a/tests/test_tracker_settings.py
+++ b/tests/test_tracker_settings.py
@@ -36,3 +36,16 @@ class TestTrackerSettings(TestCase):
             'http://example.com/sweepstakes',
             msg='SWEEPSTAKES_URL',
         )
+
+    def test_browsable_api(self):
+        with override_settings(DEBUG=False):
+            self.assertFalse(
+                settings.TRACKER_ENABLE_BROWSABLE_API,
+                msg='TRACKER_ENABLE_BROWSABLE_API',
+            )
+
+        with override_settings(DEBUG=True):
+            self.assertTrue(
+                settings.TRACKER_ENABLE_BROWSABLE_API,
+                msg='TRACKER_ENABLE_BROWSABLE_API',
+            )

--- a/tracker/api/views/run.py
+++ b/tracker/api/views/run.py
@@ -1,11 +1,10 @@
-from rest_framework import viewsets
-
 from tracker.api.pagination import TrackerPagination
 from tracker.api.permissions import TechNotesPermission
 from tracker.api.serializers import SpeedRunSerializer
 from tracker.api.views import (
     EventNestedMixin,
     FlatteningViewSetMixin,
+    TrackerReadViewSet,
     WithPermissionsMixin,
 )
 from tracker.models import SpeedRun
@@ -15,7 +14,7 @@ class SpeedRunViewSet(
     FlatteningViewSetMixin,
     WithPermissionsMixin,
     EventNestedMixin,
-    viewsets.ReadOnlyModelViewSet,
+    TrackerReadViewSet,
 ):
     queryset = SpeedRun.objects.select_related('event').prefetch_related(
         'runners', 'hosts', 'commentators'

--- a/tracker/settings.py
+++ b/tracker/settings.py
@@ -43,6 +43,10 @@ class TrackerSettings(object):
     def TRACKER_LOGO(self):
         return getattr(settings, 'TRACKER_LOGO', '')
 
+    @property
+    def TRACKER_ENABLE_BROWSABLE_API(self):
+        return getattr(settings, 'TRACKER_ENABLE_BROWSABLE_API', settings.DEBUG)
+
     # pass everything else through for convenience
     def __getattr__(self, item):
         return getattr(settings, item)
@@ -100,4 +104,8 @@ def tracker_settings_checks(app_configs, **kwargs):
         )
     if type(TrackerSettings().TRACKER_LOGO) != str:
         errors.append(Error('TRACKER_LOGO should be a string', id='tracker.E105'))
+    if type(TrackerSettings().TRACKER_ENABLE_BROWSABLE_API) != bool:
+        errors.append(
+            Error('TRACKER_ENABLE_BROWSABLE_API should be a bool', id='tracker.E106')
+        )
     return errors


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186670646

### Description of the Change

This was hardcoded in the live fixes branch but it probably deserves a more formal setting.

### Verification Process

Flipped the DEBUG or the new explicit flag on and off and made sure the browsable API either worked or didn't.