### PR TITLE
add Prize to V2 api [#184870668]

### DIFF
--- a/tests/apiv2/test_donations.py
+++ b/tests/apiv2/test_donations.py
@@ -117,7 +117,7 @@ class TestDonations(APITestCase):
             self.event,
             count=2,
             state='pending',
-            time=date.replace(year=9999),
+            time=date.replace(year=9998),
         )
 
         response = self.client.get(

--- a/tests/apiv2/test_milestones.py
+++ b/tests/apiv2/test_milestones.py
@@ -173,7 +173,7 @@ class TestMilestones(APITestCase):
         with self.subTest('error cases'):
             self.patch_detail(
                 self.public_milestone,
-                data={'event': self.event.id},
+                data={'event': self.blank_event.id},
                 status_code=400,
                 expected_error_codes=messages.EVENT_READ_ONLY_CODE,
             )

--- a/tests/apiv2/test_prizes.py
+++ b/tests/apiv2/test_prizes.py
@@ -1,0 +1,264 @@
+from datetime import timedelta
+
+from tests import randgen
+from tests.util import APITestCase, today_noon
+from tracker import models
+from tracker.api import messages
+from tracker.api.serializers import PrizeSerializer
+
+
+class TestPrizes(APITestCase):
+    model_name = 'prize'
+    serializer_class = PrizeSerializer
+
+    def setUp(self):
+        super().setUp()
+        self.runs = randgen.generate_runs(
+            self.rand, num_runs=3, event=self.event, ordered=True
+        )
+        self.accepted_prize = randgen.generate_prize(
+            self.rand, start_run=self.runs[0], end_run=self.runs[1]
+        )
+        self.accepted_prize.description = 'test long description'
+        self.accepted_prize.shortdescription = 'test short description'
+        self.accepted_prize.save()
+        self.pending_prize = randgen.generate_prize(
+            self.rand, event=self.event, state='PENDING'
+        )
+        self.pending_prize.save()
+        self.denied_prize = randgen.generate_prize(
+            self.rand, event=self.event, state='DENIED'
+        )
+        self.denied_prize.save()
+        self.flagged_prize = randgen.generate_prize(
+            self.rand, event=self.event, state='FLAGGED'
+        )
+        self.flagged_prize.save()
+        self.locked_prize = randgen.generate_prize(
+            self.rand, event=self.locked_event, state='PENDING'
+        )
+        self.locked_prize.save()
+        # TODO
+        # self.view_winner_user = User.objects.create(username='view_winner_user')
+        # self.view_winner_user.user_permissions.add(Permission.objects.get(codename='view_prizewinner'))
+
+    def test_fetch(self):
+        with self.saveSnapshot():
+            with self.subTest('public'):
+                data = self.get_list()
+                self.assertExactV2Models([self.accepted_prize], data)
+
+                # TODO: more exhaustive?
+                data = self.get_list(
+                    kwargs={'feed': 'current'}, data={'time': self.runs[0].starttime}
+                )
+                self.assertExactV2Models([self.accepted_prize], data)
+
+                data = self.get_list(
+                    kwargs={'feed': 'current'}, data={'run': self.runs[0].pk}
+                )
+                self.assertExactV2Models([self.accepted_prize], data)
+
+                with self.subTest('searches'):
+                    data = self.get_list(data={'q': self.accepted_prize.name})
+                    self.assertExactV2Models([self.accepted_prize], data)
+
+                    data = self.get_list(data={'q': self.accepted_prize.description})
+                    self.assertExactV2Models([self.accepted_prize], data)
+
+                    data = self.get_list(
+                        data={'q': self.accepted_prize.shortdescription}
+                    )
+                    self.assertExactV2Models([self.accepted_prize], data)
+
+                    data = self.get_list(data={'name': self.accepted_prize.name})
+                    self.assertExactV2Models([self.accepted_prize], data)
+
+                    data = self.get_list(data={'state': 'ACCEPTED'})
+                    self.assertExactV2Models([self.accepted_prize], data)
+
+                data = self.get_detail(self.accepted_prize)
+                self.assertV2ModelPresent(self.accepted_prize, data)
+
+                data = self.get_detail(
+                    self.accepted_prize, kwargs={'event_pk': self.event.pk}
+                )
+                self.assertV2ModelPresent(self.accepted_prize, data)
+
+            with self.subTest('private'):
+                data = self.get_list(user=self.view_user, kwargs={'feed': 'all'})
+                self.assertExactV2Models(
+                    [
+                        self.accepted_prize,
+                        self.flagged_prize,
+                        self.denied_prize,
+                        self.pending_prize,
+                        self.locked_prize,
+                    ],
+                    data,
+                )
+
+                data = self.get_list(
+                    user=self.view_user,
+                    data={'state': ['PENDING', 'DENIED', 'FLAGGED']},
+                    kwargs={'event_pk': self.event.pk},
+                )
+                self.assertExactV2Models(
+                    [self.flagged_prize, self.denied_prize, self.pending_prize], data
+                )
+
+                # TODO
+                # data = self.get_list(user=self.view_winner_user, data={'include_winners': ''})
+                # self.assertExactV2Models([self.accepted_prize], data, serializer_kwargs={'include_winners': True})
+
+        with self.subTest('error cases'):
+            with self.subTest('private feeds'):
+                for feed in models.Prize.HIDDEN_FEEDS:
+                    with self.subTest(feed):
+                        self.get_list(user=None, kwargs={'feed': feed}, status_code=403)
+
+            with self.subTest('wrong event detail'):
+                self.get_detail(
+                    self.accepted_prize,
+                    kwargs={'event_pk': self.blank_event.pk},
+                    status_code=404,
+                )
+
+            with self.subTest('private detail'):
+                for prize in [
+                    self.pending_prize,
+                    self.denied_prize,
+                    self.flagged_prize,
+                ]:
+                    with self.subTest(prize.state):
+                        self.get_detail(prize, user=None, status_code=404)
+
+            with self.subTest('private states'):
+                for state in models.Prize.HIDDEN_STATES:
+                    with self.subTest(state):
+                        self.get_list(user=None, data={'state': state}, status_code=403)
+
+            with self.subTest('combining feed and state'):
+                self.get_list(
+                    data={'state': 'ACCEPTED'},
+                    kwargs={'feed': 'public'},
+                    status_code=400,
+                )
+
+            with self.subTest('combining feed and detail'):
+                self.get_detail(
+                    self.accepted_prize, kwargs={'feed': 'public'}, status_code=404
+                )
+
+    def test_create(self):
+        with self.saveSnapshot(), self.assertLogsChanges(4):
+            with self.subTest('minimal'):
+                data = self.post_new(
+                    user=self.add_user,
+                    data={'event': self.event.pk, 'name': 'Event Wide Prize'},
+                )
+                prize = models.Prize.objects.get(pk=data['id'])
+                serialized = PrizeSerializer(prize)
+                self.assertEqual(data, serialized.data)
+                self.assertEqual(prize.handler, self.add_user)
+
+                data = self.post_new(
+                    user=self.add_user,
+                    data={
+                        'event': self.event.pk,
+                        'name': 'Timed Prize',
+                        'starttime': today_noon,
+                        'endtime': today_noon + timedelta(hours=1),
+                    },
+                )
+                serialized = PrizeSerializer(models.Prize.objects.get(pk=data['id']))
+                self.assertEqual(data, serialized.data)
+
+                data = self.post_new(
+                    user=self.add_user,
+                    data={
+                        'event': self.event.pk,
+                        'name': 'Block Prize',
+                        'startrun': self.runs[0].pk,
+                        'endrun': self.runs[2].pk,
+                    },
+                )
+                serialized = PrizeSerializer(models.Prize.objects.get(pk=data['id']))
+                self.assertEqual(data, serialized.data)
+
+            with self.subTest('full blown'):
+                data = self.post_new(
+                    user=self.add_user,
+                    kwargs={'event_pk': self.event.pk},
+                    data={
+                        'name': 'Earthquake Pills',
+                        'startrun': self.runs[0].pk,
+                        'endrun': self.runs[1].pk,
+                        'description': 'Why wait? Make your own earthquakes - loads of fun!',
+                        'shortdescription': 'Make your own earthquakes!',
+                        'image': 'https://www.example.com/image.jpg',
+                        'altimage': 'https://www.example.com/thumbnail.jpg',
+                        'estimatedvalue': 10,
+                        'minimumbid': 25,
+                        'sumdonations': 1,
+                        'provider': 'Coyote',
+                        'creator': 'ACME',
+                        'creatorwebsite': 'https://www.acme.com/',
+                    },
+                )
+                serialized = PrizeSerializer(
+                    models.Prize.objects.get(pk=data['id']), event_pk=self.event.pk
+                )
+                self.assertEqual(data, serialized.data)
+
+        with self.subTest('error cases'):
+            self.post_new(
+                user=self.add_user,
+                data={'event': self.locked_event.pk},
+                status_code=403,
+                expected_error_codes=messages.UNAUTHORIZED_LOCKED_EVENT_CODE,
+            )
+            self.post_new(
+                user=self.view_user,
+                status_code=403,
+                expected_error_codes=messages.PERMISSION_DENIED_CODE,
+            )
+            self.post_new(
+                user=None,
+                status_code=403,
+                expected_error_codes=messages.NOT_AUTHENTICATED_CODE,
+            )
+
+    def test_patch(self):
+        with self.saveSnapshot(), self.assertLogsChanges(1):
+            data = self.patch_detail(
+                self.pending_prize, user=self.add_user, data={'state': 'ACCEPTED'}
+            )
+            self.assertEqual(self.pending_prize.state, 'ACCEPTED')
+            self.assertEqual(data, PrizeSerializer(self.pending_prize).data)
+
+        with self.subTest('error cases'):
+            self.patch_detail(
+                self.accepted_prize,
+                data={'event': self.blank_event.pk},
+                status_code=400,
+                expected_error_codes=messages.EVENT_READ_ONLY_CODE,
+            )
+            self.patch_detail(
+                self.locked_prize,
+                user=self.add_user,
+                status_code=403,
+                expected_error_codes=messages.UNAUTHORIZED_LOCKED_EVENT_CODE,
+            )
+            self.patch_detail(
+                self.accepted_prize,
+                user=self.view_user,
+                status_code=403,
+                expected_error_codes='permission_denied',
+            )
+            self.patch_detail(
+                self.accepted_prize,
+                user=None,
+                status_code=403,
+                expected_error_codes=messages.NOT_AUTHENTICATED_CODE,
+            )

--- a/tests/randgen.py
+++ b/tests/randgen.py
@@ -211,7 +211,6 @@ def generate_prize(
     end_time=None,
     sum_donations=None,
     min_amount=Decimal('1.00'),
-    max_amount=Decimal('20.00'),
     random_draw=True,
     maxwinners=1,
     state='ACCEPTED',
@@ -232,17 +231,8 @@ def generate_prize(
         prize.category = category
     else:
         prize.category = rand.choice([None] + list(PrizeCategory.objects.all()))
-    if true_false_or_random(rand, sum_donations):
-        prize.sumdonations = True
-        lo = random_amount(rand, min_amount=min_amount, max_amount=max_amount)
-        hi = random_amount(rand, min_amount=min_amount, max_amount=max_amount)
-        prize.minimumbid = min(lo, hi)
-        prize.maximumbid = max(lo, hi)
-    else:
-        prize.sumdonations = False
-        prize.minimumbid = prize.maximumbid = random_amount(
-            rand, min_amount=min_amount, max_amount=max_amount
-        )
+    prize.sumdonations = true_false_or_random(rand, sum_donations)
+    prize.minimumbid = min_amount
     prize.randomdraw = random_draw
     if start_run:
         prize.event = start_run.event

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -753,7 +753,6 @@ minimal@example.com
             end_run=runs[0],
             sum_donations=False,
             min_amount=5,
-            max_amount=5,
         )
         prize.save()
         donors = randgen.generate_donors(self.rand, 3)
@@ -781,7 +780,6 @@ minimal@example.com
             event=self.event,
             sum_donations=True,
             min_amount=50,
-            max_amount=50,
         )
         grandPrize.save()
         # generate 2 for summation

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -597,7 +597,6 @@ class TestPersistentPrizeWinners(TransactionTestCase):
             sum_donations=False,
             random_draw=False,
             min_amount=amount,
-            max_amount=amount,
             maxwinners=1,
         )
         targetPrize.save()
