### PR TITLE
add donation feeds to queryset [#186837954]

### DIFF
--- a/tests/randgen.py
+++ b/tests/randgen.py
@@ -374,7 +374,8 @@ def generate_donation(
     donation.fee = (donation.amount * Decimal(0.03)).quantize(
         Decimal('0.01'), rounding=decimal.ROUND_UP
     )
-    donation.comment = random_name(rand, 'Comment')
+    if commentstate != 'ABSENT':
+        donation.comment = random_name(rand, 'Comment')
     donation.commentstate = commentstate
     donation.readstate = readstate
     if not min_time:

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -23,7 +23,6 @@ from .util import (
     MigrationsTestCase,
     long_ago_noon,
     parse_test_mail,
-    parse_time,
     today_noon,
     tomorrow_noon,
 )
@@ -86,7 +85,7 @@ class TestPrizeGameRange(TransactionTestCase):
 
 class TestPrizeDrawingGeneratedEvent(TransactionTestCase):
     def setUp(self):
-        self.eventStart = parse_time('2014-01-01 16:00:00Z')
+        self.eventStart = util.parse_time('2014-01-01 16:00:00Z')
         self.rand = random.Random(516273)
         self.event = randgen.build_random_event(
             self.rand, start_time=self.eventStart, num_donors=100, num_runs=50

--- a/tests/test_tracker_settings.py
+++ b/tests/test_tracker_settings.py
@@ -49,3 +49,16 @@ class TestTrackerSettings(TestCase):
                 settings.TRACKER_ENABLE_BROWSABLE_API,
                 msg='TRACKER_ENABLE_BROWSABLE_API',
             )
+
+    def test_paypal_test(self):
+        with override_settings(DEBUG=False):
+            self.assertFalse(
+                settings.PAYPAL_TEST,
+                msg='PAYPAL_TEST',
+            )
+
+        with override_settings(DEBUG=True):
+            self.assertTrue(
+                settings.PAYPAL_TEST,
+                msg='PAYPAL_TEST',
+            )

--- a/tests/util.py
+++ b/tests/util.py
@@ -26,7 +26,7 @@ from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
-from tracker import models, settings
+from tracker import models, settings, util
 from tracker.api.pagination import TrackerPagination
 from tracker.compat import zoneinfo
 
@@ -70,16 +70,6 @@ long_ago = today - datetime.timedelta(days=180)
 long_ago_noon = datetime.datetime.combine(long_ago, noon).astimezone(
     zoneinfo.ZoneInfo(settings.TIME_ZONE)
 )
-
-
-# TODO: remove this when 3.11 is oldest supported version
-def parse_time(value):
-    if sys.version_info < (3, 11):
-        import dateutil.parser
-
-        return dateutil.parser.parse(value)
-    else:
-        return datetime.datetime.fromisoformat(value)
 
 
 class MigrationsTestCase(TransactionTestCase):
@@ -355,7 +345,7 @@ class APITestCase(TransactionTestCase):
             return True
         if not isinstance(expected, str) and isinstance(found, str):
             if isinstance(expected, datetime.datetime):
-                if expected == parse_time(found):
+                if expected == util.parse_time(found):
                     return True
             else:
                 try:

--- a/tracker/models/event.py
+++ b/tracker/models/event.py
@@ -308,9 +308,10 @@ class Event(models.Model):
                 self.datetime = self.datetime.replace(tzinfo=self.timezone)
         super(Event, self).save(*args, **kwargs)
 
-        # When an event's datetime moves later than the starttime of the first
-        # run, we need to trigger a save on the run to update all runs' times
-        # properly to begin after the event starts.
+        # one side of an event setting edge case, see Donation.save() for the other
+        if self.use_one_step_screening:
+            # TODO: send notifications?
+            self.donation_set.completed().to_approve().update(readstate='READY')
         first_run = self.speedrun_set.all().first()
         if first_run and first_run.starttime and first_run.starttime != self.datetime:
             first_run.save(fix_time=True)

--- a/tracker/settings.py
+++ b/tracker/settings.py
@@ -47,6 +47,10 @@ class TrackerSettings(object):
     def TRACKER_ENABLE_BROWSABLE_API(self):
         return getattr(settings, 'TRACKER_ENABLE_BROWSABLE_API', settings.DEBUG)
 
+    @property
+    def PAYPAL_TEST(self):
+        return getattr(settings, 'PAYPAL_TEST', settings.DEBUG)
+
     # pass everything else through for convenience
     def __getattr__(self, item):
         return getattr(settings, item)
@@ -108,4 +112,6 @@ def tracker_settings_checks(app_configs, **kwargs):
         errors.append(
             Error('TRACKER_ENABLE_BROWSABLE_API should be a bool', id='tracker.E106')
         )
+    if type(TrackerSettings().PAYPAL_TEST) != bool:
+        errors.append(Error('PAYPAL_TEST should be a bool', id='tracker.E107'))
     return errors

--- a/tracker/templates/tracker/donation.html
+++ b/tracker/templates/tracker/donation.html
@@ -17,26 +17,24 @@
         {% trans "Amount" %}:
         {{ donation.amount|money }}
     </h2>
-    {% if donation.comment %}
-        <table class="table table-condensed">
-            <thead>
-            <tr>
-                <th align="center">
-                    <b>
-                        {% trans "Comment" %}
-                    </b>
-                </th>
-            </tr>
-            </thead>
-            <tr>
-                <td class="{{ donation.commentstate }}">
-                    {% with donation.comment as comment %}{% with donation.commentstate as state %}
-                        {% include "tracker/partials/comment.html" %}
-                    {% endwith %}{% endwith %}
-                </td>
-            </tr>
-        </table>
-    {% endif %}
+    <table class="table table-condensed">
+        <thead>
+        <tr>
+            <th align="center">
+                <b>
+                    {% trans "Comment" %}
+                </b>
+            </th>
+        </tr>
+        </thead>
+        <tr>
+            <td class="{{ donation.commentstate }}">
+                {% with donation.comment as comment %}{% with donation.commentstate as state %}
+                    {% include "tracker/partials/comment.html" %}
+                {% endwith %}{% endwith %}
+            </td>
+        </tr>
+    </table>
 
     {% if donationbids %}
         <h3>

--- a/tracker/templates/tracker/partials/comment.html
+++ b/tracker/templates/tracker/partials/comment.html
@@ -4,7 +4,7 @@
 {% if state == 'APPROVED' %}
 	{{ comment|forumfilter }}<hr>
 {% endif %}
-{% if state == 'PENDING' %}
+{% if state == 'PENDING' or state == 'FLAGGED' %}
 	<i class="fa text-gdq-black fa-question-circle"></i> ({% trans "Comment pending approval" %})
 {% elif state == 'DENIED' %}
 	<i class="fa text-gdq-red fa-times-circle"></i> ({% trans "Comment rejected" %})

--- a/tracker/views/public.py
+++ b/tracker/views/public.py
@@ -65,8 +65,8 @@ def index(request, event=None):
     if event.id:
         eventParams['event'] = event.id
 
-    donations = Donation.objects.filter(
-        transactionstate='COMPLETED', testdonation=False, **eventParams
+    donations = Donation.objects.completed().filter(
+        **eventParams,
     )
 
     agg = donations.aggregate(
@@ -335,7 +335,7 @@ def donor_detail(request, pk, event=None):
             return views_common.tracker_response(
                 request, template='tracker/badobject.html', status=404
             )
-        donations = cache.donation_set.filter(transactionstate='COMPLETED')
+        donations = cache.donation_set.completed()
 
         # TODO: double check that this is(n't) needed
         if event.id:


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/186837954

### Description of the Change

In the interest of consolidating complex queries to the querysets themselves, I've added some helpers to the Donation queryset for some common operations.

I also made the following additional tweaks:

- the special endpoints no longer blow up if you try and specify the format, e.g. `/api/v2/donations/unprocessed.json` works as expected
- Donations with a "blank" (nothing but whitespace) comment always have a comment state of `ABSENT`, and comments that are marked `ABSENT` but actually have content (entirely possible with manual entry) will instead change to `PENDING`.

### Verification Process

The endpoints use the new helpers instead of their own baked in logic, and return the same expected values.