### PR TITLE
updates to email templates for post_office compatibility [#188743887]

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,7 +7,7 @@ wheel
 django-ical==1.9.2
 django-paypal==1.1.2
 django-mptt==0.16.0
-django-post-office==3.6.0
+django-post-office==3.9.1
 django-timezone-field==7.0
 djangorestframework==3.15.2
 pre-commit==4.0.1

--- a/tracker/management/commands/default_email_templates.py
+++ b/tracker/management/commands/default_email_templates.py
@@ -3,7 +3,6 @@ import post_office.models
 from tracker import auth, commandutil, prizemail
 
 _default_templates = {
-    auth.default_password_reset_template_name(): auth.default_password_reset_template(),
     auth.default_registration_template_name(): auth.default_registration_template(),
     auth.default_volunteer_registration_template_name(): auth.default_volunteer_registration_template(),
     prizemail.default_prize_winner_template_name(): prizemail.default_prize_winner_template(),


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188743887

### Description of the Change

Autobumps for django-post-office have been failing for a bit because they changed the way that templates were attached to sent emails, which was causing test failures (and possibly real failures, not entirely sure).

This fixes it so that no code tries to send a temporary template to any post-office code.

Also made it so that `reset_url` in the registration templates throws an error, since that's been deprecated for a while.

### Verification Process

Went through the registration flow on a local machine and made sure the emails looked as expected.