### PR TITLE
fix ordering bug with trying to remove a run from the schedule [#186754054]

### DIFF
--- a/tests/apiv2/test_donations.py
+++ b/tests/apiv2/test_donations.py
@@ -103,7 +103,7 @@ class TestDonations(APITestCase):
             self.event,
             count=2,
             state='pending',
-            time=date.replace(year=1),
+            time=date.replace(year=2),
         )
         new_donations = self.generate_donations(
             self.event,
@@ -174,7 +174,7 @@ class TestDonations(APITestCase):
             self.event,
             count=2,
             state='flagged',
-            time=date.replace(year=1),
+            time=date.replace(year=2),
         )
         new_donations = self.generate_donations(
             self.event,

--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -67,10 +67,8 @@ class TestSpeedRun(TestSpeedRunBase):
             self.run3.endtime, self.run2.endtime + datetime.timedelta(minutes=5)
         )
 
-    def test_null_order_run_start_time(self):
+    def test_null_order(self):
         self.assertEqual(self.run4.starttime, None)
-
-    def test_null_order_run_end_time(self):
         self.assertEqual(self.run4.endtime, None)
 
     def test_no_run_or_setup_time_run_start_time(self):
@@ -160,8 +158,11 @@ class TestMoveSpeedRun(TransactionTestCase):
         self.run2 = models.SpeedRun.objects.create(
             name='Test Run 2', run_time='0:15:00', setup_time='0:05:00', order=2
         )
+
+        # order is 4 to make sure that the various movements all close the hole
+
         self.run3 = models.SpeedRun.objects.create(
-            name='Test Run 3', run_time='0:20:00', setup_time='0:05:00', order=3
+            name='Test Run 3', run_time='0:20:00', setup_time='0:05:00', order=4
         )
         self.run4 = models.SpeedRun.objects.create(
             name='Test Run 4', run_time='0:20:00', setup_time='0:05:00', order=None
@@ -257,6 +258,10 @@ class TestMoveSpeedRun(TransactionTestCase):
     def test_remove_from_order(self):
         self.assertResults(self.run2, None, True, expected_change_count=2)
         self.assertRunsInOrder([self.run1, self.run3], [self.run2, self.run4])
+
+    def test_remove_last_run(self):
+        self.assertResults(self.run3, None, True, expected_change_count=1)
+        self.assertRunsInOrder([self.run1, self.run2], [self.run3, self.run4])
 
     def test_already_removed(self):
         self.assertResults(self.run4, None, True, expected_status_code=400)

--- a/tracker/views/commands.py
+++ b/tracker/views/commands.py
@@ -110,9 +110,21 @@ def MoveSpeedRun(data):
                 s.save(fix_time=False)
             moving.order = final
             moving.save(fix_time=False)
-            first_run = SpeedRun.objects.get(event=moving.event, order=first)
-            first_run.clean()
-            models = first_run.save()
+            first_run = SpeedRun.objects.filter(
+                event=moving.event, order__gte=first
+            ).first()
+            if first_run:
+                first_run.clean()
+                models = first_run.save()
+            else:
+                models = []
+            # FIXME: horrible order hack until holes can be prevented
+            for order, run in enumerate(
+                SpeedRun.objects.filter(event=moving.event).exclude(order=None), start=1
+            ):
+                if run.order != order:
+                    run.order = order
+                    run.save(fix_time=False)
             if other is None:
                 models = models + [moving]
             return models, 200


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186754054

### Description of the Change

Ran into an issue with the new way that run are removed from the schedule. A "hole" in the order could result in a server error while trying to remove a run from the schedule. You could also get a similar error if you tried to remove the last run on the schedule from the order.

### Verification Process

Used a small test event with various operations (including forcing a hole by modifying the DB directly) to make sure it handled the cases I was aware of.