### PR TITLE
Update Node version matrix [#188081075]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 
-- Node (only LTS versions are officially supported, currently 16 and 18)
+- Node (only LTS versions are officially supported, currently 18, 20, and 22)
 - `yarn` (`npm i -g yarn`)
 - `pre-commit` (`pip install pre-commit`)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
       - task: NodeTool@0
         inputs:
-          versionSpec: '18'
+          versionSpec: '22'
 
       - task: Cache@2
         inputs:
@@ -86,7 +86,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '18'
+          versionSpec: '22'
 
       - task: Cache@2
         inputs:
@@ -153,10 +153,12 @@ jobs:
       YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
     strategy:
       matrix:
-        Node16:
-          NODE_VERSION: 16
         Node18:
           NODE_VERSION: 18
+        Node20:
+          NODE_VERSION: 20
+        Node22:
+          NODE_VERSION: 22
 
     steps:
       - task: NodeTool@0


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188081075

### Description of the Change

Our matrix of supported Node versions was very out of date. This updates it. The bundles seem to be identical no matter which version of Node they're built with, so it shouldn't matter.

### Verification Process

Ran `yarn start` and `yarn build` will all three supported major versions. Resulting bundles were checksum identical, and we don't run Node on the server itself, so I'm going to consider that "good enough".