### PR TITLE
fix event filter on donation v2 endpoints [#186804971]

### DIFF
--- a/tests/apiv2/test_donations.py
+++ b/tests/apiv2/test_donations.py
@@ -23,6 +23,9 @@ class TestDonations(APITestCase):
         self.client = APIClient()
         self.client.force_authenticate(user=self.super_user)
         self.event = randgen.build_random_event(self.rand, num_runs=2, num_donors=2)
+        self.other_event = randgen.build_random_event(
+            self.rand, num_runs=2, num_donors=2
+        )
 
     def generate_donations(
         self,
@@ -76,6 +79,9 @@ class TestDonations(APITestCase):
     def test_unprocessed_returns_serialized_donations(self):
         donations = self.generate_donations(self.event, count=1, state='pending')
         donations.sort(key=lambda d: d.timereceived)
+
+        self.generate_donations(self.other_event, count=1, state='pending')
+
         serialized = DonationSerializer(
             donations, with_permissions=('tracker.change_donation',), many=True
         )
@@ -147,6 +153,9 @@ class TestDonations(APITestCase):
     def test_flagged_returns_serialized_donations(self):
         donations = self.generate_donations(self.event, count=1, state='flagged')
         donations.sort(key=lambda d: d.timereceived)
+
+        self.generate_donations(self.other_event, count=1, state='flagged')
+
         serialized = DonationSerializer(
             donations, with_permissions=('tracker.change_donation',), many=True
         )

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -128,6 +128,10 @@ class DonationViewSet(viewsets.GenericViewSet, EventNestedMixin):
         """
         queryset = super().get_queryset().completed()
 
+        event_id = self.request.query_params.get('event_id')
+        if event_id is not None:
+            queryset = queryset.filter(event=event_id)
+
         after = self.request.query_params.get('after')
         if after is not None:
             queryset = queryset.filter(Q(timereceived__gte=after))


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186804971

### Description of the Change

When I refactored the v2 endpoints for donation I left out the event filter. This puts it back.

### Verification Process

Hit the endpoints with the event filter present and made sure it was actually filtering them.