### PR TITLE
remove 3.8, add 3.13 [#188680941]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,28 +12,25 @@ jobs:
     strategy:
       matrix:
         Oldest:
-          PYTHON_VERSION: '3.8'
+          PYTHON_VERSION: '3.9'
           DJANGO_VERSION: '4.2'
         Django42:
           PYTHON_VERSION: '3.12'
           DJANGO_VERSION: '4.2'
         Django50:
-          PYTHON_VERSION: '3.12'
+          PYTHON_VERSION: '3.13'
           DJANGO_VERSION: '5.0'
-        Python38:
-          PYTHON_VERSION: '3.8'
-          DJANGO_VERSION: '4.2'
-        Python39:
-          PYTHON_VERSION: '3.9'
-          DJANGO_VERSION: '4.2'
         Python3A:
           PYTHON_VERSION: '3.10'
           DJANGO_VERSION: '5.1'
         Python3B:
           PYTHON_VERSION: '3.11'
           DJANGO_VERSION: '5.1'
-        Latest:
+        Python3C:
           PYTHON_VERSION: '3.12'
+          DJANGO_VERSION: '5.1'
+        Latest:
+          PYTHON_VERSION: '3.13'
           DJANGO_VERSION: '5.1'
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_package_name(name):
 
 setup(
     name=get_package_name('django-donation-tracker'),
-    version='3.2',
+    version='3.3',
     author='Games Done Quick',
     author_email='tracker@gamesdonequick.com',
     packages=find_packages(include=['tracker', 'tracker.*']),
@@ -48,7 +48,6 @@ setup(
         'package': PackageCommand,
     },
     install_requires=[
-        'backports.zoneinfo;python_version<"3.9"',
         'celery~=5.0',
         'channels>=4.0',
         'Django>=4.2,<5.2',
@@ -64,7 +63,7 @@ setup(
     extras_require={
         'development': ['daphne~=4.0'],
     },
-    python_requires='>=3.8, <3.13',
+    python_requires='>=3.9, <3.14',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -74,11 +73,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,18 +1,16 @@
 # base
 celery==5.4.0
 channels==4.2.0
+setuptools
+wheel
 # django explicitly not listed here because azure installs a particular series immediately after
 django-ical==1.9.2
 django-paypal==1.1.2
-django-mptt==0.14.0 ; python_version<"3.9"
-django-mptt==0.16.0 ; python_version>="3.9"
+django-mptt==0.16.0
 django-post-office==3.6.0
 django-timezone-field==7.0
 djangorestframework==3.15.2
-pre-commit==3.5.0 ; python_version<"3.9"
-pre-commit==4.0.1 ; python_version>="3.9"
-python-dateutil==2.8.2
-backports.zoneinfo==0.2.1 ; python_version<"3.9"
+pre-commit==4.0.1
 python-dateutil==2.8.2 ; python_version<"3.11"
 webpack-manifest==2.1.1
 # only for testing

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -2,6 +2,7 @@ import datetime
 import io
 import json
 import random
+import zoneinfo
 
 import post_office.models
 from django.contrib.auth.models import Group, Permission, User
@@ -9,7 +10,6 @@ from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 
 from tracker import models, settings
-from tracker.compat import zoneinfo
 from tracker.util import make_rand, utcnow
 
 from . import randgen

--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import random
+import zoneinfo
 from typing import Iterable, List, Optional, Union
 from unittest import skipIf
 
@@ -12,7 +13,7 @@ from django.urls import reverse
 
 import tracker.models as models
 from tracker import settings
-from tracker.compat import pairwise, zoneinfo
+from tracker.compat import pairwise
 
 from . import randgen
 from .util import today_noon

--- a/tests/util.py
+++ b/tests/util.py
@@ -13,6 +13,7 @@ import re
 import sys
 import time
 import unittest
+import zoneinfo
 from decimal import Decimal
 
 from django.contrib.admin.models import LogEntry
@@ -36,7 +37,6 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from tracker import models, settings, util
 from tracker.api.pagination import TrackerPagination
-from tracker.compat import zoneinfo
 
 _empty = object()
 

--- a/tracker/compat.py
+++ b/tracker/compat.py
@@ -1,12 +1,4 @@
 try:
-    import zoneinfo
-except ImportError:
-    # TODO: remove when 3.9 is oldest supported version
-
-    # noinspection PyUnresolvedReferences
-    from backports import zoneinfo  # noqa: F401
-
-try:
     from itertools import pairwise
 except ImportError:
     # TODO: remove when 3.10 is oldest supported version

--- a/tracker/util.py
+++ b/tracker/util.py
@@ -52,7 +52,7 @@ def try_parse_int(s, base=10, val=None):
 
 
 def anywhere_on_earth_tz():
-    from .compat import zoneinfo
+    import zoneinfo
 
     """This is a trick used by academic conference submission deadlines
     to use the last possible timezone to define the end of a particular date"""


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188299112

### Description of the Change

3.8 is EOL, 3.13 is official, this just upgrades the supported matrix of versions, and removes any unnecessary compatibility checks.

Note that Django 5.1 does not support Python below 3.10, so checking 5.1 with 3.9 is not necessary.

### Verification Process

Tests pass, stuff loads.