### PR TITLE
unpin all unopen bids [#188391685]

### DIFF
--- a/tests/test_bid.py
+++ b/tests/test_bid.py
@@ -257,6 +257,14 @@ class TestBid(TestBidBase):
         ):
             models.Bid(parent=self.chain_bottom, goal=50).clean()
 
+    def test_auto_unpin(self):
+        self.assertEqual(self.challenge.state, 'OPENED')
+        self.assertTrue(self.challenge.pinned)
+        self.challenge.state = 'CLOSED'
+        self.challenge.save()
+        self.assertEqual(self.challenge.state, 'CLOSED')
+        self.assertFalse(self.challenge.pinned)
+
     def test_autoclose(self):
         with self.subTest('standard challenge'):
             self.assertEqual(self.challenge.state, 'OPENED')

--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -493,6 +493,8 @@ class Bid(mptt.models.MPTTModel):
         else:
             self.chain_goal = self.chain_remaining = None
         self.update_total()
+        if self.state != 'OPENED':
+            self.pinned = False
         super(Bid, self).save(*args, **kwargs)
         for option in self.get_children():
             changed = False


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188391685

### Description of the Change

Pinned bids clutter up the `current` feed if they're closed. This ensures they unpin after they close for any reason.

### Verification Process

Edited a bid into various states, either trying to set the pin flag, or with an already existing pin flag, and in all cases I could find, the pin flag automatically dropped whenever the bid was no longer 'open'.