### PR TITLE
remove Django 3.2 from supported versions [#187737837]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.8 to 3.12
-- Django 3.2, 4.2, or 5.0
+- Django 4.2, or 5.0
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 
@@ -104,7 +104,7 @@ production mode and enabled in development.
 This can potentially override DRF's own explicit or default settings, but only in that it will remove the renderer in
 question if it's in the list.
 
-### Testing Your Deploy (incomplete)
+### Testing Your Deploy (WIP)
 
 - PayPal currently requires the receiver account to have IPNs turned on so that payment can be confirmed
   - The sandbox sends IPNs, so you should not need to use the IPN simulator unless you really want to
@@ -215,12 +215,6 @@ If everything boots up correctly, you should be able to visit the [Index Page](h
 Additionally, you should be able to open the [Websocket Test Page](http://localhost:8080/tracker/websocket_test/) and
 see the heartbeat. If the page loads but the pings don't work, Channels isn't set up correctly. The
 [Channels Documentation](https://channels.readthedocs.io/en/latest/installation.html) may be helpful.
-
-## Note for PyCharm users
-
-There is a known bug with PyCharm as of PyCharm 2023.2.4 and Django 5.0. See
-[this YouTrack ticket](https://youtrack.jetbrains.com/issue/PY-53355) for details. There is a workaround that
-requires you hand-editing the bundled test runner script before you can run unit tests within the IDE.
 
 ## Contributing
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,7 @@ jobs:
       matrix:
         Oldest:
           PYTHON_VERSION: '3.8'
-          DJANGO_VERSION: '3.2'
-        Django32:
-          PYTHON_VERSION: '3.10'
-          DJANGO_VERSION: '3.2'
+          DJANGO_VERSION: '4.2'
         Django42:
           PYTHON_VERSION: '3.12'
           DJANGO_VERSION: '4.2'

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'backports.zoneinfo;python_version<"3.9"',
         'celery~=5.0',
         'channels>=2.0',
-        'Django>=3.2,!=4.0.*,!=4.1.*,<5.1',
+        'Django>=4.2,<5.1',
         'django-ajax-selects~=2.1',  # publish error, see: https://github.com/crucialfelix/django-ajax-selects/issues/306
         'django-ical~=1.7',
         'django-mptt~=0.10',


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/187737837

### Description of the Change

Django 3.2 was EOLed about 2 months ago, so this was overdue.

### Verification Process

CI pipeline change, mostly, so no verification needed.