### PR TITLE
show Prize/Run category on React view page, and fix CSS for long Provider names [#188117676]

### DIFF
--- a/bundles/tracker/prizes/components/PrizeCard.mod.css
+++ b/bundles/tracker/prizes/components/PrizeCard.mod.css
@@ -73,7 +73,7 @@
 }
 
 .providedBy {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   margin-right: 8px;
 }
 

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -64,6 +64,7 @@ const PrizeCard = (props: PrizeCardProps) => {
       <div className={styles.content}>
         <Header className={styles.prizeName} size={Header.Sizes.H5}>
           {prize.public}
+          {prize.category && ` (${prize.category.name})`}
         </Header>
         <Text size={Text.Sizes.SIZE_14} marginless>
           {getPrizeRelativeAvailability(prize, now)}


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188117676

### Description of the Change

It was requested that we show the run category next to the availability information, mostly because FF names The Chomp the same thing but with different categories, so the "availability starts" information was confusing. As part of this I had to add the info to the prize API.

Also Shout reported a long time ago a CSS issue that I had fixed on the live branch but never pulled back in here, so it lives here now.

### Verification Process

This was mostly visual fixes, other than the API, which was a test change.