### PR TITLE
fix donation processing state bug with websocket [#188438371]

### DIFF
--- a/bundles/processing/modules/donations/DonationsStore.tsx
+++ b/bundles/processing/modules/donations/DonationsStore.tsx
@@ -21,6 +21,9 @@ function getDonationStateFromReadState(donation: Donation, defaultState: Donatio
       return 'ready';
     case 'FLAGGED':
       return 'flagged';
+    case 'READ':
+    case 'IGNORED':
+      return 'done';
     default:
       return defaultState;
   }


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [ ] I've added tests or modified existing tests for the change.
(see note below)
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188438371

### Description of the Change

This was a confluence of some incomplete logic running into a change in the shape of data for Donations with no comment. This state was not handled correctly, but in practice said shape never occurred in the wild. With some backend changes made in #703 the `commentstate` field on Donations could be `ABSENT` after it has passed through the host queue, and the logic to determine which "feed" a Donation belongs to from the live update websocket was returning the incorrect value for this particular state combination. Now it correctly treats them as "done", as the actual API does.

Note that this ONLY affected the websocket processing, the API was still doing the correct thing, so one workaround was hard-refreshing the processing page.

I was unable to write tests for this since I've been unable to get websockets working on the browser test, and that's the only way to get the actual problem to manifest.

### Verification Process

Tested it with two tabs open, with and without the fix. With the fix, donations marked "read" no longer rose from the dead in the processing queue.

It was deployed during DRDQ and fixed the issue.