### PR TITLE
add read-only Donor to v2 [#184870657]

### DIFF
--- a/tests/apiv2/test_donors.py
+++ b/tests/apiv2/test_donors.py
@@ -1,0 +1,132 @@
+from django.db.models import Q
+
+from tests import randgen
+from tests.util import APITestCase
+from tracker.api.serializers import DonorSerializer
+
+
+class TestDonor(APITestCase):
+    model_name = 'donor'
+    serializer_class = DonorSerializer
+
+    def _format_donor(self, donor, *, include_totals=False, event=None):
+        return {
+            'type': 'donor',
+            'id': donor.id,
+            **({'alias': donor.full_alias} if donor.visibility == 'ALIAS' else {}),
+            **(
+                {
+                    'totals': [
+                        {
+                            'event': c.event_id,
+                            'total': c.donation_total,
+                            'count': c.donation_count,
+                            'avg': c.donation_avg,
+                            'max': c.donation_max,
+                        }
+                        for c in (
+                            donor.cache.filter(Q(event__isnull=True) | Q(event=event))
+                            if event
+                            else donor.cache.all()
+                        )
+                    ]
+                }
+                if include_totals
+                else {}
+            ),
+        }
+
+    def setUp(self):
+        super().setUp()
+        randgen.generate_runs(self.rand, self.event, 1, ordered=True)
+        self.visible_donor = randgen.generate_donor(self.rand, visibility='ALIAS')
+        self.visible_donor.save()
+        randgen.generate_donations(
+            self.rand, self.event, num_donations=5, donors=[self.visible_donor]
+        )
+        self.anonymous_donor = randgen.generate_donor(self.rand, visibility='ANON')
+        self.anonymous_donor.save()
+        randgen.generate_donations(
+            self.rand, self.event, num_donations=3, donors=[self.anonymous_donor]
+        )
+
+    def test_fetch(self):
+        with self.saveSnapshot():
+            data = self.get_list(user=self.view_user)
+            self.assertExactV2Models(
+                [self.visible_donor, self.anonymous_donor], data['results']
+            )
+
+            data = self.get_list(user=self.view_user, data={'include_totals': ''})
+            self.assertExactV2Models(
+                [self.visible_donor, self.anonymous_donor],
+                data['results'],
+                serializer_kwargs={'include_totals': True},
+            )
+
+            data = self.get_list(
+                user=self.view_user,
+                kwargs={'event_pk': self.event.id},
+                data={'include_totals': ''},
+            )
+            self.assertExactV2Models(
+                [self.visible_donor, self.anonymous_donor],
+                data['results'],
+                serializer_kwargs={'include_totals': True, 'event_pk': self.event.id},
+            )
+
+            data = self.get_detail(self.visible_donor, user=self.view_user)
+            self.assertV2ModelPresent(self.visible_donor, data)
+
+            data = self.get_detail(
+                self.visible_donor, user=self.view_user, data={'include_totals': ''}
+            )
+            self.assertV2ModelPresent(
+                self.visible_donor, data, serializer_kwargs={'include_totals': True}
+            )
+
+            data = self.get_detail(
+                self.visible_donor,
+                user=self.view_user,
+                kwargs={'event_pk': self.event.id},
+                data={'include_totals': ''},
+            )
+            self.assertV2ModelPresent(
+                self.visible_donor,
+                data,
+                serializer_kwargs={'event_pk': self.event.id, 'include_totals': True},
+            )
+
+        data = self.get_list(
+            user=self.view_user, kwargs={'event_pk': self.locked_event.id}
+        )
+        self.assertEqual(len(data['results']), 0, msg='Donor list was not empty')
+
+        with self.subTest('error cases'):
+            with self.subTest('no donations on event'):
+                self.get_detail(
+                    self.visible_donor,
+                    user=self.view_user,
+                    kwargs={'event_pk': self.locked_event.id},
+                    status_code=404,
+                )
+
+            with self.subTest('anonymous'):
+                self.get_list(user=None, status_code=403)
+                self.get_detail(self.visible_donor, user=None, status_code=403)
+
+    def test_serializer(self):
+        data = DonorSerializer(self.visible_donor, include_totals=True).data
+        formatted = self._format_donor(self.visible_donor, include_totals=True)
+        # FIXME
+        data['totals'] = sorted(data['totals'], key=lambda t: t['event'] or 0)
+        formatted['totals'] = sorted(formatted['totals'], key=lambda t: t['event'] or 0)
+        self.assertEqual(data, formatted)
+        self.assertEqual(
+            len(data['totals']),
+            self.visible_donor.cache.count(),
+            msg='Cache count did not match',
+        )
+
+        data = DonorSerializer(self.anonymous_donor).data
+        self.assertEqual(data, self._format_donor(self.anonymous_donor))

--- a/tests/apiv2/test_serializers.py
+++ b/tests/apiv2/test_serializers.py
@@ -78,7 +78,7 @@ class TestDonationSerializer(TransactionTestCase):
         # user entered, regardless of who we attribute it to internally.
         self.donation.requestedalias = 'requested by donation'
         self.donation.donor = generate_donor(
-            self.rand, alias='requested by donor', visibility='ALIAS'
+            self.rand, alias='requested_by_donor', visibility='ALIAS'
         )
 
         serialized = DonationSerializer(self.donation).data

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -9,6 +9,7 @@ from tracker.api.views import (
     bids,
     country,
     donations,
+    donors,
     interview,
     me,
     milestone,
@@ -42,6 +43,7 @@ event_nested_route(r'runs', run.SpeedRunViewSet)
 event_nested_route(r'ads', ad.AdViewSet)
 event_nested_route(r'interviews', interview.InterviewViewSet)
 event_nested_route(r'milestones', milestone.MilestoneViewSet)
+event_nested_route(r'donors', donors.DonorViewSet)
 router.register(r'donations', donations.DonationViewSet, basename='donations')
 router.register(r'me', me.MeViewSet, basename='me')
 router.register(r'countries', country.CountryViewSet)

--- a/tracker/api/views/donors.py
+++ b/tracker/api/views/donors.py
@@ -1,0 +1,48 @@
+from django.db.models import Prefetch, Q
+
+from tracker.api.pagination import TrackerPagination
+from tracker.api.permissions import tracker_permission
+from tracker.api.serializers import DonorSerializer
+from tracker.api.views import EventNestedMixin, TrackerReadViewSet
+from tracker.models import Donor, DonorCache
+
+
+class DonorViewSet(EventNestedMixin, TrackerReadViewSet):
+    queryset = Donor.objects.all()
+    pagination_class = TrackerPagination
+    permission_classes = [tracker_permission('tracker.view_donor')]
+    serializer_class = DonorSerializer
+
+    def _include_totals(self):
+        return 'include_totals' in self.request.query_params
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self._include_totals():
+            if event := self.get_event_from_request():
+                dc_queryset = DonorCache.objects.filter(
+                    Q(event__isnull=True) | Q(event=event)
+                )
+            else:
+                dc_queryset = DonorCache.objects.all()
+            queryset = queryset.prefetch_related(
+                Prefetch('cache', queryset=dc_queryset)
+            )
+        return queryset
+
+    def get_serializer(self, *args, **kwargs):
+        if self._include_totals():
+            kwargs['include_totals'] = True
+        return super().get_serializer(*args, **kwargs)
+
+    def get_event_filter(self, queryset, event):
+        if event:
+            queryset = queryset.filter(
+                id__in=(
+                    d['id']
+                    for d in queryset.filter(donation__event=event)
+                    .distinct()
+                    .values('id')
+                )
+            )
+        return queryset

--- a/tracker/models/donation.py
+++ b/tracker/models/donation.py
@@ -492,11 +492,12 @@ class Donor(models.Model):
             return f'{self.alias}#{self.alias_num}'
         return None
 
-    def get_absolute_url(self):
-        return reverse(
-            'tracker:donor',
-            args=(self.id,),
-        )
+    # disabled for now
+    # def get_absolute_url(self):
+    #     return reverse(
+    #         'tracker:donor',
+    #         args=(self.id,),
+    #     )
 
     def __repr__(self):
         return self.visible_name()
@@ -578,7 +579,9 @@ class DonorCache(models.Model):
         self.donation_avg = aggregate['avg']
 
     def __str__(self):
-        return str(self.donor)
+        return (
+            f'{str(self.donor)} -- {(str(self.event) if self.event else "All Events")}'
+        )
 
     @property
     def donation_set(self):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184870657

### Description of the Change

Adding a read-only view of the Donor model to the V2 api. Unlike most endpoints this *requires*, at a mininum, the `view donor` permission to look at all, as currently very little Donor information is considered public. While Donors don't explicitly belong to events, you can scope donor information to events since it includes aggregate information. I had to rework how the serializers and viewsets treated the `event` field/parameter because of this, but it ended up being a bit cleaner as a bonus.

### Verification Process

Hitting the endpoints gives the expected results, especially with the permissions checks.