### PR TITLE
Lock DRF to less than 3.15 due to breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'django-paypal~=1.1',
         'django-post-office~=3.2',
         'django-timezone-field>=3.1,<7.0',
-        'djangorestframework~=3.9',
+        'djangorestframework~=3.9,<3.15.0',
         'python-dateutil~=2.8.1;python_version<"3.11"',
         'requests>=2.27.1,<2.32.0',
     ],


### PR DESCRIPTION
See: https://github.com/encode/django-rest-framework/pull/8438

still need to clean up the router urls to avoid this error, but this makes it less confusing for now

Fixes https://github.com/GamesDoneQuick/donation-tracker/issues/658