### PR TITLE
edit interview v2 [#188495256]

### DIFF
--- a/tests/apiv2/test_interstitials.py
+++ b/tests/apiv2/test_interstitials.py
@@ -1,0 +1,90 @@
+from unittest import SkipTest
+
+from tests import randgen
+from tests.util import APITestCase
+from tracker.api import messages
+
+
+class InterstitialTestCase(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.run = randgen.generate_run(self.rand, event=self.event, ordered=True)
+        self.run.save()
+
+    def test_interstitial_common(self):
+        if getattr(self, 'model_name', None) is None:
+            raise SkipTest
+        with self.subTest('error cases'):
+            self.post_new(
+                data={
+                    'event': self.locked_event.pk,
+                },
+                user=self.add_user,
+                status_code=403,
+            )
+
+            self.post_new(
+                data={
+                    'event': self.event.pk,
+                    'order': self.run.order,
+                    'anchor': self.run.pk,
+                },
+                status_code=400,
+                expected_error_codes={
+                    'event': messages.ANCHOR_FIELD_CODE,
+                    'order': messages.ANCHOR_FIELD_CODE,
+                },
+            )
+
+            self.run.order = None
+            self.run.save()
+
+            self.post_new(
+                data={
+                    'anchor': self.run.pk,
+                },
+                status_code=400,
+                expected_error_codes={'anchor': messages.INVALID_ANCHOR_CODE},
+            )
+
+            # doesn't blow up if missing/nonsense
+
+            self.post_new(
+                data={
+                    'anchor': {'what': 'is this'},
+                },
+                status_code=400,
+            )
+
+            self.post_new(
+                data={
+                    'suborder': 'last',
+                },
+                status_code=400,
+            )
+
+            self.post_new(
+                data={
+                    'event': 'not_an_id',
+                },
+                status_code=400,
+            )
+
+            self.post_new(
+                data={
+                    'event': {'total': 'garbage'},
+                    'suborder': 'last',
+                },
+                status_code=400,
+            )
+
+            self.post_new(
+                data={
+                    'order': {'also': 'silly'},
+                    'suborder': 'last',
+                },
+                status_code=400,
+            )
+
+        with self.subTest('anonymous user'):
+            self.post_new(user=None, status_code=403)

--- a/tests/apiv2/test_interviews.py
+++ b/tests/apiv2/test_interviews.py
@@ -1,46 +1,146 @@
 import random
 
 from tests import randgen
-from tests.util import APITestCase
 from tracker.api.serializers import InterviewSerializer
+from tracker.models import Interview
+
+from .test_interstitials import InterstitialTestCase
 
 
-class TestInterviews(APITestCase):
+class TestInterviews(InterstitialTestCase):
     model_name = 'interview'
     serializer_class = InterviewSerializer
     rand = random.Random()
 
     def setUp(self):
         super().setUp()
-        self.run = randgen.generate_run(self.rand, event=self.event, ordered=True)
-        self.run.save()
         self.public_interview = randgen.generate_interview(self.rand, run=self.run)
         self.public_interview.save()
         self.private_interview = randgen.generate_interview(self.rand, run=self.run)
         self.private_interview.public = False
         self.private_interview.save()
 
-    def test_public_fetch(self):
-        data = self.get_detail(self.public_interview)
-        self.assertV2ModelPresent(self.public_interview, data)
+    def test_fetch(self):
+        with self.subTest('happy path'), self.saveSnapshot():
+            with self.subTest('public'):
+                data = self.get_detail(self.public_interview)
+                self.assertV2ModelPresent(self.public_interview, data)
 
-    def test_private_fetch(self):
-        self.get_detail(self.private_interview, status_code=404)
+                data = self.get_list()['results']
+                self.assertV2ModelPresent(self.public_interview, data)
+                self.assertV2ModelNotPresent(self.private_interview, data)
 
-        self.client.force_authenticate(self.view_user)
+            with self.subTest('private'):
+                data = self.get_detail(self.private_interview, user=self.view_user)
+                self.assertV2ModelPresent(self.private_interview, data)
 
-        data = self.get_detail(self.private_interview)
-        self.assertV2ModelPresent(self.private_interview, data)
+                data = self.get_list(data={'all': ''})['results']
+                self.assertV2ModelPresent(self.public_interview, data)
+                self.assertV2ModelPresent(self.private_interview, data)
 
-    def test_public_list(self):
-        data = self.get_list()['results']
-        self.assertV2ModelPresent(self.public_interview, data)
-        self.assertV2ModelNotPresent(self.private_interview, data)
+        with self.subTest('error cases'):
+            self.get_detail(self.private_interview, user=None, status_code=404)
+            self.get_list(data={'all': ''}, status_code=403)
 
-    def test_private_list(self):
-        self.get_list(data={'all': ''}, status_code=403)
+    def test_create(self):
+        with self.subTest(
+            'happy path with ids'
+        ), self.saveSnapshot(), self.assertLogsChanges(2):
+            data = self.post_new(
+                data={
+                    'event': self.event.id,
+                    'order': self.run.order,
+                    'suborder': 'last',
+                    'interviewers': 'feasel',
+                    'subjects': 'PJ',
+                    'topic': 'Why Are You a Chaos Elemental',
+                    'length': '15:00',
+                },
+                user=self.add_user,
+            )
+            result = Interview.objects.get(id=data['id'])
+            self.assertV2ModelPresent(result, data)
 
-        self.client.force_authenticate(self.view_user)
-        data = self.get_list(data={'all': ''})['results']
-        self.assertV2ModelPresent(self.public_interview, data)
-        self.assertV2ModelPresent(self.private_interview, data)
+            data = self.post_new(
+                data={
+                    'anchor': self.run.id,
+                    'suborder': data['suborder'] + 1,
+                    'interviewers': 'SpikeVegeta',
+                    'subjects': 'puwexil',
+                    'topic': 'Why Are You an Order Elemental',
+                    'length': '15:00',
+                }
+            )
+            result = Interview.objects.get(id=data['id'])
+            self.assertV2ModelPresent(result, data)
+
+        with self.subTest(
+            'happy path with natural keys'
+        ), self.saveSnapshot(), self.assertLogsChanges(2):
+            data = self.post_new(
+                data={
+                    'event': self.event.natural_key(),
+                    'order': self.run.order,
+                    'suborder': 'last',
+                    'interviewers': 'frozenflygone',
+                    'subjects': 'Sent',
+                    'topic': 'Why Are You a Prize Elemental',
+                    'length': '15:00',
+                },
+                user=self.add_user,
+            )
+            result = Interview.objects.get(id=data['id'])
+            self.assertV2ModelPresent(result, data)
+
+            data = self.post_new(
+                data={
+                    'anchor': self.run.natural_key(),
+                    'suborder': data['suborder'] + 1,
+                    'interviewers': 'JHobz',
+                    'subjects': 'Brossentia',
+                    'topic': 'Why Are You a Punishment Elemental',
+                    'length': '15:00',
+                }
+            )
+            result = Interview.objects.get(id=data['id'])
+            self.assertV2ModelPresent(result, data)
+
+        with self.subTest('locked event user'), self.assertLogsChanges(1):
+            self.post_new(
+                data={
+                    'event': self.locked_event.pk,
+                    'order': 1,
+                    'suborder': 1,
+                    'interviewers': 'Keizaron',
+                    'subjects': 'Andy',
+                    'topic': 'Why Are You a Random Elemental',
+                    'length': '15:00',
+                },
+                user=self.locked_user,
+            )
+
+    def test_patch(self):
+        with self.subTest('happy path'), self.saveSnapshot(), self.assertLogsChanges(2):
+            data = self.patch_detail(
+                self.private_interview,
+                data={
+                    'topic': 'Setting a new PB',
+                },
+                user=self.add_user,
+            )
+            self.assertV2ModelPresent(self.private_interview, data)
+
+            self.patch_detail(
+                self.private_interview,
+                data={
+                    'topic': 'Setting a new WR',
+                },
+                kwargs={'event_pk': self.event.pk},
+            )
+
+        with self.subTest('wrong event'):
+            self.patch_detail(
+                self.private_interview,
+                kwargs={'event_pk': self.blank_event.pk},
+                status_code=404,
+            )

--- a/tracker/api/views/interview.py
+++ b/tracker/api/views/interview.py
@@ -3,16 +3,13 @@ import logging
 from tracker.api.pagination import TrackerPagination
 from tracker.api.permissions import PrivateGenericPermissions
 from tracker.api.serializers import InterviewSerializer
-from tracker.api.views import EventNestedMixin, TrackerReadViewSet
+from tracker.api.views import EventCreateNestedMixin, TrackerFullViewSet
 from tracker.models import Interview
 
 logger = logging.getLogger(__name__)
 
 
-class InterviewViewSet(
-    EventNestedMixin,
-    TrackerReadViewSet,
-):
+class InterviewViewSet(TrackerFullViewSet, EventCreateNestedMixin):
     queryset = Interview.objects.select_related('event')
     serializer_class = InterviewSerializer
     pagination_class = TrackerPagination


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188495256

### Description of the Change

Could only fetch interviews on V2, now you can create/patch them as well. Because of the work from #731 this was pretty straightforward, since there's a lot of shared logic.

Also tweaked the way the snapshots were being created since I noticed it had an odd interaction with the counting when nested subtests were involved.

### Verification Process

Sent payloads to the create and patch endpoints and got the expected results.