### PR TITLE
add Pin indicator to Read Donations [#188081545]

### DIFF
--- a/bundles/processing/modules/donations/DonationRow.tsx
+++ b/bundles/processing/modules/donations/DonationRow.tsx
@@ -86,6 +86,7 @@ export default function DonationRow(props: DonationRowProps) {
       <strong>
         <HighlightKeywords>{donation.donor_name || UNKNOWN_DONOR_NAME}</HighlightKeywords>
       </strong>
+      {donation.pinned && '📌'}
     </Text>
   );
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188081545

### Description of the Change

The old page had an indicator when something was pinned. The new page does not appear to, or it got lost at some point. This brings it back.

### Verification Process

Pin acts as expected, both live and after a refresh.