@@ -880,7 +879,6 @@ class TestPrizeDrawAcceptOffset(TransactionTestCase):
             sum_donations=False,
             random_draw=False,
             min_amount=amount,
-            max_amount=amount,
             maxwinners=1,
         )
         targetPrize.save()

--- a/tracker/api/filters.py
+++ b/tracker/api/filters.py
@@ -1,5 +1,8 @@
 import datetime
+import itertools
 import logging
+import operator
+from functools import reduce
 
 from django.db.models import Q
 from django.http import Http404
@@ -8,68 +11,128 @@ from rest_framework import filters
 from rest_framework.exceptions import NotFound, ParseError, PermissionDenied
 
 from tracker.api import messages
-from tracker.models import Bid
+from tracker.api.util import parse_time
+from tracker.api.views.run import SpeedRunViewSet
+from tracker.models import Bid, Prize
 
 logger = logging.getLogger(__name__)
 
+empty = object()
+
 
 class TrackerFilter(filters.BaseFilterBackend):
-    filter_params = {}
+    general_filter = []
+    filter_lookup = []
+    filter_keys = {}
 
     def filter_queryset(self, request, queryset, view):
-        if not view.detail:
-            filter_args = []
-            filter_kwargs = {}
-            if 'id' in request.query_params:
-                filter_kwargs['id__in'] = request.query_params.getlist('id')
-            for param, filter_param in self.filter_params.items():
-                if param in request.query_params:
-                    if isinstance(filter_param, str):
-                        if filter_param.endswith('__in'):
-                            values = request.query_params.getlist(param)
-                            if any(
-                                not self.has_filter_permission(request, param, value)
-                                for value in values
-                            ):
-                                raise PermissionDenied(
-                                    detail=messages.UNAUTHORIZED_FILTER_PARAM,
-                                    code=messages.UNAUTHORIZED_FILTER_PARAM_CODE,
-                                )
-                            filter_kwargs[filter_param] = [
-                                self.normalize_value(param, value) for value in values
-                            ]
-                        else:
-                            value = request.query_params[param]
-                            if not self.has_filter_permission(request, param, value):
-                                raise PermissionDenied(
-                                    detail=messages.UNAUTHORIZED_FILTER_PARAM,
-                                    code=messages.UNAUTHORIZED_FILTER_PARAM_CODE,
-                                )
-                            filter_kwargs[filter_param] = self.normalize_value(
-                                param, value
-                            )
-                    elif isinstance(filter_param, Q):
-                        filter_args.append(filter_param)
-                    elif callable(filter_param):
-                        filter_args.append(filter_param(request.query_params[param]))
-            try:
-                queryset = queryset.filter(*filter_args, **filter_kwargs)
-            except (ValueError, TypeError):
+        if view.detail or view.action == ['create']:
+            return queryset
+
+        if 'q' in request.query_params:
+            if not self.general_filter:
                 raise ParseError(
-                    detail=messages.MALFORMED_SEARCH_PARAMETER,
-                    code=messages.MALFORMED_SEARCH_PARAMETER_CODE,
+                    detail=messages.NO_GENERAL_SEARCH,
+                    code=messages.NO_GENERAL_SEARCH_CODE,
                 )
