### PR TITLE
add some missing DB prefetches [#188745162]

### DIFF
--- a/tracker/api/views/interview.py
+++ b/tracker/api/views/interview.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class InterviewViewSet(TrackerFullViewSet, EventCreateNestedMixin):
-    queryset = Interview.objects.select_related('event')
+    queryset = Interview.objects.select_related('event').prefetch_related('tags')
     serializer_class = InterviewSerializer
     pagination_class = TrackerPagination
     permission_classes = [*PrivateGenericPermissions('interview', lambda o: o.public)]

--- a/tracker/api/views/run.py
+++ b/tracker/api/views/run.py
@@ -16,8 +16,10 @@ class SpeedRunViewSet(
     EventNestedMixin,
     TrackerFullViewSet,
 ):
-    queryset = SpeedRun.objects.select_related('event').prefetch_related(
-        'runners', 'hosts', 'commentators', 'video_links__link_type'
+    queryset = SpeedRun.objects.select_related(
+        'event', 'priority_tag'
+    ).prefetch_related(
+        'runners', 'hosts', 'commentators', 'video_links__link_type', 'tags'
     )
     serializer_class = SpeedRunSerializer
     pagination_class = TrackerPagination


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188745162

### Description of the Change

Couple of api viewsets are missing select/prefetch which can result in a lot of redundant DB calls. This fixes the ones I'm aware of.

### Verification Process

Since there's no good way to unit test it (counting DB calls is sketchy at best), I hit the API endpoints and looked at the DB traffic and ensured that it the right thing.