### PR TITLE
update viewnames for DRF 3.15 change [#187298296]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'django-paypal~=1.1',
         'django-post-office~=3.2',
         'django-timezone-field>=3.1,<7.0',
-        'djangorestframework~=3.9,<3.15.0',
+        'djangorestframework~=3.9',
         'python-dateutil~=2.8.1;python_version<"3.11"',
         'requests>=2.27.1,<2.32.0',
     ],

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ django-paypal==1.1.2
 django-mptt==0.14.0
 django-post-office==3.6.0
 django-timezone-field==6.1.0
-djangorestframework==3.14.0
+djangorestframework==3.15.1
 pre-commit==3.5.0 ; python_version<"3.9"
 pre-commit==3.7.0 ; python_version>="3.9"
 python-dateutil==2.8.2

--- a/tests/util.py
+++ b/tests/util.py
@@ -161,6 +161,16 @@ class APITestCase(TransactionTestCase):
         paginator.paginate_queryset(queryset, FakeRequest())
         return paginator.get_paginated_response(data)
 
+    def _get_viewname(self, model_name, action, **kwargs):
+        if 'event_pk' in kwargs:
+            if 'feed' in kwargs:
+                viewname = f'tracker:api_v2:event-{model_name}-feed-{action}'
+            else:
+                viewname = f'tracker:api_v2:event-{model_name}-{action}'
+        else:
+            viewname = f'tracker:api_v2:{model_name}-{action}'
+        return viewname
+
     def get_detail(
         self,
         obj,
@@ -178,7 +188,8 @@ class APITestCase(TransactionTestCase):
         assert model_name is not None
         response = self.client.get(
             reverse(
-                f'tracker:api_v2:{model_name}-detail', kwargs={'pk': obj.pk, **kwargs}
+                self._get_viewname(model_name, 'detail', **kwargs),
+                kwargs={'pk': obj.pk, **kwargs},
             ),
             data=data,
         )
@@ -205,7 +216,7 @@ class APITestCase(TransactionTestCase):
         assert model_name is not None
         response = self.client.get(
             reverse(
-                f'tracker:api_v2:{model_name}-list',
+                self._get_viewname(model_name, 'list', **kwargs),
                 kwargs=kwargs,
             ),
             data=data,
@@ -237,7 +248,7 @@ class APITestCase(TransactionTestCase):
         assert model_name is not None
         response = self.client.get(
             reverse(
-                f'tracker:api_v2:{model_name}-{noun}',
+                self._get_viewname(model_name, noun, **kwargs),
                 kwargs=kwargs,
             ),
             data=data,
@@ -285,7 +296,7 @@ class APITestCase(TransactionTestCase):
         assert model_name is not None
         response = self.client.post(
             reverse(
-                f'tracker:api_v2:{model_name}-{noun}',
+                self._get_viewname(model_name, noun, **kwargs),
                 kwargs=kwargs,
             ),
             data=data,
@@ -314,7 +325,8 @@ class APITestCase(TransactionTestCase):
         assert model_name is not None
         response = self.client.patch(
             reverse(
-                f'tracker:api_v2:{model_name}-detail', kwargs={'pk': obj.pk, **kwargs}
+                self._get_viewname(model_name, 'detail', **kwargs),
+                kwargs={'pk': obj.pk, **kwargs},
             ),
             data=data,
         )

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -9,15 +9,19 @@ from tracker.api.views import bids, donations, interview, me, run, runner
 router = routers.DefaultRouter()
 
 
-def event_nested_route(path, viewset, *, feed=False, **kwargs):
-    router.register(path, viewset)
+def event_nested_route(path, viewset, *, basename=None, feed=False):
+    if basename is None:
+        basename = router.get_default_basename(viewset)
+    router.register(path, viewset, basename)
     if feed:
         router.register(
             r'events/(?P<event_pk>[^/.]+)/' + path + r'/feed_(?P<feed>\w+)',
             viewset,
-            **kwargs,
+            f'event-{basename}-feed',
         )
-    router.register(r'events/(?P<event_pk>[^/.]+)/' + path, viewset, **kwargs)
+    router.register(
+        r'events/(?P<event_pk>[^/.]+)/' + path, viewset, f'event-{basename}'
+    )
 
 
 # routers generate URLs based on the view sets, so that we don't need to do a bunch of stuff by hand


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

See also #658, as this is when the issue was brought to my attention. Relevant issue from DRF: https://github.com/encode/django-rest-framework/pull/8438

https://www.pivotaltracker.com/story/show/187298296

### Description of the Change

When multiple possible paths go to the same viewset, DRF 3.15 added a check to ensure that they have different internal names so that you don't end up with ambiguity. In our case every path variant had its own explicit requirements so this didn't affect us, but it's a simple enough change. It mostly affected tests, and changing the helpers was enough to keep the tests green.

### Verification Process

This change didn't affect the public API, just some internal bookkeeping. The tests are green, so that's good enough.