### PR TITLE
missing tracker settings imports

### DIFF
--- a/tracker/admin/prize.py
+++ b/tracker/admin/prize.py
@@ -1,7 +1,6 @@
 import datetime
 from itertools import groupby
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin import register
 from django.contrib.auth.decorators import permission_required
@@ -10,7 +9,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import path, reverse
 
-from tracker import forms, logutil, models, prizemail, util, viewutil
+from tracker import forms, logutil, models, prizemail, settings, util, viewutil
 
 from .filters import PrizeListFilter
 from .forms import DonorPrizeEntryForm, PrizeForm, PrizeKeyImportForm, PrizeWinnerForm

--- a/tracker/prizemail.py
+++ b/tracker/prizemail.py
@@ -1,13 +1,13 @@
 import os
 
 import post_office.mail
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import F, Q
 from django.urls import reverse
 
 import tracker.viewutil as viewutil
+from tracker import settings
 from tracker.models import Prize, PrizeWinner
 
 AuthUser = get_user_model()


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Description of the Change

Got a report that `TRACKER_HAS_CELERY` was causing issues with prize draws if the setting was missing entirely. Found a couple spots where the Django settings were being imported directly instead of going through the wrapper.

### Verification Process

No real behavior change, so just let the tests run.