### PR TITLE
hidden Bid permissions tweaks [#188391351]

### DIFF
--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -6,7 +6,7 @@ import { BrowserRouter, Link } from 'react-router-dom';
 import { useConstants } from '@common/Constants';
 import Loading from '@common/Loading';
 import { actions } from '@public/api';
-import { usePermissions } from '@public/api/helpers/auth';
+import { usePermission } from '@public/api/helpers/auth';
 import V2HTTPUtils from '@public/apiv2/HTTPUtils';
 import Dropdown from '@public/dropdown';
 import Spinner from '@public/spinner';
@@ -89,7 +89,7 @@ function DropdownMenu({ name, path }) {
 
 function Menu() {
   const { ADMIN_ROOT } = useConstants();
-  const canSeeHiddenBids = usePermissions(['tracker.change_bid', 'tracker.view_hidden_bid']);
+  const canChangeBids = usePermission('tracker.change_bid');
   const { status } = useSelector(state => ({
     status: state.status,
   }));
@@ -105,7 +105,7 @@ function Menu() {
         <DropdownMenu name="Schedule Editor" path="schedule_editor" />
         &mdash;
         <DropdownMenu name="Interstitials" path="interstitials" />
-        {canSeeHiddenBids && (
+        {canChangeBids && (
           <>
             &mdash;
             <DropdownMenu name="Process Pending Bids" path="process_pending_bids" />
@@ -126,7 +126,7 @@ function App({ rootPath }) {
   }));
 
   const { API_ROOT, APIV2_ROOT } = useConstants();
-  const canSeeHiddenBids = usePermissions(['tracker.change_bid', 'tracker.view_hidden_bid']);
+  const canChangeBids = usePermission('tracker.change_bid');
 
   React.useLayoutEffect(() => {
     setAPIRoot(API_ROOT);
@@ -176,10 +176,10 @@ function App({ rootPath }) {
                   </React.Suspense>
                 }
               />
-              {canSeeHiddenBids && (
+              {canChangeBids && (
                 <Route path="process_pending_bids/" element={React.createElement(EventMenu('Process Pending Bids'))} />
               )}
-              {canSeeHiddenBids && (
+              {canChangeBids && (
                 <Route
                   path="process_pending_bids/:eventId"
                   element={

--- a/tests/apiv2/test_bids.py
+++ b/tests/apiv2/test_bids.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Permission, User
 
 from tracker import models
 from tracker.api.serializers import BidSerializer
@@ -11,49 +11,53 @@ from ..util import APITestCase
 
 class TestBidViewSet(TestBidBase, APITestCase):
     model_name = 'bid'
-    view_user_permissions = ['view_hidden_bid']
     add_user_permissions = ['top_level_bid']
+    serializer_class = BidSerializer
 
     def setUp(self):
         super().setUp()
         self.client.force_authenticate(user=self.locked_user)
 
-    def test_detail(self):
-        serialized = BidSerializer(self.opened_parent_bid, tree=True)
-        data = self.get_detail(self.opened_parent_bid)
-        self.assertEqual(data, serialized.data)
-        serialized = BidSerializer(self.chain_top, tree=True)
-        data = self.get_detail(self.chain_top)
-        self.assertEqual(data, serialized.data)
+        # to test toplevel permission
+        self.limited_user = User.objects.create(username='limited_user')
+        self.limited_user.user_permissions.add(
+            Permission.objects.get(codename='add_bid'),
+            Permission.objects.get(codename='change_bid'),
+        )
+        self.view_hidden_user = User.objects.create(username='view_hidden_user')
+        self.view_hidden_user.user_permissions.add(
+            Permission.objects.get(codename='view_hidden_bid')
+        )
 
-        with self.subTest('nested'):
-            serialized = BidSerializer(
-                self.opened_parent_bid, event_pk=self.event.id, tree=True
-            )
-            data = self.get_detail(
-                self.opened_parent_bid, kwargs={'event_pk': self.event.id}
-            )
-            self.assertEqual(data, serialized.data)
+    def test_fetch(self):
+        with self.saveSnapshot():
+            with self.subTest('detail'):
+                serialized = BidSerializer(self.opened_parent_bid, tree=True)
+                data = self.get_detail(self.opened_parent_bid)
+                self.assertEqual(data, serialized.data)
+                serialized = BidSerializer(self.chain_top, tree=True)
+                data = self.get_detail(self.chain_top)
+                self.assertEqual(data, serialized.data)
 
-    def test_hidden_detail(self):
-        with self.subTest('user with permission'):
-            self.hidden_parent_bid.refresh_from_db()
-            serialized = BidSerializer(
-                self.hidden_parent_bid,
-                include_hidden=True,
-                tree=True,
-                with_permissions=('tracker.view_hidden_bid',),
-            )
-            data = self.get_detail(self.hidden_parent_bid)
-            self.assertEqual(data, serialized.data)
-
-        with self.subTest('user without permission'):
-            self.client.force_authenticate(user=None)
-            self.get_detail(self.hidden_parent_bid, status_code=404)
-
-    def test_list(self):
-        with self.subTest('authenticated'):
-            with self.subTest('normal list'):
+                with self.subTest('nested'):
+                    serialized = BidSerializer(
+                        self.opened_parent_bid, event_pk=self.event.id, tree=True
+                    )
+                    data = self.get_detail(
+                        self.opened_parent_bid, kwargs={'event_pk': self.event.id}
+                    )
+                    self.assertEqual(data, serialized.data)
+                with self.subTest('hidden'):
+                    self.hidden_parent_bid.refresh_from_db()
+                    serialized = BidSerializer(
+                        self.hidden_parent_bid,
+                        include_hidden=True,
+                        tree=True,
+                        with_permissions=('tracker.view_hidden_bid',),
+                    )
+                    data = self.get_detail(self.hidden_parent_bid)
+                    self.assertEqual(data, serialized.data)
+            with self.subTest('list'):
                 serialized = BidSerializer(
                     models.Bid.objects.filter(event=self.event).public(),
                     event_pk=self.event.id,
@@ -61,6 +65,31 @@ class TestBidViewSet(TestBidBase, APITestCase):
                 )
                 data = self.get_list(kwargs={'event_pk': self.event.pk})
                 self.assertEqual(data['results'], serialized.data)
+
+                with self.subTest('normal tree'):
+                    serialized = BidSerializer(
+                        models.Bid.objects.filter(event=self.event, level=0).public(),
+                        many=True,
+                        event_pk=self.event.id,
+                        tree=True,
+                    )
+                    data = self.get_noun('tree', kwargs={'event_pk': self.event.pk})
+                    self.assertEqual(data['results'], serialized.data)
+
+                with self.subTest('hidden tree'):
+                    serialized = BidSerializer(
+                        models.Bid.objects.filter(event=self.event, level=0),
+                        include_hidden=True,
+                        with_permissions=('tracker.view_hidden_bid',),
+                        many=True,
+                        event_pk=self.event.id,
+                        tree=True,
+                    )
+                    data = self.get_noun(
+                        'tree',
+                        kwargs={'event_pk': self.event.pk, 'feed': 'all'},
+                    )
+                    self.assertEqual(data['results'], serialized.data)
 
             with self.subTest('feeds'):
                 for feed in ['open', 'closed']:
@@ -82,36 +111,50 @@ class TestBidViewSet(TestBidBase, APITestCase):
                     opened_bid = BidSerializer(self.opened_bid, event_pk=self.event.id)
                     # challenge is pinned, always shows up regardless of parameters
                     challenge = BidSerializer(self.challenge, event_pk=self.event.id)
-                    data = self.get_list(
-                        kwargs={'event_pk': self.event.pk, 'feed': 'current'},
-                        data={'now': self.run.starttime},
-                    )
-                    self.assertV2ModelPresent(opened_bid.data, data['results'])
-                    self.assertV2ModelPresent(challenge.data, data['results'])
-                    data = self.get_list(
-                        kwargs={'event_pk': self.event.pk, 'feed': 'current'},
-                        data={'now': self.run.endtime + datetime.timedelta(seconds=1)},
-                    )
-                    self.assertV2ModelNotPresent(opened_bid.data, data['results'])
-                    self.assertV2ModelPresent(challenge.data, data['results'])
-                    # need `min_runs` or we'll just get the run anyway
-                    data = self.get_list(
-                        kwargs={'event_pk': self.event.pk, 'feed': 'current'},
-                        data={
-                            'min_runs': 0,
-                            'now': self.run.starttime - datetime.timedelta(minutes=60),
-                            'delta': 30,
-                        },
-                    )
-                    self.assertV2ModelNotPresent(opened_bid.data, data['results'])
-                    self.assertV2ModelPresent(challenge.data, data['results'])
-                    # pathological, but it tests max_runs
-                    data = self.get_list(
-                        kwargs={'event_pk': self.event.pk, 'feed': 'current'},
-                        data={'max_runs': 0, 'now': self.run.starttime},
-                    )
-                    self.assertV2ModelNotPresent(opened_bid.data, data['results'])
-                    self.assertV2ModelPresent(challenge.data, data['results'])
+
+                    with self.subTest('start of run'):
+                        data = self.get_list(
+                            kwargs={'event_pk': self.event.pk, 'feed': 'current'},
+                            data={'now': self.run.starttime},
+                        )
+                        self.assertV2ModelPresent(opened_bid.data, data['results'])
+                        self.assertV2ModelPresent(challenge.data, data['results'])
+                    with self.suppressSnapshot():
+                        with self.subTest('end of run'):
+                            data = self.get_list(
+                                kwargs={'event_pk': self.event.pk, 'feed': 'current'},
+                                data={
+                                    'now': self.run.endtime
+                                    + datetime.timedelta(seconds=1)
+                                },
+                            )
+                            self.assertV2ModelNotPresent(
+                                opened_bid.data, data['results']
+                            )
+                            self.assertV2ModelPresent(challenge.data, data['results'])
+                        # need `min_runs` or we'll just get the run anyway
+                        with self.subTest('an hour ago'):
+                            data = self.get_list(
+                                kwargs={'event_pk': self.event.pk, 'feed': 'current'},
+                                data={
+                                    'min_runs': 0,
+                                    'now': self.run.starttime
+                                    - datetime.timedelta(minutes=60),
+                                    'delta': 30,
+                                },
+                            )
+                            self.assertV2ModelNotPresent(
+                                opened_bid.data, data['results']
+                            )
+                            self.assertV2ModelPresent(challenge.data, data['results'])
+
+                        # pathological, but it tests max_runs
+                        data = self.get_list(
+                            kwargs={'event_pk': self.event.pk, 'feed': 'current'},
+                            data={'max_runs': 0, 'now': self.run.starttime},
+                        )
+                        self.assertV2ModelNotPresent(opened_bid.data, data['results'])
+                        self.assertV2ModelPresent(challenge.data, data['results'])
 
                 # hidden feeds
                 for feed in ['pending', 'all']:
@@ -130,9 +173,13 @@ class TestBidViewSet(TestBidBase, APITestCase):
                         )
                         self.assertEqual(data['results'], serialized.data)
 
-        with self.subTest('anonymous'):
-            self.client.force_authenticate(user=None)
+        with self.subTest('limited permissions'):
+            self.get_list(data={'feed': 'all'}, user=self.view_hidden_user)
+            self.get_detail(self.denied_bid)
+            self.get_list(data={'feed': 'all'}, user=self.view_user)
+            self.get_detail(self.denied_bid)
 
+        with self.subTest('anonymous'):
             with self.subTest('normal feeds without permission'):
                 self.get_list(
                     kwargs={'event_pk': self.event.pk},
@@ -140,81 +187,63 @@ class TestBidViewSet(TestBidBase, APITestCase):
                 for feed in ['open', 'closed', 'current']:
                     with self.subTest(feed):
                         self.get_list(
+                            user=None,
                             kwargs={'event_pk': self.event.pk, 'feed': feed},
                         )
 
-            with self.subTest('hidden feeds without permission'):
-                for feed in ['pending', 'all']:
-                    with self.subTest(feed):
-                        self.get_list(
-                            kwargs={'event_pk': self.event.pk, 'feed': feed},
-                            status_code=403,
-                        )
+            with self.subTest('error cases'):
+                with self.subTest('hidden feeds without permission'):
+                    for feed in ['pending', 'all']:
+                        with self.subTest(feed):
+                            self.get_list(
+                                kwargs={'event_pk': self.event.pk, 'feed': feed},
+                                status_code=403,
+                            )
 
-    def test_tree(self):
-        with self.subTest('normal tree'):
-            serialized = BidSerializer(
-                models.Bid.objects.filter(event=self.event, level=0).public(),
-                many=True,
-                event_pk=self.event.id,
-                tree=True,
-            )
-            data = self.get_noun('tree', kwargs={'event_pk': self.event.pk})
-            self.assertEqual(data['results'], serialized.data)
+                with self.subTest('hidden bid without permission'):
+                    self.get_detail(self.hidden_parent_bid, status_code=404)
 
-        with self.subTest('hidden tree'):
-            serialized = BidSerializer(
-                models.Bid.objects.filter(event=self.event, level=0),
-                include_hidden=True,
-                with_permissions=('tracker.view_hidden_bid',),
-                many=True,
-                event_pk=self.event.id,
-                tree=True,
-            )
-            data = self.get_noun(
-                'tree',
-                kwargs={'event_pk': self.event.pk, 'feed': 'all'},
-            )
-            self.assertEqual(data['results'], serialized.data)
-
-        with self.subTest('hidden tree without permission'):
-            self.get_noun(
-                'tree',
-                kwargs={'event_pk': self.event.pk, 'feed': 'all'},
-                user=None,
-                status_code=403,
-            )
+                with self.subTest('hidden tree without permission'):
+                    self.get_noun(
+                        'tree',
+                        kwargs={'event_pk': self.event.pk, 'feed': 'all'},
+                        status_code=403,
+                    )
 
     def test_create(self):
-        with self.subTest('attach to event'):
-            data = self.post_new(data={'name': 'New Event Bid', 'event': self.event.pk})
-            serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
-            self.assertEqual(data, serialized.data)
+        with self.saveSnapshot(), self.assertLogsChanges(4):
+            # TODO: natural key tests
+            with self.subTest('attach to event'):
+                data = self.post_new(
+                    data={'name': 'New Event Bid', 'event': self.event.pk}
+                )
+                serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
+                self.assertEqual(data, serialized.data)
 
-        with self.subTest('attach to parent'):
-            data = self.post_new(
-                data={'name': 'New Child', 'parent': self.opened_parent_bid.pk},
-            )
-            serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
-            self.assertEqual(data, serialized.data)
+            with self.subTest('attach to parent'):
+                data = self.post_new(
+                    data={'name': 'New Child', 'parent': self.opened_parent_bid.pk},
+                )
+                serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
+                self.assertEqual(data, serialized.data)
 
-        with self.subTest('attach to speedrun'):
-            data = self.post_new(
-                data={'name': 'New Run Bid', 'speedrun': self.run.pk},
-            )
-            serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
-            self.assertEqual(data, serialized.data)
+            with self.subTest('attach to speedrun'):
+                data = self.post_new(
+                    data={'name': 'New Run Bid', 'speedrun': self.run.pk},
+                )
+                serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
+                self.assertEqual(data, serialized.data)
 
-        with self.subTest('attach to chain'):
-            data = self.post_new(
-                data={
-                    'name': 'Chain Abyss',
-                    'parent': self.chain_bottom.pk,
-                    'goal': 50,
-                },
-            )
-            serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
-            self.assertEqual(data, serialized.data)
+            with self.subTest('attach to chain'):
+                data = self.post_new(
+                    data={
+                        'name': 'Chain Abyss',
+                        'parent': self.chain_bottom.pk,
+                        'goal': 50,
+                    },
+                )
+                serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
+                self.assertEqual(data, serialized.data)
 
         with self.subTest('attach to locked event with permission'):
             data = self.post_new(
@@ -238,110 +267,116 @@ class TestBidViewSet(TestBidBase, APITestCase):
             serialized = BidSerializer(models.Bid.objects.get(pk=data['id']))
             self.assertEqual(data, serialized.data)
 
-        with self.subTest('attach to nonsense'):
+        with self.subTest('error cases'):
+            with self.subTest('attach to nonsense'):
+                self.post_new(
+                    data={'name': 'Nonsense Bid', 'event': 'foo'},
+                    status_code=400,
+                    expected_error_codes={'event': 'incorrect_type'},
+                )
+                self.post_new(
+                    data={'name': 'Nonsense Bid', 'speedrun': 'bar'},
+                    status_code=400,
+                    expected_error_codes={'speedrun': 'incorrect_type'},
+                )
+                self.post_new(
+                    data={'name': 'Nonsense Bid', 'parent': 'baz'},
+                    status_code=400,
+                    expected_error_codes={'parent': 'incorrect_type'},
+                )
 
-            self.post_new(
-                data={'name': 'Nonsense Bid', 'event': 'foo'}, status_code=400
-            )
-            data = self.post_new(
-                data={'name': 'Nonsense Bid', 'speedrun': 'bar'},
-                status_code=400,
-            )
-            data = self.post_new(
-                data={'name': 'Nonsense Bid', 'parent': 'baz'},
-                status_code=400,
-            )
+            with self.subTest('model validation'):
+                # smoke test, don't want to repeat all the validation rules here
+                self.post_new(
+                    data={
+                        'name': 'Nonsense Repeat Bid',
+                        'event': self.event.pk,
+                        'goal': 500,
+                        'repeat': 12,
+                        'istarget': True,
+                    },
+                    status_code=400,
+                    expected_error_codes={'repeat': 'invalid'},
+                )
 
-        with self.subTest('model validation'):
-            # smoke test, don't want to repeat all the validation rules here
-            data = self.post_new(
-                data={
-                    'name': 'Nonsense Repeat Bid',
-                    'event': self.event.pk,
-                    'goal': 500,
-                    'repeat': 12,
-                },
-                status_code=400,
-            )
+            with self.subTest('require locked permission'):
+                self.post_new(
+                    data={
+                        'name': 'New Locked Event Bid 2',
+                        'event': self.locked_event.pk,
+                    },
+                    user=self.add_user,
+                    status_code=403,
+                )
 
-        self.client.force_authenticate(user=self.add_user)
+                self.post_new(
+                    data={
+                        'name': 'New Locked Run Bid 2',
+                        'speedrun': self.locked_run.pk,
+                    },
+                    status_code=403,
+                )
 
-        with self.subTest('require locked permission'):
-            self.post_new(
-                data={
-                    'name': 'New Locked Event Bid 2',
-                    'event': self.locked_event.pk,
-                },
-                status_code=403,
-            )
+                self.post_new(
+                    data={
+                        'name': 'New Locked Child 2',
+                        'parent': self.locked_parent_bid.pk,
+                    },
+                    status_code=403,
+                )
 
-            self.post_new(
-                data={
-                    'name': 'New Locked Run Bid 2',
-                    'speedrun': self.locked_run.pk,
-                },
-                status_code=403,
-            )
+            with self.subTest('require top level permission for bids without parents'):
+                self.post_new(
+                    data={'name': 'New Event Bid 2', 'event': self.event.pk},
+                    user=self.limited_user,
+                    status_code=403,
+                )
 
-            self.post_new(
-                data={
-                    'name': 'New Locked Child 2',
-                    'parent': self.locked_parent_bid.pk,
-                },
-                status_code=403,
-            )
+                self.post_new(
+                    data={
+                        'name': 'New Child 2',
+                        'parent': self.opened_parent_bid.pk,
+                    },
+                    status_code=201,
+                )
 
-        with self.subTest('require top level permission for bids without parents'):
-            self.add_user.user_permissions.remove(
-                Permission.objects.get(codename='top_level_bid')
-            )
-            # TODO: maybe make a separate user for this
-            del self.add_user._perm_cache
-            del self.add_user._user_perm_cache
-
-            self.post_new(
-                data={'name': 'New Event Bid 2', 'event': self.event.pk},
-                status_code=403,
-            )
-
-            self.post_new(
-                data={
-                    'name': 'New Child 2',
-                    'parent': self.opened_parent_bid.pk,
-                },
-                status_code=201,
-            )
-
-        with self.subTest('anonymous'):
-            self.post_new(
-                data={
-                    'name': 'New Child 3',
-                    'parent': self.opened_parent_bid.pk,
-                },
-                status_code=403,
-                user=None,
-            )
+            with self.subTest('anonymous'):
+                self.post_new(
+                    data={
+                        'name': 'New Child 3',
+                        'parent': self.opened_parent_bid.pk,
+                    },
+                    status_code=403,
+                    user=None,
+                )
 
     def test_patch(self):
-        with self.subTest('can edit locked bid with permission'):
+        with self.saveSnapshot(), self.assertLogsChanges(1):
+            data = self.patch_detail(self.challenge, data={'name': 'Challenge Updated'})
+            self.assertV2ModelPresent(self.challenge, data)
+
+        with self.subTest(
+            'can edit locked bid with permission'
+        ), self.assertLogsChanges(1):
             data = self.patch_detail(
                 self.locked_challenge, data={'name': 'Locked Updated'}
             )
             self.assertEqual(data['name'], 'Locked Updated')
 
-        self.client.force_authenticate(user=self.add_user)
-
-        with self.subTest('can edit top level bids'):
+        with self.subTest(
+            'can edit top level bids even without creation permission'
+        ), self.assertLogsChanges(1):
             data = self.patch_detail(
                 self.opened_parent_bid,
                 data={'name': 'Opened Parent Updated'},
+                user=self.limited_user,
             )
             self.assertEqual(data['name'], 'Opened Parent Updated')
 
         with self.subTest('should not be able to change parent'):
             self.patch_detail(
                 self.opened_bid,
-                data={'parent': self.opened_parent_bid.pk},
+                data={'parent': self.opened_parent_bid.pk},  # same parent, so no-op
             )
 
             self.patch_detail(
@@ -360,7 +395,7 @@ class TestBidViewSet(TestBidBase, APITestCase):
         with self.subTest('should not be able to move to a locked event'):
             self.patch_detail(
                 self.opened_parent_bid,
-                data={'event': self.locked_event.pk},  # same parent
+                data={'event': self.locked_event.pk},
                 status_code=403,
             )
             self.patch_detail(
@@ -372,7 +407,7 @@ class TestBidViewSet(TestBidBase, APITestCase):
         with self.subTest('anonymous'):
             self.patch_detail(
                 self.opened_parent_bid,
-                data={'name': 'Opened Parent Updated Anonymous'},  # different parent
+                data={'name': 'Opened Parent Updated Anonymous'},
                 status_code=403,
                 user=None,
             )
@@ -498,6 +533,37 @@ class TestBidSerializer(TestBidBase, APITestCase):
                     self._format_bid(self.pending_bid, child=True),
                     serialized.data['options'],
                 )
+
+        with self.subTest('hidden permissions checks'):
+            for bid in [
+                self.pending_bid,
+                self.denied_bid,
+                self.hidden_bid,
+                self.hidden_parent_bid,
+            ]:
+                # smoke test for base case
+                with self.assertRaises(AssertionError):
+                    BidSerializer().to_representation(bid)
+
+                # flag isn't enough, permission needs to be provided
+                with self.assertRaises(AssertionError):
+                    BidSerializer(include_hidden=True).to_representation(bid)
+
+                # permission isn't enough, the flag needs to be specified too
+                with self.assertRaises(AssertionError):
+                    BidSerializer(
+                        with_permissions='tracker.view_hidden_bid'
+                    ).to_representation(bid)
+
+                # any of the following permissions are sufficient
+                for perm in [
+                    'tracker.view_hidden_bid',
+                    'tracker.view_bid',
+                    'tracker.change_bid',
+                ]:
+                    BidSerializer(
+                        include_hidden=True, with_permissions=perm
+                    ).to_representation(bid)
 
         with self.subTest('child bid'):
             serialized = BidSerializer(self.opened_bid, tree=True)

--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -60,7 +60,10 @@ class BidFeedPermission(BasePermission):
         return super().has_permission(request, view) and (
             feed is None
             or feed in self.PUBLIC_FEEDS
-            or request.user.has_perm('tracker.view_hidden_bid')
+            or any(
+                request.user.has_perm(f'tracker.{p}')
+                for p in ('view_hidden_bid', 'change_bid', 'view_bid')
+            )
         )
 
 
@@ -72,7 +75,10 @@ class BidStatePermission(BasePermission):
     def has_object_permission(self, request: Request, view: t.Callable, obj: t.Any):
         return super().has_object_permission(request, view, obj) and (
             obj.state in self.PUBLIC_STATES
-            or request.user.has_perm('tracker.view_hidden_bid')
+            or any(
+                request.user.has_perm(f'tracker.{p}')
+                for p in ('view_hidden_bid', 'change_bid', 'view_bid')
+            )
         )
 
 

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -420,8 +420,13 @@ class BidSerializer(
         yield from (child for child in self._tree if child.parent_id == parent.id)
 
     def _has_permission(self, instance):
+        # check for any of the sufficient permissions
         return instance.state in Bid.PUBLIC_STATES or (
-            self.include_hidden and 'tracker.view_hidden_bid' in self.permissions
+            self.include_hidden
+            and (
+                {'tracker.view_hidden_bid', 'tracker.view_bid', 'tracker.change_bid'}
+                & set(self.permissions)
+            )
         )
 
     def to_representation(self, instance, child=False):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188391351

### Description of the Change

Just some behind the scenes tweaks of how the permission structure works. If you can "view" bids at all via the permission, that's good enough. The `hidden_bid` permission is a more limited form that mostly allows for searching the API without needing full admin access to bids in general, rather than it being an additional requirement for seeing them at all.

### Verification Process

Tested with a limited user, could see the hidden bids as expected.