### PR TITLE
do not override filter_queryset on viewsets [#188679583]

### DIFF
--- a/tracker/api/views/country.py
+++ b/tracker/api/views/country.py
@@ -45,7 +45,8 @@ class CountryRegionViewSet(TrackerReadViewSet):
         self.country = country
         super().__init__(*args, **kwargs)
 
-    def filter_queryset(self, queryset):
+    def get_queryset(self):
+        queryset = super().get_queryset()
         if self.country:
             queryset = queryset.filter(country=self.country)
         return queryset

--- a/tracker/api/views/donation_bids.py
+++ b/tracker/api/views/donation_bids.py
@@ -18,7 +18,8 @@ class DonationBidViewSet(WithSerializerPermissionsMixin, TrackerReadViewSet):
         self.bid = bid
         super().__init__(*args, **kwargs)
 
-    def filter_queryset(self, queryset):
+    def get_queryset(self):
+        queryset = super().get_queryset()
         # this can be filtered in multiple ways
         # - by donation, which excludes hidden children unless explicitly asked for
         # - by exact bid, which includes the descendant tree if there is one, excluding

--- a/tracker/api/views/milestone.py
+++ b/tracker/api/views/milestone.py
@@ -26,8 +26,8 @@ class MilestoneViewSet(
             isinstance(instance, Milestone) and instance.visible
         ) or 'all' in self.request.query_params
 
-    def filter_queryset(self, queryset):
+    def get_queryset(self):
         queryset = super().get_queryset()
         if not (self.detail or 'all' in self.request.query_params):
             queryset = queryset.filter(visible=True)
-        return super().filter_queryset(queryset)
+        return queryset


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188679583

### Description of the Change

While working on the Donor API V2 branch I realized that the standard is NOT to override `filter_queryset` on the viewsets, so this addresses that. Just a refactor. No behavior change.

### Verification Process

Only a couple of viewsets were touched, so I double checked to make sure they still gave the expected results. Plus all the tests are still green, and the underlying behavior should not have changed.