+            # TODO: recurse the keys like in search_filters
+            queryset = queryset.filter(
+                reduce(
+                    operator.or_,
+                    (
+                        Q(**{k + '__icontains': v})
+                        for (k, v) in itertools.product(
+                            self.general_filter, request.query_params.getlist('q')
+                        )
+                    ),
+                )
+            )
+
+        filter_args = []
+        filter_kwargs = {}
+
+        if 'id' in request.query_params:
+            filter_kwargs['id__in'] = request.query_params.getlist('id')
+
+        for param in self.filter_lookup:
+            if param in request.query_params:
+                if not self.has_filter_permission(request, param):
+                    raise PermissionDenied(
+                        detail=messages.UNAUTHORIZED_FIELD,
+                        code=messages.UNAUTHORIZED_FIELD_CODE,
+                    )
+                value = request.query_params[param]
+                if not self.has_filter_permission(request, param, value):
+                    raise PermissionDenied(
+                        detail=messages.UNAUTHORIZED_FILTER_PARAM,
+                        code=messages.UNAUTHORIZED_FILTER_PARAM_CODE,
+                    )
+                filter_kwargs[param] = self.normalize_value(param, value)
+
+        for param, filter_param in self.filter_keys.items():
+            if param in request.query_params:
+                if not self.has_filter_permission(request, param):
+                    raise PermissionDenied(
+                        detail=messages.UNAUTHORIZED_FIELD,
+                        code=messages.UNAUTHORIZED_FIELD_CODE,
+                    )
+                if isinstance(filter_param, str):
+                    if filter_param.endswith('__in'):
+                        values = request.query_params.getlist(param)
+                        if any(
+                            not self.has_filter_permission(request, param, value)
+                            for value in values
+                        ):
+                            raise PermissionDenied(
+                                detail=messages.UNAUTHORIZED_FILTER_PARAM,
+                                code=messages.UNAUTHORIZED_FILTER_PARAM_CODE,
+                            )
+                        filter_kwargs[filter_param] = [
+                            self.normalize_value(param, value) for value in values
+                        ]
+                    else:
+                        value = request.query_params[param]
+                        if not self.has_filter_permission(request, param, value):
+                            raise PermissionDenied(
+                                detail=messages.UNAUTHORIZED_FILTER_PARAM,
+                                code=messages.UNAUTHORIZED_FILTER_PARAM_CODE,
+                            )
+                        filter_kwargs[filter_param] = self.normalize_value(param, value)
+                elif isinstance(filter_param, Q):
+                    filter_args.append(filter_param)
+                elif callable(filter_param):
+                    filter_args.append(filter_param(request.query_params[param]))
+        try:
+            queryset = queryset.filter(*filter_args, **filter_kwargs)
+        except (ValueError, TypeError):
+            raise ParseError(
+                detail=messages.MALFORMED_SEARCH_PARAMETER,
+                code=messages.MALFORMED_SEARCH_PARAMETER_CODE,
+            )
+
         return queryset
 
     def normalize_value(self, field, value):
         return value
 
