### PR TITLE
add selenium skip flag [#188181444]

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,7 @@
+import os
 import random
 import time
+from unittest import skipIf
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -38,6 +40,7 @@ class MergeDonorsViewTests(TestCase):
         self.assertContains(response, 'Select which donor to use as the template')
 
 
+@skipIf(os.environ.get('TRACKER_SKIP_SELENIUM', ''), 'selenium disabled')
 class ProcessDonationsBrowserTest(TrackerSeleniumTestCase):
     def setUp(self):
         self.rand = random.Random(None)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188181444

### Description of the Change

While working on hotfixes I found the Selenium tests unacceptably flaky when I wasn't even doing anything to touch them, so there's an Environment variable to skip them locally.

Set `TRACKER_SKIP_SELENIUM` to any value other than a blank string and the tests will be skipped.

If you set this on Azure I'm coming after you.

### Verification Process

Set the flag. Tests were skipped. Cleared the flag. Tests were not skipped. Done.