### PR TITLE
add environment variable controls to webpack [#188744555]

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const SOURCE_MAPS = process.env.SOURCE_MAPS ?? false;
 const ANALYZE = process.env.ANALYZE ?? false;
 const NO_MANIFEST = !!process.env.NO_MANIFEST ?? false;
 const PROJECT_ROOT = __dirname;
+const STATIC_ROOT = process.env.STATIC_ROOT ?? '/static/gen';
 
 console.log(PROD ? 'PRODUCTION BUILD' : 'DEVELOPMENT BUILD');
 
@@ -47,7 +48,7 @@ module.exports = {
     filename: PROD ? 'tracker-[name]-[contenthash].js' : 'tracker-[name].js',
     pathinfo: true,
     path: PROJECT_ROOT + '/tracker/static/gen',
-    publicPath: '/static/gen',
+    publicPath: STATIC_ROOT,
   },
   stats: 'minimal',
   module: {
@@ -152,8 +153,15 @@ module.exports = {
     : {
         proxy: [
           {
-            context: ['/admin', '/logout', '/api', '/ui', '/static', '/tracker', '/donate', '/media'],
+            context: ['/tracker/api'],
+            target: process.env.TRACKER_API_HOST || process.env.TRACKER_HOST || 'http://127.0.0.1:8000/',
+            changeOrigin: !!(process.env.TRACKER_API_HOST || process.env.TRACKER_HOST),
+          },
+          {
+            context: ['/admin', '/logout', '/ui', '/static', '/tracker', '/donate', '/media'],
             target: process.env.TRACKER_HOST || 'http://127.0.0.1:8000/',
+            changeOrigin: !!process.env.TRACKER_HOST,
+            cookieDomainRewrite: '',
             ws: true,
           },
         ],


### PR DESCRIPTION

# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188744555

### Description of the Change

These are dev-server/build flags to allow the JS ui to use "real" tracker hosts to ease in data testing, or to override the static asset path when building the bundles.

- TRACKER_API_HOST for /api/ calls
- TRACKER_HOST for anything else (incl /api/ if not otherwise specified)
- STATIC_ROOT to override the path for the webpack templates (this is used at build time if the standard static path is incorrect)

### Verification Process

These are dev server/build only and they work as expected. Been using them for months.