### PR TITLE
preserve search filters after using Start Run action [#188749200]

### DIFF
--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -424,15 +424,21 @@ class TestSpeedRunAdmin(TransactionTestCase):
 
         self.client.login(username='admin', password='password')
         with self.subTest('normal run'):
+            cf = f'event__id__exact={self.event1.pk}'
             resp = self.client.post(
                 reverse('admin:start_run', args=(self.run2.id,)),
                 data={
                     'run_time': '0:41:20',
                     'start_time': '%s 12:51:00' % self.event1.date,
                     'run_id': self.run2.id,
+                    '_changelist_filters': cf,
                 },
             )
             self.assertEqual(resp.status_code, 302)
+            self.assertEqual(
+                resp['Location'],
+                reverse('admin:tracker_speedrun_changelist') + '?' + cf,
+            )
             self.run1.refresh_from_db()
             self.assertEqual(self.run1.run_time, '0:41:20')
             self.assertEqual(self.run1.setup_time, '0:09:40')

--- a/tracker/templates/admin/tracker/generic_form.html
+++ b/tracker/templates/admin/tracker/generic_form.html
@@ -20,6 +20,9 @@
         <table>
             {% csrf_token %}
             {{ form }}
+            {% for name, value in extra.items %}
+              <input type="hidden" name="{{ name }}" value="{{ value }}" />
+            {% endfor %}
             <tr>
                 <td>
                     <input type="submit" name="Submit">


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188749200

### Description of the Change

When using a dropdown action it doesn't remember your filters if it ends up being a redirect unless you specifically code this in. Tries to re-use the existing admin logic as much as possible.

### Verification Process

Filters were preserved after using the `Start Run` dropdown action after the change.