### PR TITLE
do not try to show hidden bids from donation endpoints [#188744956]

### DIFF
--- a/tests/randgen.py
+++ b/tests/randgen.py
@@ -306,9 +306,12 @@ def generate_bid(
     else:
         bid.event = event
     children = []
-    if max_depth > 0 and true_false_or_random(rand, allow_children):
-        if state in ['PENDING', 'DENIED']:
-            bid.allowuseroptions = True
+    assert 0 <= min_children <= max_children
+    if (
+        max_depth > 0
+        and true_false_or_random(rand, allow_children or allowuseroptions)
+        and state not in ['PENDING', 'DENIED']
+    ):
         num_children = rand.randint(min_children, max_children)
         for c in range(0, num_children):
             children.append(
@@ -322,7 +325,11 @@ def generate_bid(
                     run=run,
                     event=event,
                     parent=bid,
-                    state=state,
+                    state=(
+                        state
+                        if allowuseroptions is not True
+                        else rand.choice([state, 'DENIED', 'PENDING'])
+                    ),
                 )
             )
         bid.istarget = False

--- a/tracker/api/views/donations.py
+++ b/tracker/api/views/donations.py
@@ -120,7 +120,7 @@ class DonationViewSet(EventNestedMixin, viewsets.GenericViewSet):
         Processing only occurs on Donations that have settled their transaction
         and were not tests.
         """
-        queryset = super().get_queryset().completed()
+        queryset = super().get_queryset().completed().prefetch_public_bids()
 
         event_id = self.request.query_params.get('event_id')
         if event_id is not None:
@@ -166,9 +166,7 @@ class DonationViewSet(EventNestedMixin, viewsets.GenericViewSet):
         moderation), up to a maximum of TRACKER_PAGINATION_LIMIT donations.
         """
         limit = settings.TRACKER_PAGINATION_LIMIT
-        donations = (
-            self.get_queryset().to_process().prefetch_related('bids', 'bids__bid')
-        )[0:limit]
+        donations = (self.get_queryset().to_process())[0:limit]
         serializer = self.get_serializer(donations, many=True)
         return Response(serializer.data)
 
@@ -180,9 +178,7 @@ class DonationViewSet(EventNestedMixin, viewsets.GenericViewSet):
         up to a maximum of TRACKER_PAGINATION_LIMIT donations.
         """
         limit = settings.TRACKER_PAGINATION_LIMIT
-        donations = (
-            self.get_queryset().to_approve().prefetch_related('bids', 'bids__bid')
-        )[0:limit]
+        donations = (self.get_queryset().to_approve())[0:limit]
         serializer = self.get_serializer(donations, many=True)
         return Response(serializer.data)
 
@@ -195,7 +191,7 @@ class DonationViewSet(EventNestedMixin, viewsets.GenericViewSet):
         TRACKER_PAGINATION_LIMIT donations.
         """
         limit = settings.TRACKER_PAGINATION_LIMIT
-        donations = (self.get_queryset().to_read().prefetch_related('bids'))[0:limit]
+        donations = (self.get_queryset().to_read())[0:limit]
         serializer = self.get_serializer(donations, many=True)
         return Response(serializer.data)
 

--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -619,6 +619,9 @@ class DonationBidQuerySet(models.QuerySet):
     def completed(self):
         return self.filter(donation__transactionstate='COMPLETED')
 
+    def public(self):
+        return self.completed().filter(bid__state__in=Bid.PUBLIC_STATES)
+
 
 class DonationBid(models.Model):
     objects = models.Manager.from_queryset(DonationBidQuerySet)()

--- a/tracker/models/donation.py
+++ b/tracker/models/donation.py
@@ -8,7 +8,7 @@ from functools import reduce
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Avg, Count, FloatField, Max, Q, Sum, signals
+from django.db.models import Avg, Count, FloatField, Max, Prefetch, Q, Sum, signals
 from django.db.models.functions import Cast, Coalesce
 from django.dispatch import receiver
 from django.urls import reverse
@@ -80,6 +80,14 @@ class DonationQuerySet(models.QuerySet):
 
     def to_read(self):
         return self.completed().filter(readstate='READY')
+
+    def prefetch_public_bids(self):
+        from tracker.models import Bid, DonationBid
+
+        return self.prefetch_related(
+            Prefetch('bids', queryset=DonationBid.objects.public()),
+            Prefetch('bids__bid', queryset=Bid.objects.public()),
+        )
 
 
 class DonationManager(models.Manager):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/n/projects/1521291

### Description of the Change

At some point after the last event the Donation endpoints started trying to serialize all attached bids by default, but were not filtering out the hidden bids, causing the permissions check to fail and return a 500 if there were pending/denied/hidden bids attached. This filters those out. Maybe we can add an argument later to return them anyway, but the permissions check gets a little complicated, to this was easier for now.

### Verification Process

Hit the endpoints when a hidden bid was attached and ensured it returned the donations with the bids not included, instead of erroring on the permissions check.