### PR TITLE
New prize detail page template

### DIFF
--- a/tracker/templates/tracker/prize.html
+++ b/tracker/templates/tracker/prize.html
@@ -5,106 +5,90 @@
 {% block title %}{% trans "Prize Detail" %} &mdash; {{ event.name }}{% endblock %}
 
 {% block content %}
-    {% if settings.TRACKER_SWEEPSTAKES_URL %}
-      <div>No donation necessary for a chance to win.
-        See <a href="{{ settings.TRACKER_SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
-        details and instructions.
-      </div>
-    {% endif %}
-
-    <div class="title">
-        <b>
-            {% trans "Prize" %}:
-        </b>
+    <h2>
         {{ prize.name }}
-        <b>
-            {% trans "Minimum Bid" %}:
-        </b>
-        {{ prize.minimumbid|money }}
+        <br>
+        <small>
+            {% trans "Minimum Bid" %}: {{ prize.minimumbid|money }}
         {% if category %}
-            <b>
-                {% trans "Category" %}:
-            </b>
-            {{ category }}
+            <br>
+            {% trans "Category" %}: {{ category }}
         {% endif %}
-        {% if prize.image %}
-            <b>
-                {% trans "Image" %}:
-            </b>
-            <a href="{{ prize.image }}">{% trans "Link" %}</a>
+        {% if prize.provider %}
+            <br>
+            {% trans "Contributed By" %}:
+            {% if prize.creatorwebsite %}
+                <a href="{{ prize.creatorwebsite }}">{{ prize.provider }}</a>
+            {% else %}
+                {{ prize.provider }}
+            {% endif %}
         {% endif %}
