### PR TITLE
unordered runs are considered hidden (mostly) [#188391804]

### DIFF
--- a/tests/apiv2/test_runs.py
+++ b/tests/apiv2/test_runs.py
@@ -28,6 +28,9 @@ class TestRunViewSet(TestSpeedRunBase, APITestCase):
             data = self.get_detail(self.run1, kwargs={'event_pk': self.event.pk})
             self.assertEqual(data, serialized.data)
 
+            data = self.get_detail(self.run4)  # unordered run
+            self.assertV2ModelPresent(self.run4, data)
+
         with self.subTest('wrong event (whether event exists or not)'):
             self.get_detail(
                 self.run1, kwargs={'event_pk': self.event.pk + 1}, status_code=404
@@ -37,17 +40,25 @@ class TestRunViewSet(TestSpeedRunBase, APITestCase):
             self.get_detail(
                 self.run1, data={'tech_notes': ''}, user=None, status_code=403
             )
+            self.get_detail(self.run4, status_code=404)
 
     def test_list(self):
         with self.subTest('normal lists'), self.saveSnapshot():
             serialized = SpeedRunSerializer(
-                models.SpeedRun.objects.filter(event=self.event), many=True
+                models.SpeedRun.objects.filter(event=self.event).exclude(order=None),
+                many=True,
             )
             data = self.get_list()
             self.assertEqual(data['results'], serialized.data)
 
             serialized = SpeedRunSerializer(
-                models.SpeedRun.objects.filter(event=self.event),
+                models.SpeedRun.objects.filter(event=self.event), many=True
+            )
+            data = self.get_list(data={'all': ''})
+            self.assertEqual(data['results'], serialized.data)
+
+            serialized = SpeedRunSerializer(
+                models.SpeedRun.objects.filter(event=self.event).exclude(order=None),
                 event_pk=self.event.pk,
                 many=True,
             )
@@ -56,7 +67,7 @@ class TestRunViewSet(TestSpeedRunBase, APITestCase):
 
         with self.subTest('requesting tech notes'), self.saveSnapshot():
             serialized = SpeedRunSerializer(
-                models.SpeedRun.objects.filter(event=self.event),
+                models.SpeedRun.objects.filter(event=self.event).exclude(order=None),
                 with_permissions=('tracker.can_view_tech_notes',),
                 with_tech_notes=True,
                 many=True,
@@ -66,6 +77,7 @@ class TestRunViewSet(TestSpeedRunBase, APITestCase):
 
         with self.subTest('permissions checks'):
             self.get_list(data={'tech_notes': ''}, user=None, status_code=403)
+            self.get_list(data={'all': ''}, status_code=403)
 
         with self.subTest('not a real event'):
             self.get_list(kwargs={'event_pk': self.event.pk + 100}, status_code=404)

--- a/tracker/api/views/run.py
+++ b/tracker/api/views/run.py
@@ -1,5 +1,5 @@
 from tracker.api.pagination import TrackerPagination
-from tracker.api.permissions import TechNotesPermission
+from tracker.api.permissions import PrivateGenericPermissions, TechNotesPermission
 from tracker.api.serializers import SpeedRunSerializer
 from tracker.api.views import (
     EventNestedMixin,
@@ -21,7 +21,16 @@ class SpeedRunViewSet(
     )
     serializer_class = SpeedRunSerializer
     pagination_class = TrackerPagination
-    permission_classes = [TechNotesPermission]
+    permission_classes = [
+        TechNotesPermission,
+        *PrivateGenericPermissions('speedrun', lambda r: r.order is not None),
+    ]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if not self.detail and 'all' not in self.request.query_params:
+            queryset = queryset.exclude(order=None)
+        return queryset
 
     def get_serializer(self, *args, **kwargs):
         with_tech_notes = (

--- a/tracker/models/event.py
+++ b/tracker/models/event.py
@@ -656,6 +656,8 @@ class SpeedRun(models.Model):
                     )
                 self.starttime = self.anchor_time
         else:
+            self.starttime = None
+            self.endtime = None
             self.order = None
 
     def save(self, fix_time=True, fix_runners=True, *args, **kwargs):

--- a/tracker/templates/tracker/run.html
+++ b/tracker/templates/tracker/run.html
@@ -8,6 +8,13 @@
 {% block content %}
 	<h2 class="text-center">
 		{{ run.name_with_category }} &mdash; {{ run.event }}
+    {% if run.starttime %}
+      <br>
+      <small>
+        {% trans "Start Time" %}: <span class="datetime" data-epoch="{{ run.starttime|date:"U" }}">{{ run.starttime|date:"c" }}</span>
+        {% trans "Run Time" %}: {{ run.run_time }}
+      </small>
+    {% endif %}
 	</h2>
 
   {% if run.description %}

--- a/tracker/templates/tracker/runindex.html
+++ b/tracker/templates/tracker/runindex.html
@@ -39,7 +39,7 @@
 				{% trans "Start Time" %}
 			</th>
 			<th>
-				{% trans "End Time" %}
+				{% trans "Run Time" %}
 			</th>
 			<th>
 				{% trans "Bid Wars" %}
@@ -63,11 +63,11 @@
 			<td>
 				{{ run.description|forumfilter }}
 			</td>
-			<td class="datetime">
+			<td class="datetime {% if run.anchor_time %}anchored{% endif %}" data-epoch="{{ run.starttime|date:"U" }}">
 				{{ run.starttime|date:"c" }}
 			</td>
-			<td class="datetime">
-				{{ run.endtime|date:"c" }}
+			<td>
+				{{ run.run_time }}
 			</td>
 			{% autoescape off %}
 			<td>


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188391804

### Description of the Change

There are some edge cases where an unordered run can cause sorting to be very weird, but after some internal discussions we decided that an unordered run should be mostly hidden anyway. V2 and the public pages won't show unordered runs by default, V2 you specifically have to request and have permission. V1 still will list them, but the only reason V1 still needs them at all is because of the schedule editor and I'm going to be rewriting that from scratch soon, so I'll close that when it comes to it.

Also while I was in there, I changed the formatting of the public run list slightly. Lists length rather than end time.

### Verification Process

Poked the API, both list and detail, and got the expected results. Public page just always 404s for an unordered run. V1 continues to list them for now, regardless of permission, because of the note above.