### PR TITLE
volunteer import behavior tweaks [#188094341]

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,7 @@
+import csv
 import datetime
 import functools
+import io
 import itertools
 import json
 import logging
@@ -43,6 +45,16 @@ def parse_test_mail(mail):
                 result[name] = []
             result[name].append(value)
     return result
+
+
+def parse_csv_response(response):
+    assert response['content-type'].startswith(
+        'text/csv'
+    ), f'expected `text/csv` for content-type, got {response["content-type"]}'
+    return [
+        line
+        for line in csv.reader(io.StringIO(response.content.decode(response.charset)))
+    ]
 
 
 noon = datetime.time(12, 0)

--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -1,5 +1,6 @@
 import csv
 import time
+from collections import defaultdict
 from decimal import Decimal
 from io import BytesIO, StringIO
 
@@ -221,7 +222,9 @@ class EventAdmin(CustomModelAdmin):
                 ), 'some permissions were missing, check admin_codenames or that all migrations have run'
                 admin_group.permissions.set(admin_permissions)
                 successful = 0
+                email_validator = EmailValidator()
                 for row, volunteer in enumerate(volunteers, start=2):
+                    volunteer = defaultdict(str, volunteer)
                     try:
                         firstname, space, lastname = (
                             volunteer['name'].strip().partition(' ')
@@ -229,10 +232,10 @@ class EventAdmin(CustomModelAdmin):
                         is_head = 'head' in volunteer['position'].strip().lower()
                         is_host = 'host' in volunteer['position'].strip().lower()
                         email = volunteer['email'].strip()
-                        EmailValidator()(email)
+                        email_validator(email)
                         username = volunteer['username'].strip()
                         if not username:
-                            raise ValueError('username cannot be blank')
+                            username = email
                         user, created = auth.User.objects.get_or_create(
                             email__iexact=volunteer['email'],
                             defaults=dict(
@@ -262,7 +265,7 @@ class EventAdmin(CustomModelAdmin):
                             messages.add_message(
                                 request,
                                 messages.INFO,
-                                f'Found existing user {volunteer["username"]} with email {volunteer["email"]}',
+                                f'Found existing user {user.username} with email {volunteer["email"]}',
                             )
 
                         context = dict(


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188094341

### Description of the Change

While importing users for an event, I decided that future events could benefit from the following tweaks:

1) Blank usernames are accepted and default to the email itself, since new users are allowed to choose their username when they activate anyway (behavior change)
2) Missing columns will be treated as blank instead of causing an error (technically a behavior change)
3) Existing users were displaying the wrong value for existing username after import (visual bug fix)

Note that a missing `email` column will cause validation errors because the email cannot be blank. A missing `position` column will treat all entries as first-pass screeners. 

### Verification Process

Fed a few test CSVs into the importer, including an absolute bare minimum that only contained the email column and nothing else. Got the expected results.