### PR TITLE
fix perm check in Donation consumer [#188391569]

### DIFF
--- a/tracker/consumers/processing.py
+++ b/tracker/consumers/processing.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from channels.layers import get_channel_layer
 from django.contrib.auth import get_user_model
@@ -14,7 +14,7 @@ PROCESSING_GROUP_NAME = 'processing'
 class ProcessingConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         self.user = self.scope['user']
-        if not self.user.has_perm('tracker.change_donation'):
+        if not await sync_to_async(self.user.has_perm)('tracker.change_donation'):
             await self.close()
             return
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188391569

### Description of the Change

For non-superusers, the permission check in the Donation consumer fails because it's a sync call in an async context.

This has been fixed on the event branch for far too long without making it back to master.

### Verification Process

Before: Non-superuser with the `change_donation` permission cannot access the live socket via the processing pages.
After: It works.