### PR TITLE
most admin pages show newer Events first for submodel sorting [#188364906]

### DIFF
--- a/tracker/admin/util.py
+++ b/tracker/admin/util.py
@@ -101,6 +101,14 @@ def api_urls():
 
 
 class EventLockedMixin:
+    def get_ordering(self, request):
+        ordering = super().get_ordering(request) or self.opts.ordering
+        # show most recent events first, but otherwise leave the ordering alone
+        return [
+            '-event__datetime' if o in ['event__datetime', 'event'] else o
+            for o in ordering
+        ]
+
     def _has_locked_permission(self, request, obj):
         event = self.get_event(obj)
         return (

--- a/tracker/models/interstitial.py
+++ b/tracker/models/interstitial.py
@@ -28,7 +28,7 @@ class Interstitial(models.Model):
     anchor = models.ForeignKey(
         'tracker.speedrun', on_delete=models.PROTECT, null=True, blank=True
     )
-    # needs to be nullable to support moves when anchored
+    # needs to be nullable to support moves when anchored, but should always fix itself coming out the other end
     order = models.IntegerField(
         validators=[validators.positive, validators.nonzero], null=True
     )
@@ -44,6 +44,8 @@ class Interstitial(models.Model):
 
     @property
     def run(self):
+        if self.order is None:  # should never happen, but blows things up if it does
+            return None
         if self.anchor:
             return self.anchor
         runs = SpeedRun.objects.filter(event=self.event)


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [X] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188364906

### Description of the Change

Chances are you aren't trying to look at really old stuff first, so changing the default sorting for admin pages made sense. 

### Verification Process

Just a display change, so no tests really, just poking about and seeing if the sort order changed.
