### PR TITLE
move eventutil from urllib to requests

### DIFF
--- a/tracker/eventutil.py
+++ b/tracker/eventutil.py
@@ -1,7 +1,7 @@
 import json
 import traceback
-import urllib.request
 
+import requests
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.core import serializers
@@ -11,8 +11,6 @@ import tracker.models as models
 import tracker.search_filters as filters
 import tracker.viewutil as viewutil
 from tracker.consumers.processing import broadcast_new_donation_to_processors
-
-# TODO: this is 2018, we ought to be using requests
 
 
 def post_donation_to_postbacks(donation):
@@ -57,13 +55,12 @@ def post_donation_to_postbacks(donation):
 
         postbacks = models.PostbackURL.objects.filter(event=donation.event)
         for postback in postbacks:
-            opener = urllib.request.build_opener()
-            req = urllib.request.Request(
+            requests.post(
                 postback.url,
-                data_json,
+                data=data_json,
                 headers={'Content-Type': 'application/json; charset=utf-8'},
+                timeout=5,
             )
-            opener.open(req, timeout=5)
     except Exception:
         viewutil.tracker_log(
             'postback_url', traceback.format_exc(), event=donation.event


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [x] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

Link to the issue from the [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1521291) that your change addresses. (Expand the story and click the link icon to copy the link to your clipboard.)
N/A

### Description of the Change

If fixing a bug, please describe the bug and provide reproduction steps.

If adding a feature or changing functionality, please describe the change in a way that makes it easy to understand the design of the change. When applicable, screenshots are very useful to help us understand changes.

If there are possible side effects of negative impacts of the code change, list them here.

This resolves the 2018 TODO comment that suggests moving to requests. I've preserved exact compatibility with the previous version here by ensuring that the body is exactly the same, and I've re-enabled the test for `eventutil` since it can now be mocked with responses. There are no design changes, and I've modified the fewest number of lines possible to make this change possible.

This should stay completely compatible with the previous version, as it follows the exact same patterns, no extra processing is done, and `requests` explicitly `POST`s here instead of implicitly doing so like `urllib` does.

### Verification Process

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you took apart from writing tests, such as running a local instance of the tracker. (What buttons did you press, etc.)

When testing, both before and after making this change, I disabled responses and used <https://webhook.site> to get the test body before and after the changes were made. Before making my changes, I did have to set `transactionstate='COMPLETED'` on the test donation, so that it actually registered in the `run_model_query` call of line 31 in `tracker/eventutil.py` and prevented an exception from the donations total total sent being None(since the total is derived from only completed transactions, and if the state was not set as COMPLETED, it did not register).
