### PR TITLE
add DonationBid to v2, under donations/bids [#184870652]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
   rev: 7.1.0
   hooks:
     - id: flake8
+- repo: https://github.com/pycqa/autoflake
+  rev: v2.3.1
+  hooks:
+    - id: autoflake
+      args: [--remove-all-unused-imports, --in-place]
 - repo: local
   hooks:
     - id: prettier

--- a/tests/apiv2/test_donation_bids.py
+++ b/tests/apiv2/test_donation_bids.py
@@ -1,0 +1,257 @@
+from decimal import Decimal
+
+from tests import randgen
+from tests.util import APITestCase
+from tracker import models
+from tracker.api.serializers import DonationBidSerializer
+
+
+class TestDonationBids(APITestCase):
+    model_name = 'donationbid'
+    serializer_class = DonationBidSerializer
+    extra_serializer_kwargs = {'with_permissions': 'tracker.view_hidden_bid'}
+    view_user_permissions = ['view_bid']
+
+    def _format_donation_bid(self, bid):
+        bid.refresh_from_db()
+        return {
+            'type': 'donationbid',
+            'id': bid.id,
+            'donation': bid.donation_id,
+            'bid': bid.bid_id,
+            'bid_name': bid.bid.fullname(),
+            'bid_state': bid.bid.state,
+            'amount': str(bid.amount),
+        }
+
+    def setUp(self):
+        super().setUp()
+        self.donor = randgen.generate_donor(self.rand)
+        self.donor.save()
+        self.donation = randgen.generate_donation(
+            self.rand, min_amount=10, max_amount=25
+        )
+        self.donation.save()
+        self.other_donation = randgen.generate_donation(self.rand)
+        self.other_donation.save()
+        self.pending_donation = randgen.generate_donation(
+            self.rand, domain='PAYPAL', transactionstate='PENDING'
+        )
+        self.pending_donation.save()
+        self.opened_bid = randgen.generate_bid(
+            self.rand,
+            event=self.event,
+            state='OPENED',
+            allow_children=True,
+            allowuseroptions=True,
+        )[0]
+        self.opened_bid.save()
+        self.opened_child = randgen.generate_bid(
+            self.rand, parent=self.opened_bid, state='OPENED', allow_children=False
+        )[0]
+        self.opened_child.save()
+        self.denied_child = randgen.generate_bid(
+            self.rand, parent=self.opened_bid, state='DENIED', allow_children=False
+        )[0]
+        self.denied_child.save()
+        self.opened_child_bid = models.DonationBid.objects.create(
+            donation=self.donation,
+            bid=self.opened_child,
+            amount=Decimal(self.rand.uniform(5.0, 9.5)),
+        )
+        self.denied_child_bid = models.DonationBid.objects.create(
+            donation=self.donation,
+            bid=self.denied_child,
+            amount=self.donation.amount - self.opened_child_bid.amount,
+        )
+        self.other_child_bid = models.DonationBid.objects.create(
+            donation=self.other_donation,
+            bid=self.opened_child,
+            amount=self.other_donation.amount / 3,
+        )
+        self.hidden_bid, hidden_children = randgen.generate_bid(
+            self.rand,
+            event=self.event,
+            min_children=1,
+            max_children=1,
+            state='HIDDEN',
+            allow_children=True,
+            allowuseroptions=True,
+        )
+        self.hidden_child = hidden_children[0][0]
+        self.hidden_bid.save()
+        self.hidden_child.save()
+        self.hidden_denied_child = randgen.generate_bid(
+            self.rand, parent=self.hidden_bid, state='DENIED', allow_children=False
+        )[0]
+        self.hidden_denied_child.save()
+        self.hidden_child_bid = models.DonationBid.objects.create(
+            donation=self.other_donation,
+            bid=self.hidden_child,
+            amount=self.other_donation.amount / 3,
+        )
+        self.hidden_denied_child_bid = models.DonationBid.objects.create(
+            donation=self.other_donation,
+            bid=self.hidden_denied_child,
+            amount=self.other_donation.amount / 3,
+        )
+        self.pending_donation_bid = models.DonationBid.objects.create(
+            donation=self.pending_donation,
+            bid=self.opened_child,
+            amount=self.pending_donation.amount,
+        )
+
+    def test_fetch(self):
+        with self.saveSnapshot():
+            with self.subTest('via donation'):
+                data = self.get_noun(
+                    'bids', self.donation, model_name='donations', user=self.view_user
+                )
+                self.assertExactV2Models([self.opened_child_bid], data['results'])
+
+                data = self.get_noun(
+                    'bids',
+                    self.donation,
+                    data={'all': ''},
+                    model_name='donations',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models(
+                    [self.opened_child_bid, self.denied_child_bid], data['results']
+                )
+
+                data = self.get_noun(
+                    'bids',
+                    self.other_donation,
+                    data={'all': ''},
+                    model_name='donations',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models(
+                    [
+                        self.other_child_bid,
+                        self.hidden_child_bid,
+                        self.hidden_denied_child_bid,
+                    ],
+                    data['results'],
+                )
+
+            with self.subTest('via parent bid'):
+                data = self.get_noun(
+                    'donations',
+                    self.opened_bid,
+                    model_name='bid',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models(
+                    [self.opened_child_bid, self.other_child_bid], data['results']
+                )
+
+                data = self.get_noun(
+                    'donations',
+                    self.opened_bid,
+                    data={'all': ''},
+                    model_name='bid',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models(
+                    [
+                        self.opened_child_bid,
+                        self.denied_child_bid,
+                        self.other_child_bid,
+                    ],
+                    data['results'],
+                )
+
+                data = self.get_noun(
+                    'donations',
+                    self.hidden_bid,
+                    model_name='bid',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models(
+                    [self.hidden_child_bid, self.hidden_denied_child_bid],
+                    data['results'],
+                )
+
+            with self.subTest('via child bid'):
+                data = self.get_noun(
+                    'donations',
+                    self.opened_child,
+                    model_name='bid',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models(
+                    [self.opened_child_bid, self.other_child_bid], data['results']
+                )
+
+                data = self.get_noun(
+                    'donations',
+                    self.denied_child,
+                    model_name='bid',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models([self.denied_child_bid], data['results'])
+
+                data = self.get_noun(
+                    'donations',
+                    self.hidden_child,
+                    model_name='bid',
+                    user=self.view_user,
+                )
+                self.assertExactV2Models([self.hidden_child_bid], data['results'])
+
+        with self.subTest('error cases'):
+            # strictly speaking, 403, but easier to write the permission check this way
+            self.get_noun(
+                'bids',
+                self.donation,
+                data={'all': ''},
+                model_name='donations',
+                user=None,
+                status_code=404,
+            )
+            self.get_noun(
+                'bids',
+                self.pending_donation,
+                model_name='donations',
+                user=None,
+                status_code=404,
+            )
+            self.get_noun(
+                'donations',
+                self.opened_bid,
+                data={'all': ''},
+                model_name='bid',
+                user=None,
+                status_code=404,
+            )
+            self.get_noun(
+                'donations',
+                self.denied_child,
+                model_name='bid',
+                user=None,
+                status_code=404,
+            )
+            self.get_noun(
+                'donations',
+                self.hidden_bid,
+                model_name='bid',
+                user=None,
+                status_code=404,
+            )
+
+    def test_serializer(self):
+        with self.assertRaises(AssertionError):
+            print(DonationBidSerializer(self.hidden_child_bid).data)
+
+        data = DonationBidSerializer(
+            self.hidden_child_bid, with_permissions=('tracker.view_hidden_bid')
+        ).data
+        self.assertEqual(data, self._format_donation_bid(self.hidden_child_bid))
+
+        data = DonationBidSerializer(
+            [self.opened_child_bid, self.other_child_bid], many=True
+        ).data
+        self.assertEqual(data[0], self._format_donation_bid(self.opened_child_bid))
+        self.assertEqual(data[1], self._format_donation_bid(self.other_child_bid))

--- a/tests/randgen.py
+++ b/tests/randgen.py
@@ -284,6 +284,7 @@ def generate_bid(
     rand,
     *,
     allow_children=None,
+    allowuseroptions=None,
     min_children=2,
     max_children=5,
     max_depth=2,
@@ -299,6 +300,8 @@ def generate_bid(
     bid = Bid()
     bid.description = random_bid_description(rand, bid.name)
     assert run or event or parent, 'Need at least one of run, event, or parent'
+    if allowuseroptions is not None:
+        bid.allowuseroptions = allowuseroptions
     if parent:
         bid.parent = parent
         bid.speedrun = parent.speedrun
@@ -411,12 +414,12 @@ def generate_donation(
         ), 'Local donations must be specified as COMPLETED'
 
     if not no_donor:
-        if not donor:
+        if donor is None:
             if donors:
                 donor = rand.choice(donors)
             else:
+                assert Donor.objects.exists(), 'No donor provided and none exist'
                 donor = rand.choice(Donor.objects.all())
-        assert donor, 'No donor provided and none exist'
         donation.donor = donor
     donation.clean()
     return donation

--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -82,6 +82,26 @@ class BidStatePermission(BasePermission):
         )
 
 
+class DonationBidStatePermission(BasePermission):
+    PUBLIC_STATES = models.Bid.PUBLIC_STATES
+    message = messages.GENERIC_NOT_FOUND
+    code = messages.UNAUTHORIZED_OBJECT_CODE
+
+    def has_permission(self, request, view):
+        has_perm = any(
+            request.user.has_perm(f'tracker.{p}')
+            for p in ('view_hidden_bid', 'change_bid', 'view_bid')
+        )
+        return (
+            super().has_permission(request, view)
+            and has_perm
+            or (
+                ((view.bid is None or view.bid.state in self.PUBLIC_STATES))
+                and ('all' not in request.query_params)
+            )
+        )
+
+
 class TechNotesPermission(BasePermission):
     message = messages.UNAUTHORIZED_FIELD
     code = messages.UNAUTHORIZED_FIELD_CODE

--- a/tracker/api/views/bids.py
+++ b/tracker/api/views/bids.py
@@ -15,6 +15,7 @@ from tracker.api.views import (
     TrackerFullViewSet,
     WithSerializerPermissionsMixin,
 )
+from tracker.api.views.donation_bids import DonationBidViewSet
 from tracker.models import Bid, SpeedRun
 
 logger = logging.getLogger(__name__)
@@ -86,3 +87,9 @@ class BidViewSet(
         page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page, tree=True, many=True)
         return self.get_paginated_response(serializer.data)
+
+    @action(detail=True, methods=['get'])
+    def donations(self, request, *args, **kwargs):
+        viewset = DonationBidViewSet(request=request, bid=self.get_object())
+        viewset.initial(request, *args, **kwargs)
+        return viewset.list(request, *args, **kwargs)

--- a/tracker/api/views/donation_bids.py
+++ b/tracker/api/views/donation_bids.py
@@ -1,0 +1,43 @@
+from django.db.models import Q
+
+from tracker import models
+from tracker.api.pagination import TrackerPagination
+from tracker.api.permissions import DonationBidStatePermission
+from tracker.api.serializers import DonationBidSerializer
+from tracker.api.views import TrackerReadViewSet, WithSerializerPermissionsMixin
+
+
+class DonationBidViewSet(WithSerializerPermissionsMixin, TrackerReadViewSet):
+    serializer_class = DonationBidSerializer
+    pagination_class = TrackerPagination
+    permission_classes = [DonationBidStatePermission]
+    queryset = models.DonationBid.objects.select_related('bid')
+
+    def __init__(self, *args, donation=None, bid=None, **kwargs):
+        self.donation = donation
+        self.bid = bid
+        super().__init__(*args, **kwargs)
+
+    def filter_queryset(self, queryset):
+        # this can be filtered in multiple ways
+        # - by donation, which excludes hidden children unless explicitly asked for
+        # - by exact bid, which includes the descendant tree if there is one, excluding
+        #   hidden descendants unless explicitly asked for, or if the parent itself is hidden
+        # note that we NEVER return bids attached to pending donations from this endpoint, if
+        #  you really need that, you can look at the admin page
+        queryset = queryset.filter(donation__transactionstate='COMPLETED')
+        assert self.donation or self.bid, 'did not get either donation or bid'
+        state_filter = Q()
+        if 'all' not in self.request.query_params:
+            state_filter = Q(bid__state__in=models.Bid.PUBLIC_STATES)
+        if self.donation:
+            queryset = queryset.filter(Q(donation=self.donation) & state_filter)
+        if self.bid:
+            if self.bid.state not in models.Bid.PUBLIC_STATES:
+                # if we're requesting a specific bid that's not public, just assume we want to view all states,
+                #  since we would have gotten a 404 by now if we didn't already have permission
+                state_filter = Q()
+            queryset = queryset.filter(
+                (Q(bid=self.bid) | Q(bid__in=self.bid.get_descendants()) & state_filter)
+            )
+        return queryset

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -12,6 +12,7 @@ from tracker.analytics import AnalyticsEventTypes, analytics
 from tracker.api.permissions import CanSendToReader, tracker_permission
 from tracker.api.serializers import DonationSerializer
 from tracker.api.views import EventNestedMixin
+from tracker.api.views.donation_bids import DonationBidViewSet
 from tracker.consumers.processing import broadcast_processing_action
 from tracker.models import Donation
 
@@ -349,3 +350,9 @@ class DonationViewSet(EventNestedMixin, viewsets.GenericViewSet):
             data = self.get_serializer(donation).data
 
         return Response(data)
+
+    @action(detail=True, methods=['get'])
+    def bids(self, request, *args, **kwargs):
+        viewset = DonationBidViewSet(request=request, donation=self.get_object())
+        viewset.initial(request, *args, **kwargs)
+        return viewset.list(request, *args, **kwargs)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184870652

### Description of the Change

This adds a read only view of donation bids, nested under either the donation, or the bid (which will include descendants if you query a parent bid).

The rules ended up being a little more complicated than I originally expected, because of the way it interacts with donation and especially bid states. I settled on the following:

- NEVER show attachments to donations that aren't completed
- by default, only show attachments to public bids
- if the `all` parameter is included, include attachments on all bid states
- if requesting via a bid that is not public, include attachments on all bid states, regardless of the presence of the `all` parameter

The latter two also require either the `view_bid` or `view_hidden_bid` permission. For purposes of these rules, `OPENED` and `CLOSED` are considered public, and any other state is not.

### Verification Process

Set up various bid states and got the expected results when trying various combinations of states and queries.