-    </div>
+
+    {% if games %}
+        </small>
+    </h2>
+    <h3 class="text-gdq-black">
+        {% trans "Games" %}
+    </h3>
+    <ul style="list-style:none;padding-left:0">
+        {% for game in games %}
+            <li style="margin-bottom:2px;">
+                <a href="{% url 'tracker:run' pk=game.pk %}">
+                    {{ game.name }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+    {% elif prize.starttime %}
+        <div style="margin-top:0.55em;display:grid;width:fit-content">
+            <div style="margin-bottom:5px;">{% trans "Opens" %}: <span class='datetime'>{{ prize.starttime|date:"c" }}</span></div>
+            <i class="fa fa-arrows-v" style="justify-self:center"></i>
+            <div style="margin-top:5px;">{% trans "Closes" %}: <span class='datetime'>{{ prize.endtime|date:"c" }}</span></div>
+        </div>
+        </small>
+    </h2>
+    {% endif %}
     {% for winner in prize.get_winners %}
         {% if forloop.first %}
-            <table>
-                <th>{% trans "Winner(s)" %}</th>
+            <h3 class="text-gdq-black">
+                {% trans "Winners" %}
+            </h3>
+            <ul style="list-style:none">
         {% endif %}
-                <tr>
-                  <td>
-                    {{ winner.donor_cache.visible_name }}
-{#                    {% include "tracker/partials/donor_link.html" with donor=winner.donor_cache only %}#}
-                  </td>
-                </tr>
+            <li>
+                {{ winner.donor_cache.visible_name }}
+{#              {% include "tracker/partials/donor_link.html" with donor=winner.donor_cache only %}#}
+            </li>
         {% if forloop.last %}
-            </table>
+            </ul>
         {% endif %}
     {% endfor %}
-
-    {% if prize.provider %}
-        <table>
-            <tr>
-                <th>
-                    {% trans "Contributed By" %}
-                </th>
-            </tr>
-            <tr>
-                <td>
-                    {{ prize.provider }}
-                </td>
-            </tr>
-        </table>
+    {% if prize.description %}
+        <h3 class="text-gdq-black">
+            {% trans "Description" %}
+        </h3>
+        <p>{{ prize.description|forumfilter }}</p>
     {% endif %}
-    {% if games %}
-        <table>
-            <tr>
-                <th align="center">
-                    {% trans "Games" %}
-                </th>
-            </tr>
-            {% for game in games %}
-                <tr>
-                    <td>
-                        <a href="{% url 'tracker:run' pk=game.pk %}">
-                            {{ game.name }}
-                        </a>
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
-    {% elif prize.starttime %}
-        <div>
-            <b>Opens:</b> <span class='datetime'>{{ prize.starttime|date:"c" }}</span>
-            <i class="fa fa-arrows-h"></i>
-            <b>Closes:</b> <span class='datetime'>{{ prize.endtime|date:"c" }}</span>
+    {% if prize.image %}
+        <hr>
+        <div style="display:grid">
+            <img
+                src="{{ prize.image }}"
+                style="justify-self:center;max-width: calc(40% - 50px);max-height:auto"
+                alt=""
+            />
         </div>
     {% endif %}
-    {% if prize.description %}
-        <table>
-            <tr>
-                <th align="center">
-                    <b>
-                        {% trans "Description" %}
-                    </b>
-                </th>
-            </tr>
-            <tr>
-                <td>
-                    {{ prize.description|forumfilter }}
-                </td>
-            </tr>
-        </table>
+    <hr>
+    {% if settings.TRACKER_SWEEPSTAKES_URL %}
+        <small>No donation necessary for a chance to win.
+        See <a href="{{ settings.TRACKER_SWEEPSTAKES_URL }}" target="_blank" rel="noopener noreferrer">sweepstakes rules</a> for
+        details and instructions.
+        </small>
+        <br>
     {% endif %}
-    <p align="center"><a
+
+    <p align="center" style="margin-top:10px"><a
             href="{% url 'tracker:prizeindex' event=prize.event.short %}">{% trans "Back to Prize Index" %}</a>
     </p>
     {% include "tracker/partials/navfooter.html" %}


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

No automated tests needed to be run, and the current tests still work with these changes applied.

### Issue from Pivotal Tracker

Link to the issue from the [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1521291) that your change addresses. (Expand the story and click the link icon to copy the link to your clipboard.)

N/A

### Description of the Change
<!--
If fixing a bug, please describe the bug and provide reproduction steps.

If adding a feature or changing functionality, please describe the change in a way that makes it easy to understand the design of the change. When applicable, screenshots are very useful to help us understand changes.

If there are possible side effects of negative impacts of the code change, list them here.
-->

This makes the prize template look closer to other templates bid and run details. The name of the prize is more evident, the information is more clearly laid out, and the overall look is more polished.

The new template has been tested on both desktop and mobile form factors, and mobile is vastly more readable thanks to the larger font sizes.

In all below screenshot sets, top is the image before the template was changed, and the bottom one is after.

### Prize Page with Image(Desktop)
Also includes a category(even though this is no longer used for new prizes in the main tracker, it is in the code(and used on historical prizes), so it's been included in these changes) and uses the game-based prize draw timing. Prize provider has a website, so it's linked as well.

![with-image-category-games-desktop-before](https://github.com/user-attachments/assets/94f01d29-5ca2-4051-b4ca-713d24f65df2)

![with-image-category-games-desktop-after](https://github.com/user-attachments/assets/276d91da-49f0-4d18-ab5d-76c8d83471c5)

### Prize Page without Image(Desktop)
Does not have categories, and uses start/end-times for drawing. Prize provider does not have a website, so no link is added.

![no-image-no-category-start-end-times-desktop-before](https://github.com/user-attachments/assets/795de81e-0652-4391-ab8f-9f0dd536bf34)

![no-image-no-category-start-end-times-desktop-after](https://github.com/user-attachments/assets/16ddf836-6adc-44a3-9dac-13c2cfb6cfda)

### Prize Page With Image(Mobile)

![with-image-category-games-mobile-before](https://github.com/user-attachments/assets/242fc554-5d38-4d54-9baf-5b70e12bde5d)

![with-image-category-games-mobile-after](https://github.com/user-attachments/assets/e8fa2eb7-3af6-44b3-afc0-a4deb530eab4)

### Prize Page Without Image(Mobile)

![no-image-no-category-start-end-times-mobile-before](https://github.com/user-attachments/assets/3a40a943-1c48-46ca-8536-74f7c01c4583)

![no-image-no-category-start-end-times-mobile-after](https://github.com/user-attachments/assets/7f6a48ee-7203-4656-92b2-df4077aa011d)

### Verification Process

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you took apart from writing tests, such as running a local instance of the tracker. (What buttons did you press, etc.)

I've run a local instance of the tracker to ensure that the prize pages work properly on both desktop and mobile.

I've cropped the mobile screenshots down to the important sections, but they have full dimensions of 1080p wide and 2057p tall. All removed height is at the bottom, so if scaling them back up, just add a fully white section to the bottom to match the height.

For reference, the screenshots were taken using firefox's Take Screenshot function(available in the right-click menu) and then selecting "Save Full Page." The resolution of these appears to be ~2x what is shown on the screen, but that should not be too much of an issue for what's shown in these screenshots.

The desktop screenshots were taken on the 2560x1600 panel of my Framework Laptop 16, and the mobile screenshots are basic screenshots from my Google Pixel 7 using Android's screenshot functionality.