### PR TITLE
adjust Package conditions [#188164708]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,8 +89,9 @@ jobs:
     condition: >
       not(
         or(
-          startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue'),
-          startsWith(variables['Build.SourceBranchName'], 'spike')
+          eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+          startsWith(variables['Build.SourceBranchName'], 'spike'),
+          eq(variables['System.PullRequest.IsFork'], 'True')
         )
       )
     steps:


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker


### Description of the Change

Tweaks to the Package step on Azure:

- build on the merge queue, not on master
- don't build for forks

The second is important because we can't actually merge any external PRs otherwise.

### Verification Process

Verify that azure does the right thing. Unfortunately the final check will be -after- the merge, but that's just how these things work.