### PR TITLE
moving a run over an anchor no longer leaves a gap [#186847783]

### DIFF
--- a/tracker/models/event.py
+++ b/tracker/models/event.py
@@ -551,6 +551,8 @@ class SpeedRun(models.Model):
             )
             if prev:
                 self.starttime = prev.endtime
+            else:
+                self.starttime = self.event.datetime
             if next_anchor:
                 if self.anchor_time and next_anchor.anchor_time < self.anchor_time:
                     raise ValidationError(


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186847783

### Description of the Change

With the addition of the anchor functionality, certain moves would not correctly recalculate start times for runs that were adjacent to the changed spots. This plugs the holes I was aware of.

### Verification Process

Various moves on a test environment to ensure that not only did runs close the gaps after a move, but also that the API would return the full set of changes so that it was easier on the client to display said changes.