### PR TITLE
document PAYPAL_TEST [#188743912]

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ For further reading on what else your server needs to look like:
 
 Docker should also work but support is still in the experimental phases.
 
+**Ensure that `PAYPAL_TEST` is present in your settings.** It should be set to True for development/testing and False for
+production mode.
+
 ### Configuration
 
 The Donation Tracker adds a few configuration options.
@@ -155,6 +158,7 @@ Add the following chunk somewhere in `settings.py`:
 ```python
 ASGI_APPLICATION = 'tracker_development.routing.application'
 CHANNEL_LAYERS = {'default': {'BACKEND': 'channels.layers.InMemoryChannelLayer'}}
+PAYPAL_TEST = True
 
 # Only required if analytics tracking is enabled
 TRACKER_ANALYTICS_INGEST_HOST = 'http://localhost:5000'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -69,6 +69,8 @@ ASGI_APPLICATION = 'tests.routing.application'
 CHANNEL_LAYERS = {'default': {'BACKEND': 'channels.layers.InMemoryChannelLayer'}}
 TEST_OUTPUT_DIR = 'test-results'
 
+PAYPAL_TEST = True
+
 TRACKER_SWEEPSTAKES_URL = 'https://example.com/sweepstakes'
 
 # uncomment this for some additional logging during testing

--- a/tests/test_tracker_settings.py
+++ b/tests/test_tracker_settings.py
@@ -49,16 +49,3 @@ class TestTrackerSettings(TestCase):
                 settings.TRACKER_ENABLE_BROWSABLE_API,
                 msg='TRACKER_ENABLE_BROWSABLE_API',
             )
-
-    def test_paypal_test(self):
-        with override_settings(DEBUG=False):
-            self.assertFalse(
-                settings.PAYPAL_TEST,
-                msg='PAYPAL_TEST',
-            )
-
-        with override_settings(DEBUG=True):
-            self.assertTrue(
-                settings.PAYPAL_TEST,
-                msg='PAYPAL_TEST',
-            )

--- a/tracker/settings.py
+++ b/tracker/settings.py
@@ -47,10 +47,6 @@ class TrackerSettings(object):
     def TRACKER_ENABLE_BROWSABLE_API(self):
         return getattr(settings, 'TRACKER_ENABLE_BROWSABLE_API', settings.DEBUG)
 
-    @property
-    def PAYPAL_TEST(self):
-        return getattr(settings, 'PAYPAL_TEST', settings.DEBUG)
-
     # pass everything else through for convenience
     def __getattr__(self, item):
         return getattr(settings, item)
@@ -114,4 +110,11 @@ def tracker_settings_checks(app_configs, **kwargs):
         )
     if type(TrackerSettings().PAYPAL_TEST) != bool:
         errors.append(Error('PAYPAL_TEST should be a bool', id='tracker.E107'))
+    if not hasattr(settings, 'PAYPAL_TEST'):
+        errors.append(
+            Error(
+                'PAYPAL_TEST is completely missing, set it to True for development/testing and False for production mode',
+                id='tracker.E108',
+            )
+        )
     return errors

--- a/tracker/views/public.py
+++ b/tracker/views/public.py
@@ -70,6 +70,9 @@ def index(request, event=None):
         **eventParams,
     )
 
+    if not settings.PAYPAL_TEST:
+        donations = donations.filter(testdonation=False)
+
     agg = donations.aggregate(
         total=Cast(Coalesce(Sum('amount'), 0), output_field=FloatField()),
         count=Count('amount'),
@@ -422,10 +425,7 @@ def donationindex(request, event=None):
 @cache_page(300)
 def donation_detail(request, pk):
     try:
-        donation = Donation.objects.get(pk=pk)
-
-        if donation.transactionstate != 'COMPLETED':
-            return views_common.tracker_response(request, 'tracker/badobject.html')
+        donation = Donation.objects.completed().get(pk=pk)
 
         event = donation.event
         donor = donation.donor


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188743912

### Description of the Change

Was made aware via somebody setting up a new instance that the default provided by TrackerSettings isn't good enough and it needs to be a real value because of django-paypal itself. Kinda surprised it took this long to notice, actually.

### Verification Process

This is technically feature -removal-, but still verified that the externally visible behavior was as expected.

- whether or not you get redirected to real PayPal or the sandbox
- whether or not the donation page or endpoints return completed test donations