-    def has_filter_permission(self, request, field, value):
+    def has_filter_permission(self, request, field, value=empty):
         return True
 
 
+def check_feed(feed, view, query_params):
+    if feed is not None:
+        # feed makes no sense for detail views or when trying to explicitly filter by state, but for different reasons
+        if view.detail:
+            raise Http404
+        if 'state' in query_params:
+            raise ParseError(
+                detail=_('Cannot search for state while using the feed endpoint.'),
+                code=messages.INVALID_SEARCH_PARAMETER_CODE,
+            )
+
+
 class BidFilter(TrackerFilter):
-    filter_params = {
+    filter_keys = {
         'name': 'name__icontains',
         'state': 'state__in',
         'run': 'speedrun__in',
@@ -86,18 +149,26 @@ class BidFilter(TrackerFilter):
             return value.upper()
         return value
 
-    def has_filter_permission(self, request, field, value):
+    def has_filter_permission(self, request, field, value=empty):
         return (
             field != 'state'
+            or value is empty
             or value in Bid.PUBLIC_STATES
             or request.user.has_perm('tracker.view_hidden_bid')
+            or request.user.has_perm('tracker.view_bid')
         )
 
     def filter_queryset(self, request, queryset, view):
         feed = view.get_feed()
         query_params = request.query_params
+
+        check_feed(feed, view, query_params)
+
+        if view.detail or view.action == ['create']:
+            return queryset
+
         if feed is None:
-            if not view.detail and 'state' not in query_params:
+            if 'state' not in query_params:
                 queryset = queryset.public()
         elif feed == 'open':
             queryset = queryset.open()
@@ -134,16 +205,6 @@ class BidFilter(TrackerFilter):
                 detail=messages.INVALID_FEED % feed, code=messages.INVALID_FEED_CODE
             )
 
-        if feed is not None:
-            # feed makes no sense for detail views or when trying to explicitly filter by state, but for different reasons
-            if view.detail:
-                raise Http404
-            if 'state' in query_params:
-                raise ParseError(
-                    detail=_('Cannot search for state while using the feed endpoint.'),
-                    code=messages.INVALID_SEARCH_PARAMETER_CODE,
-                )
-
         if view.action == 'tree':
             if feed == 'pending':
                 raise NotFound(
@@ -158,5 +219,60 @@ class BidFilter(TrackerFilter):
                         % param,
                         code=messages.INVALID_SEARCH_PARAMETER_CODE,
                     )
+
+        return super().filter_queryset(request, queryset, view)
+
+
+class PrizeFilter(TrackerFilter):
+    general_filter = ['name', 'description', 'shortdescription']
+    filter_lookup = ['event', 'category']
+    filter_keys = {
+        'name': 'name__icontains',
+        'state': 'state__in',
+    }
+
+    def normalize_value(self, field, value):
+        if field == 'state':
+            return value.upper()
+        return value
+
+    def has_filter_permission(self, request, field, value=empty):
+        return (
+            field != 'state'
+            or value is empty
+            or value in Prize.PUBLIC_STATES
+            or request.user.has_perm('tracker.view_prize')
+        )
+
+    def filter_queryset(self, request, queryset, view):
+        feed = view.get_feed()
+        query_params = request.query_params
+
+        check_feed(feed, view, query_params)
+
+        if view.detail or view.action == ['create']:
+            return queryset
+
+        if feed is None or feed == 'public':
+            if 'state' not in query_params:
+                queryset = queryset.public()
+        elif feed == 'current':
+            if 'run' in request.query_params:
+                run = SpeedRunViewSet(
+                    kwargs={'pk': request.query_params['run']}, request=request
+                ).get_object()
+            else:
+                run = None
+            queryset = queryset.current(
+                parse_time(query_params.get('time', None)), run=run
+            )
+        elif feed == 'all':
+            pass  # no change for 'all'
+        elif feed is not None:
+            if feed.upper() in Prize.ALL_FEEDS:
+                logger.warning(f'unhandled valid prize feed `{feed}`')
+            raise NotFound(
+                detail=messages.INVALID_FEED % feed, code=messages.INVALID_FEED_CODE
+            )
 
         return super().filter_queryset(request, queryset, view)

--- a/tracker/api/messages.py
+++ b/tracker/api/messages.py
@@ -1,10 +1,12 @@
 from django.utils.translation import gettext_lazy as _
-from rest_framework.exceptions import NotAuthenticated
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 
 GENERIC_NOT_FOUND = _(
     'That resource does not exist or you do not have permission to view it.'
 )
 
+NO_GENERAL_SEARCH = _('That endpoint does not support `q` searches.')
+NO_GENERAL_SEARCH_CODE = 'no_general_search'
 MALFORMED_SEARCH_PARAMETER = _('At least one search parameter was malformed.')
 MALFORMED_SEARCH_PARAMETER_SPECIFIC = _('`%s` parameter was malformed.')
 MALFORMED_SEARCH_PARAMETER_CODE = 'malformed_search_parameter'
@@ -51,5 +53,9 @@ ANCHOR_FIELD = _('`event` and `order` fields are implicit if specifying `anchor`
 ANCHOR_FIELD_CODE = 'invalid_anchor_sibling'
 INVALID_ANCHOR = _('Specified anchor is not ordered.')
 INVALID_ANCHOR_CODE = 'invalid_anchor'
+PERMISSION_DENIED = PermissionDenied.default_detail
+PERMISSION_DENIED_CODE = PermissionDenied.default_code
 NOT_AUTHENTICATED = NotAuthenticated.default_detail
 NOT_AUTHENTICATED_CODE = NotAuthenticated.default_code
+INVALID_TIMESTAMP = _('Provided timestamp could not be parsed.')
+INVALID_TIMESTAMP_CODE = 'invalid_timestamp'

--- a/tracker/api/permissions.py
+++ b/tracker/api/permissions.py
@@ -82,6 +82,38 @@ class BidStatePermission(BasePermission):
         )
 
 
+class PrizeFeedPermission(BasePermission):
+    PUBLIC_FEEDS = models.Prize.PUBLIC_FEEDS
+    message = messages.UNAUTHORIZED_FEED
+    code = messages.UNAUTHORIZED_FEED_CODE
+
+    def has_permission(self, request: Request, view: t.Callable):
+        feed = view.get_feed()
+        return super().has_permission(request, view) and (
+            feed is None
+            or feed in self.PUBLIC_FEEDS
+            or any(
+                request.user.has_perm(f'tracker.{p}')
+                for p in ('change_prize', 'view_prize')
+            )
+        )
+
+
+class PrizeStatePermission(BasePermission):
+    PUBLIC_STATES = models.Prize.PUBLIC_STATES
+    message = messages.GENERIC_NOT_FOUND
+    code = messages.UNAUTHORIZED_OBJECT_CODE
+
+    def has_object_permission(self, request: Request, view: t.Callable, obj: t.Any):
+        return super().has_object_permission(request, view, obj) and (
+            obj.state in self.PUBLIC_STATES
+            or any(
+                request.user.has_perm(f'tracker.{p}')
+                for p in ('change_prize', 'view_prize')
+            )
+        )
+
+
 class DonationBidStatePermission(BasePermission):
     PUBLIC_STATES = models.Bid.PUBLIC_STATES
     message = messages.GENERIC_NOT_FOUND

--- a/tracker/api/urls.py
+++ b/tracker/api/urls.py
@@ -13,6 +13,7 @@ from tracker.api.views import (
     interview,
     me,
     milestone,
+    prize,
     run,
     talent,
 )
@@ -23,16 +24,21 @@ router = routers.DefaultRouter()
 def event_nested_route(path, viewset, *, basename=None, feed=False):
     if basename is None:
         basename = router.get_default_basename(viewset)
-    router.register(path, viewset, basename)
     if feed:
         router.register(
             r'events/(?P<event_pk>[^/.]+)/' + path + r'/feed_(?P<feed>\w+)',
             viewset,
             f'event-{basename}-feed',
         )
+        router.register(
+            path + r'/feed_(?P<feed>\w+)',
+            viewset,
+            f'{basename}-feed',
+        )
     router.register(
         r'events/(?P<event_pk>[^/.]+)/' + path, viewset, f'event-{basename}'
     )
+    router.register(path, viewset, basename)
 
 
 # routers generate URLs based on the view sets, so that we don't need to do a bunch of stuff by hand
@@ -43,6 +49,7 @@ event_nested_route(r'runs', run.SpeedRunViewSet)
 event_nested_route(r'ads', ad.AdViewSet)
 event_nested_route(r'interviews', interview.InterviewViewSet)
 event_nested_route(r'milestones', milestone.MilestoneViewSet)
+event_nested_route(r'prizes', prize.PrizeViewSet, feed=True)
 event_nested_route(r'donors', donors.DonorViewSet)
 router.register(r'donations', donations.DonationViewSet, basename='donations')
 router.register(r'me', me.MeViewSet, basename='me')

--- a/tracker/api/util.py
+++ b/tracker/api/util.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from rest_framework.exceptions import ParseError
+
+from tracker.api import messages
+
+
+def parse_time(time: None | str | int | datetime) -> datetime:
+    """api helper to throw the correct exception"""
+    from tracker.util import parse_time
+
+    try:
+        return parse_time(time)
+    except (TypeError, ValueError):
+        raise ParseError(
+            detail=messages.INVALID_TIMESTAMP, code=messages.INVALID_TIMESTAMP_CODE
+        )

--- a/tracker/api/views/prize.py
+++ b/tracker/api/views/prize.py
@@ -1,0 +1,25 @@
+from tracker.api.filters import PrizeFilter
+from tracker.api.permissions import PrizeFeedPermission, PrizeStatePermission
+from tracker.api.serializers import PrizeSerializer
+from tracker.api.views import (
+    EventNestedMixin,
+    TrackerFullViewSet,
+    WithSerializerPermissionsMixin,
+)
+from tracker.models import Prize
+
+
+class PrizeViewSet(
+    WithSerializerPermissionsMixin,
+    EventNestedMixin,
+    TrackerFullViewSet,
+):
+    queryset = Prize.objects.select_related(
+        'event', 'startrun', 'endrun', 'prev_run', 'next_run'
+    )
+    serializer_class = PrizeSerializer
+    permission_classes = [PrizeFeedPermission, PrizeStatePermission]
+    filter_backends = [PrizeFilter]
+
+    def get_feed(self):
+        return self.kwargs.get('feed', None)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/184870668

### Description of the Change

Adding endpoints to list/add/edit prizes to v2. 

While I was in here I had to make some framework changes to consolidate some common behavior, and I took the opportunity to try and move a few things out of search_feeds. 

This doesn't include the full set of fields yet since I'm not sure which we actually want as part of the API. Creating the prize also just assigns the handler to the current user since user lookup isn't really a thing the API handles yet and I'm not sure how I want to do that either.

Also changed the way the snapshots capture subTest messages since it turns out the previous method wasn't handling nesting properly.

### Verification Process

Hit the endpoints with curl requests and got the expected results.