### PR TITLE
add Interview to v2 api (read only for now) [#184870683]

### DIFF
--- a/tests/apiv2/test_interviews.py
+++ b/tests/apiv2/test_interviews.py
@@ -1,0 +1,46 @@
+import random
+
+from tests import randgen
+from tests.util import APITestCase
+from tracker.api.serializers import InterviewSerializer
+
+
+class TestInterviews(APITestCase):
+    model_name = 'interview'
+    serializer_class = InterviewSerializer
+    rand = random.Random()
+
+    def setUp(self):
+        super().setUp()
+        self.run = randgen.generate_run(self.rand, event=self.event, ordered=True)
+        self.run.save()
+        self.public_interview = randgen.generate_interview(self.rand, run=self.run)
+        self.public_interview.save()
+        self.private_interview = randgen.generate_interview(self.rand, run=self.run)
+        self.private_interview.public = False
+        self.private_interview.save()
+
+    def test_public_fetch(self):
+        data = self.get_detail(self.public_interview)
+        self.assertV2ModelPresent(self.public_interview, data)
+
+    def test_private_fetch(self):
+        self.get_detail(self.private_interview, status_code=404)
+
+        self.client.force_authenticate(self.view_user)
+
+        data = self.get_detail(self.private_interview)
+        self.assertV2ModelPresent(self.private_interview, data)
+
+    def test_public_list(self):
+        data = self.get_list()['results']
+        self.assertV2ModelPresent(self.public_interview, data)
+        self.assertV2ModelNotPresent(self.private_interview, data)
+
+    def test_private_list(self):
+        self.get_list(data={'all': ''}, status_code=403)
+
+        self.client.force_authenticate(self.view_user)
+        data = self.get_list(data={'all': ''})['results']
+        self.assertV2ModelPresent(self.public_interview, data)
+        self.assertV2ModelPresent(self.private_interview, data)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -15,6 +15,7 @@ backports.zoneinfo==0.2.1 ; python_version<"3.9"
 python-dateutil==2.8.2 ; python_version<"3.11"
 webpack-manifest==2.1.1
 # only for testing
+lxml==4.9.4 ; python_version<"3.10" # azure issue?
 responses~=0.24.1
 selenium==4.16.0
 tblib==3.0.0

--- a/tests/util.py
+++ b/tests/util.py
@@ -132,6 +132,7 @@ class TestRemoveNullsMigrations(MigrationsTestCase):
 
 class APITestCase(TransactionTestCase):
     model_name = None
+    serializer_class = None
     view_user_permissions = []  # trickles to add_user and locked_user
     add_user_permissions = []  # trickles to locked_user
     locked_user_permissions = []
@@ -460,6 +461,11 @@ class APITestCase(TransactionTestCase):
     def assertV2ModelPresent(self, expected_model, data, partial=False, msg=None):
         if not isinstance(data, list):
             data = [data]
+        if not isinstance(expected_model, dict):
+            assert (
+                self.serializer_class is not None
+            ), 'no serializer_class provided and raw model was passed'
+            expected_model = self.serializer_class(expected_model).data
         try:
             found_model = next(
                 m
@@ -485,6 +491,11 @@ class APITestCase(TransactionTestCase):
             )
 
     def assertV2ModelNotPresent(self, unexpected_model, data):
+        if not isinstance(unexpected_model, dict):
+            assert hasattr(
+                self, 'serializer_class'
+            ), 'no serializer_class provided and raw model was passed'
+            unexpected_model = self.serializer_class(unexpected_model).data
         with self.assertRaises(
             StopIteration,
             msg='Found model "%s:%s" in data'

--- a/tracker/api/messages.py
+++ b/tracker/api/messages.py
@@ -14,3 +14,11 @@ UNAUTHORIZED_FIELD_CODE = 'unauthorized_field'
 INVALID_FEED = _('`%s` is not a valid feed.')
 INVALID_FEED_CODE = 'invalid_feed'
 INVALID_SEARCH_PARAMETER_CODE = 'invalid_search_parameter'
+UNAUTHORIZED_LOCKED_EVENT = _(
+    'You do not have permission to edit objects associated with locked events.'
+)
+UNAUTHORIZED_LOCKED_EVENT_CODE = 'unauthorized_locked_event'
+UNAUTHORIZED_FEED = _('You do not have permission to view that feed.')
+UNAUTHORIZED_FEED_CODE = 'unauthorized_feed'
+UNAUTHORIZED_OBJECT = _('You do not have permission to view that object.')
+UNAUTHORIZED_OBJECT_CODE = 'unauthorized_object'

--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -11,11 +11,6 @@ from rest_framework.request import Request
 from tracker.api import messages
 from tracker.models import Bid
 
-UNAUTHORIZED_LOCKED_EVENT = 'unauthorized_locked_event'
-UNAUTHORIZED_FEED = 'unauthorized_feed'
-UNAUTHORIZED_OBJECT = 'unauthorized_object'
-UNAUTHORIZED_FIELD = 'unauthorized_field'
-
 
 def tracker_permission(permission_name: str):
     class TrackerPermission(BasePermission):
@@ -32,8 +27,8 @@ def tracker_permission(permission_name: str):
 
 
 class EventLockedPermission(DjangoModelPermissionsOrAnonReadOnly):
-    message = _('You do not have permission to edit locked events.')
-    code = UNAUTHORIZED_LOCKED_EVENT
+    message = messages.UNAUTHORIZED_LOCKED_EVENT
+    code = messages.UNAUTHORIZED_LOCKED_EVENT_CODE
 
     def has_permission(self, request: Request, view: t.Callable):
         return super().has_permission(request, view) and (
@@ -53,7 +48,7 @@ class EventLockedPermission(DjangoModelPermissionsOrAnonReadOnly):
 class BidFeedPermission(BasePermission):
     PUBLIC_FEEDS = Bid.PUBLIC_FEEDS
     message = _('You do not have permission to view that feed.')
-    code = UNAUTHORIZED_FEED
+    code = messages.UNAUTHORIZED_FEED_CODE
 
     def has_permission(self, request: Request, view: t.Callable):
         feed = view.get_feed()
@@ -67,7 +62,7 @@ class BidFeedPermission(BasePermission):
 class BidStatePermission(BasePermission):
     PUBLIC_STATES = Bid.PUBLIC_STATES
     message = messages.GENERIC_NOT_FOUND
-    code = UNAUTHORIZED_OBJECT
+    code = messages.UNAUTHORIZED_OBJECT_CODE
 
     def has_object_permission(self, request: Request, view: t.Callable, obj: t.Any):
         return super().has_object_permission(request, view, obj) and (
@@ -88,8 +83,7 @@ class TechNotesPermission(BasePermission):
 
 
 class CanSendToReader(tracker_permission('tracker.change_donation')):
-    def has_permission(self, request, view):
-        return super().has_permission(request, view)
+    # TODO: message/code? this is -sort- of an internal use case
 
     def has_object_permission(self, request, view, obj):
         return (
@@ -97,3 +91,21 @@ class CanSendToReader(tracker_permission('tracker.change_donation')):
             and obj.event.use_one_step_screening
             or request.user.has_perm('tracker.send_to_reader')
         )
+
+
+class PrivateInterviewListPermission(BasePermission):
+    message = messages.UNAUTHORIZED_FILTER_PARAM
+    code = messages.UNAUTHORIZED_FILTER_PARAM_CODE
+
+    def has_permission(self, request, view):
+        return 'all' not in request.query_params or request.user.has_perm(
+            'tracker.view_interview'
+        )
+
+
+class PrivateInterviewDetailPermission(BasePermission):
+    message = messages.GENERIC_NOT_FOUND
+    code = messages.UNAUTHORIZED_OBJECT_CODE
+
+    def has_object_permission(self, request, view, obj):
+        return obj.public or request.user.has_perm('tracker.view_interview')

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -9,6 +9,7 @@ from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from tracker.models import Interview
 from tracker.models.bid import Bid, DonationBid
 from tracker.models.donation import Donation, Donor
 from tracker.models.event import Event, Headset, Runner, SpeedRun
@@ -393,3 +394,27 @@ class SpeedRunSerializer(
         if not self.with_tech_notes and 'tech_notes' in fields:
             del fields['tech_notes']
         return fields
+
+
+class InterviewSerializer(EventNestedSerializerMixin, TrackerModelSerializer):
+    type = ClassNameField()
+    event = EventSerializer()
+
+    class Meta:
+        model = Interview
+        fields = (
+            'type',
+            'id',
+            'event',
+            'order',
+            'suborder',
+            'social_media',
+            'interviewers',
+            'topic',
+            'public',
+            'prerecorded',
+            'producer',
+            'length',
+            'subjects',
+            'camera_operator',
+        )

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -3,9 +3,8 @@
 from django.urls import include, path
 from rest_framework import routers
 
-import tracker.api.views.run
 from tracker.api import views
-from tracker.api.views import bids, donations, me
+from tracker.api.views import bids, donations, interview, me, run
 
 router = routers.DefaultRouter()
 
@@ -25,7 +24,8 @@ def event_nested_route(path, viewset, *, feed=False, **kwargs):
 router.register(r'events', views.EventViewSet)
 event_nested_route(r'bids', bids.BidViewSet, feed=True)
 router.register(r'runners', views.RunnerViewSet)
-event_nested_route(r'runs', tracker.api.views.run.SpeedRunViewSet)
+event_nested_route(r'runs', run.SpeedRunViewSet)
+event_nested_route(r'interviews', interview.InterviewViewSet)
 router.register(r'donations', donations.DonationViewSet, basename='donations')
 router.register(r'me', me.MeViewSet, basename='me')
 

--- a/tracker/api/views/__init__.py
+++ b/tracker/api/views/__init__.py
@@ -10,9 +10,8 @@ from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
 
 from tracker import logutil, settings
-from tracker.api.messages import GENERIC_NOT_FOUND
+from tracker.api import messages
 from tracker.api.pagination import TrackerPagination
-from tracker.api.permissions import UNAUTHORIZED_OBJECT
 from tracker.api.serializers import EventSerializer, RunnerSerializer
 from tracker.models.event import Event, Runner
 
@@ -146,9 +145,9 @@ def generic_404(exception_handler):
     def _inner(exc, context):
         # override the default messaging for 404s
         if isinstance(exc, Http404):
-            exc = NotFound(detail=GENERIC_NOT_FOUND)
+            exc = NotFound(detail=messages.GENERIC_NOT_FOUND)
         if isinstance(exc, NotFound) and exc.detail == NotFound.default_detail:
-            exc.detail = GENERIC_NOT_FOUND
+            exc.detail = messages.GENERIC_NOT_FOUND
         return exception_handler(exc, context)
 
     return _inner
@@ -198,7 +197,7 @@ class TrackerReadViewSet(viewsets.ReadOnlyModelViewSet):
         ]
 
     def permission_denied(self, request, message=None, code=None):
-        if code == UNAUTHORIZED_OBJECT:
+        if code == messages.UNAUTHORIZED_OBJECT_CODE:
             raise Http404
         else:
             super().permission_denied(request, message=message, code=code)

--- a/tracker/api/views/interview.py
+++ b/tracker/api/views/interview.py
@@ -1,0 +1,31 @@
+import logging
+
+from tracker.api.pagination import TrackerPagination
+from tracker.api.permissions import (
+    PrivateInterviewDetailPermission,
+    PrivateInterviewListPermission,
+)
+from tracker.api.serializers import InterviewSerializer
+from tracker.api.views import EventNestedMixin, TrackerReadViewSet
+from tracker.models import Interview
+
+logger = logging.getLogger(__name__)
+
+
+class InterviewViewSet(
+    EventNestedMixin,
+    TrackerReadViewSet,
+):
+    queryset = Interview.objects.select_related('event')
+    serializer_class = InterviewSerializer
+    pagination_class = TrackerPagination
+    permission_classes = [
+        PrivateInterviewDetailPermission,
+        PrivateInterviewListPermission,
+    ]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if not (self.detail or 'all' in self.request.query_params):
+            queryset = queryset.filter(public=True)
+        return queryset


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184870683

### Description of the Change

In the ongoing grind to purge api v1 from the system, v2 now supports fetching interviews.

New endpoints:

`v2/interviews`
`v2/interviews/<interview>`
`v2/events/<event>/interviews`
`v2/events/<event>/interviews/<interview>`

In list mode, you can pass `all` as a query parameter to include private interviews. In detail mode it is implied by whether or not the interview in question has the public flag set. Viewing private interviews requires the builtin `tracker.view_interview` permission.

I also did a few pieces of misc cleanup while I was in the area, and added some tests I realized were missing from the Interview/Ad model right after I merged the other PR.

### Verification Process

Hit the new endpoints, both in list and detail form, and ensured that unauthorized (e.g. anonymous) users could not fetch interviews flagged private.