### PR TITLE
Django 5.1 compatibility [#188081018]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.8 to 3.12
-- Django 4.2, or 5.0
+- Django 4.2, 5.0, or 5.1
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,9 @@ jobs:
         Django42:
           PYTHON_VERSION: '3.12'
           DJANGO_VERSION: '4.2'
+        Django50:
+          PYTHON_VERSION: '3.12'
+          DJANGO_VERSION: '5.0'
         Python38:
           PYTHON_VERSION: '3.8'
           DJANGO_VERSION: '4.2'
@@ -25,13 +28,13 @@ jobs:
           DJANGO_VERSION: '4.2'
         Python3A:
           PYTHON_VERSION: '3.10'
-          DJANGO_VERSION: '5.0'
+          DJANGO_VERSION: '5.1'
         Python3B:
           PYTHON_VERSION: '3.11'
-          DJANGO_VERSION: '5.0'
+          DJANGO_VERSION: '5.1'
         Latest:
           PYTHON_VERSION: '3.12'
-          DJANGO_VERSION: '5.0'
+          DJANGO_VERSION: '5.1'
 
     steps:
       - task: UsePythonVersion@0

--- a/runtests.py
+++ b/runtests.py
@@ -40,13 +40,14 @@ if __name__ == '__main__':
         default=True,
         help='Tells Django to NOT prompt the user for input of any kind.',
     )
-    parser.add_argument(
-        '--failfast',
-        action='store_true',
-        dest='failfast',
-        default=False,
-        help='Tells Django to stop running the test suite after first failed test.',
-    )
+    if django.VERSION < (5, 1, 0):
+        parser.add_argument(
+            '--failfast',
+            action='store_true',
+            dest='failfast',
+            default=False,
+            help='Tells Django to stop running the test suite after first failed test.',
+        )
     parser.add_argument(
         '--nobundle',
         '--no-bundle',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'backports.zoneinfo;python_version<"3.9"',
         'celery~=5.0',
         'channels>=2.0',
-        'Django>=4.2,<5.1',
+        'Django>=4.2,<5.2',
         'django-ajax-selects~=2.1',  # publish error, see: https://github.com/crucialfelix/django-ajax-selects/issues/306
         'django-ical~=1.7',
         'django-mptt~=0.10',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,8 @@ channels==3.0.4
 django-ajax-selects==2.1.0  # publish error, see: https://github.com/crucialfelix/django-ajax-selects/issues/306
 django-ical==1.9.2
 django-paypal==1.1.2
-django-mptt==0.14.0
+django-mptt==0.14.0 ; python_version<"3.9"
+django-mptt==0.16.0 ; python_version>="3.9"
 django-post-office==3.6.0
 django-timezone-field==7.0
 djangorestframework==3.15.2

--- a/tests/test_interstitial.py
+++ b/tests/test_interstitial.py
@@ -341,7 +341,7 @@ class TestInterview(APITestCase):
             order=self.run.order,
             suborder=self.private_interview.suborder + 1,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             models.Interview.objects.for_run(self.run),
             [self.public_interview, self.private_interview],
         )
@@ -385,4 +385,4 @@ class TestAd(APITestCase):
 
     def test_for_run(self):
         randgen.generate_interview(self.rand, run=self.run).save()
-        self.assertQuerysetEqual(models.Ad.objects.for_run(self.run), [self.ad])
+        self.assertQuerySetEqual(models.Ad.objects.for_run(self.run), [self.ad])


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188081018

### Description of the Change

Django 5.1 is officially out. Add it to the list of supported versions. Had to change a couple test cases as they were using deprecated/removed features.

Had to bump MPTT to 0.16.0 since the older versions use at least one feature that was deprecated a while ago and outright removed in 5.1.

### Verification Process

Server runs. Tests run and are green.