### PR TITLE
fix milestone admin search [#188745169]

### DIFF
--- a/tracker/admin/donation.py
+++ b/tracker/admin/donation.py
@@ -405,6 +405,6 @@ class DonorAdmin(RelatedUserMixin, CustomModelAdmin):
 @register(models.Milestone)
 class MilestoneAdmin(EventLockedMixin, EventReadOnlyMixin, CustomModelAdmin):
     autocomplete_fields = ('event',)
-    search_fields = ('event', 'name', 'description', 'short_description')
+    search_fields = ('name', 'description', 'short_description')
     list_filter = ('event',)
     list_display = ('name', 'event', 'start', 'amount', 'visible')


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188745169

### Description of the Change

Removes `event` from Milestone search_fields on the admin page, primarily because it doesn't work, but also I'm not sure what it would even mean.

### Verification Process

Search works instead of spitting a server error.
