### PR TITLE
Select2 jQuery 3.6.x workaround [#188742917]

### DIFF
--- a/tracker/templates/admin/tracker/change_form.html
+++ b/tracker/templates/admin/tracker/change_form.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_form.html" %}
+
+{% block extrahead %}{{ block.super }}
+<script type="application/ecmascript">
+(function() {
+  'use strict';
+  // can be removed when Django 4.2 is no longer supported
+  django.jQuery(document).on('select2:open', () => {
+    document.querySelector('.select2-search--dropdown .select2-search__field').focus();
+  });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188742917

### Description of the Change

https://github.com/select2/select2/issues/5993

Versions of Django prior to 5.x (which is just 4.2 in terms of supported versions) ship with an older version of jQuery that has a focus behavior bug of some kind. Not super clear on the details, but it means that people have to click the autocomplete twice in order to actually start entering text. The workaround is to just put an extra listener on.

### Verification Process

Booted up an admin page on 4.2 with and without the change to verify the change in behavior. 5.0 and 5.1 don't need this fix,  so no noted change in behavior.