### PR TITLE
add Country/Region to V2 [#184870680]

### DIFF
--- a/tests/apiv2/test_countries.py
+++ b/tests/apiv2/test_countries.py
@@ -1,0 +1,80 @@
+from tests.util import APITestCase
+from tracker import models
+from tracker.api.serializers import CountryRegionSerializer, CountrySerializer
+
+
+class TestCountry(APITestCase):
+    serializer_class = CountrySerializer
+    model_name = 'country'
+    lookup_key = 'numeric_or_alpha'
+    id_field = 'alpha2'
+
+    def test_fetch(self):
+        with self.saveSnapshot():
+            country = models.Country.objects.first()
+            data = self.get_list()
+            self.assertEqual(
+                data['count'],
+                models.Country.objects.count(),
+                msg='Country count did not match',
+            )
+            self.assertV2ModelPresent(country, data['results'])
+
+            with self.subTest('via numeric code'):
+                data = self.get_detail(
+                    country, kwargs={'numeric_or_alpha': country.numeric}
+                )
+                self.assertV2ModelPresent(country, data)
+
+            with self.subTest('via alpha2'):
+                data = self.get_detail(
+                    country, kwargs={'numeric_or_alpha': country.alpha2}
+                )
+                self.assertV2ModelPresent(country, data)
+
+            with self.subTest('via alpha3'):
+                data = self.get_detail(
+                    country, kwargs={'numeric_or_alpha': country.alpha3}
+                )
+                self.assertV2ModelPresent(country, data)
+
+        with self.subTest('error cases'):
+            self.get_detail(None, kwargs={'numeric_or_alpha': '00'}, status_code=404)
+            self.get_detail(None, kwargs={'numeric_or_alpha': '000'}, status_code=404)
+            self.get_detail(None, kwargs={'numeric_or_alpha': 'XX'}, status_code=404)
+            self.get_detail(None, kwargs={'numeric_or_alpha': 'XXX'}, status_code=404)
+            self.get_detail(
+                None, kwargs={'numeric_or_alpha': 'foobar'}, status_code=404
+            )
+
+
+class TestCountryRegions(APITestCase):
+    serializer_class = CountryRegionSerializer
+    model_name = 'countryregion'
+
+    def test_fetch(self):
+        region = models.CountryRegion.objects.create(
+            name='Test Region', country=models.Country.objects.first()
+        )
+
+        with self.saveSnapshot():
+            data = self.get_list(model_name='region')
+            self.assertEqual(
+                data['count'],
+                models.CountryRegion.objects.count(),
+                msg='Region count did not match',
+            )
+            self.assertV2ModelPresent(region, data['results'])
+
+            data = self.get_detail(region, model_name='region')
+            self.assertV2ModelPresent(region, data)
+
+            with self.subTest('via country'):
+                data = self.get_noun(
+                    'regions',
+                    region.country,
+                    lookup_key='numeric_or_alpha',
+                    model_name='country',
+                    kwargs={'numeric_or_alpha': region.country.alpha3},
+                )
+                self.assertV2ModelPresent(region, data['results'])

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -17,10 +17,11 @@ from rest_framework.utils import model_meta
 from rest_framework.validators import UniqueTogetherValidator
 
 from tracker.api import messages
-from tracker.models import Ad, Interstitial, Interview
 from tracker.models.bid import Bid, DonationBid
+from tracker.models.country import Country, CountryRegion
 from tracker.models.donation import Donation, Donor, Milestone
 from tracker.models.event import Event, SpeedRun, Tag, Talent, VideoLink, VideoLinkType
+from tracker.models.interstitial import Ad, Interstitial, Interview
 
 log = logging.getLogger(__name__)
 
@@ -296,6 +297,46 @@ class ClassNameField(serializers.Field):
     def to_representation(self, obj):
         """Serialize the object's class name."""
         return obj.__class__.__name__.lower()
+
+
+class CountrySerializer(PrimaryOrNaturalKeyLookup, TrackerModelSerializer):
+    type = ClassNameField()
+
+    class Meta:
+        model = Country
+        fields = (
+            'type',
+            'name',
+            'alpha2',
+            'alpha3',
+            'numeric',
+        )
+
+    def to_representation(self, instance):
+        if self.root == self or getattr(self.root, 'child', None) == self:
+            return super().to_representation(instance)
+        else:
+            return instance.alpha3
+
+
+class CountryRegionSerializer(PrimaryOrNaturalKeyLookup, TrackerModelSerializer):
+    type = ClassNameField()
+    country = CountrySerializer()
+
+    class Meta:
+        model = CountryRegion
+        fields = (
+            'type',
+            'id',
+            'name',
+            'country',
+        )
+
+    def to_representation(self, instance):
+        if self.root == self or getattr(self.root, 'child', None) == self:
+            return super().to_representation(instance)
+        else:
+            return [instance.name, instance.country.alpha3]
 
 
 class EventNestedSerializerMixin:
@@ -582,6 +623,9 @@ class DonationSerializer(SerializerWithPermissionsMixin, serializers.ModelSerial
 
 class EventSerializer(PrimaryOrNaturalKeyLookup, TrackerModelSerializer):
     type = ClassNameField()
+    # include these later
+    # allowed_prize_countries = CountrySerializer(many=True)
+    # disallowed_prize_regions = CountryRegionSerializer(many=True)
     timezone = serializers.SerializerMethodField()
     amount = serializers.SerializerMethodField()
     donation_count = serializers.SerializerMethodField()
@@ -603,6 +647,8 @@ class EventSerializer(PrimaryOrNaturalKeyLookup, TrackerModelSerializer):
             'datetime',
             'timezone',
             'use_one_step_screening',
+            # 'allowed_prize_countries',
+            # 'disallowed_prize_regions',
         )
 
     def get_fields(self):

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -4,7 +4,17 @@ from django.urls import include, path
 from rest_framework import routers
 
 from tracker.api import views
-from tracker.api.views import ad, bids, donations, interview, me, milestone, run, talent
+from tracker.api.views import (
+    ad,
+    bids,
+    country,
+    donations,
+    interview,
+    me,
+    milestone,
+    run,
+    talent,
+)
 
 router = routers.DefaultRouter()
 
@@ -34,6 +44,8 @@ event_nested_route(r'interviews', interview.InterviewViewSet)
 event_nested_route(r'milestones', milestone.MilestoneViewSet)
 router.register(r'donations', donations.DonationViewSet, basename='donations')
 router.register(r'me', me.MeViewSet, basename='me')
+router.register(r'countries', country.CountryViewSet)
+router.register(r'regions', country.CountryRegionViewSet, basename='region')
 
 # use the router-generated URLs, and also link to the browsable API
 urlpatterns = [

--- a/tracker/api/views/country.py
+++ b/tracker/api/views/country.py
@@ -1,0 +1,51 @@
+import re
+
+from django.db.models import Q
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
+from rest_framework.generics import get_object_or_404
+
+from tracker.api.pagination import TrackerPagination
+from tracker.api.serializers import CountryRegionSerializer, CountrySerializer
+from tracker.api.views import TrackerReadViewSet
+from tracker.models import Country, CountryRegion
+
+
+class CountryViewSet(TrackerReadViewSet):
+    serializer_class = CountrySerializer
+    pagination_class = TrackerPagination
+    queryset = Country.objects.all()
+    lookup_field = 'numeric_or_alpha'
+
+    def get_object(self):
+        queryset = self.get_queryset()
+        pk = self.kwargs['numeric_or_alpha']
+        if re.match('[0-9]{3}', pk):
+            return get_object_or_404(queryset, numeric=pk)
+        elif re.match('[A-Z]{2,3}', pk):
+            return get_object_or_404(queryset, Q(alpha2=pk) | Q(alpha3=pk))
+        raise NotFound(
+            detail='Provide either an ISO 3166-1 numeric, alpha2, or alpha3 code',
+            code='invalid_lookup',
+        )
+
+    @action(detail=True)
+    def regions(self, request, *args, **kwargs):
+        viewset = CountryRegionViewSet(request=request, country=self.get_object())
+        viewset.initial(request, *args, **kwargs)
+        return viewset.list(request, *args, **kwargs)
+
+
+class CountryRegionViewSet(TrackerReadViewSet):
+    serializer_class = CountryRegionSerializer
+    pagination_class = TrackerPagination
+    queryset = CountryRegion.objects.select_related('country')
+
+    def __init__(self, country=None, *args, **kwargs):
+        self.country = country
+        super().__init__(*args, **kwargs)
+
+    def filter_queryset(self, queryset):
+        if self.country:
+            queryset = queryset.filter(country=self.country)
+        return queryset


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184870680

### Description of the Change

Just a read-only view of Countries/Regions in the database. Countries cannot be looked up by their PK, just their ISO codes (any of the 3). If regions/countries are nested inside of other serializers, presents a simplified view.

### Verification Process

Hit the various endpoints and got the expected results.