### PR TITLE
IPN callback uses celery task instead of broadcasting directly [#188769223]

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.test import TransactionTestCase
 
+from tracker import models
 from tracker.tasks import post_donation_to_postbacks
 
 from . import randgen
@@ -16,7 +17,35 @@ class TestDonationTasks(TransactionTestCase):
         event.save()
         donor = randgen.generate_donor(self.rand)
         donor.save()
-        donation = randgen.generate_donation(self.rand, event=event)
+        parent = randgen.generate_bid(
+            self.rand,
+            allowuseroptions=True,
+            min_children=0,
+            max_children=0,
+            event=event,
+            state='OPENED',
+        )[0]
+        parent.save()
+        approved = randgen.generate_bid(
+            self.rand, parent=parent, allow_children=False, state='OPENED'
+        )[0]
+        approved.save()
+        pending = randgen.generate_bid(self.rand, parent=parent, state='PENDING')[0]
+        pending.save()
+        donation = randgen.generate_donation(self.rand, event=event, min_amount=10)
         donation.save()
+        approved_bid = models.DonationBid.objects.create(
+            donation=donation, bid=approved, amount=5 - donation.amount
+        )
+        pending_bid = models.DonationBid.objects.create(
+            donation=donation, bid=pending, amount=donation.amount - 5
+        )
         post_donation_to_postbacks(donation.id)
-        post.assert_called_with(donation)
+        with self.subTest('called at all'):
+            post.assert_called_with(donation)
+
+            with self.subTest('called with prefetch filter'):
+                self.assertIn(approved_bid, donation.bids.all())
+                self.assertIn(pending_bid, donation.bids.all())
+                self.assertIn(approved_bid, post.call_args[0][0].bids.all())
+                self.assertNotIn(pending_bid, post.call_args[0][0].bids.all())

--- a/tracker/eventutil.py
+++ b/tracker/eventutil.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import traceback
 
 import requests
@@ -11,6 +12,8 @@ import tracker.models as models
 import tracker.search_filters as filters
 import tracker.viewutil as viewutil
 from tracker.consumers.processing import broadcast_new_donation_to_processors
+
+logger = logging.getLogger(__name__)
 
 
 def post_donation_to_postbacks(donation):
@@ -62,6 +65,7 @@ def post_donation_to_postbacks(donation):
                 timeout=5,
             )
     except Exception:
+        logger.exception('Error sending postback')
         viewutil.tracker_log(
             'postback_url', traceback.format_exc(), event=donation.event
         )

--- a/tracker/views/donateviews.py
+++ b/tracker/views/donateviews.py
@@ -13,7 +13,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from paypal.standard.forms import PayPalPaymentsForm
 
-from tracker import eventutil, forms, models, paypalutil, viewutil
+from tracker import forms, models, paypalutil, viewutil
 from tracker.analytics import AnalyticsEventTypes, analytics
 
 from . import common as views_common
@@ -275,7 +275,12 @@ def ipn(request):
                     template=donation.event.donationemailtemplate,
                     context=formatContext,
                 )
-            eventutil.post_donation_to_postbacks(donation)
+            from tracker import settings, tasks
+
+            if settings.TRACKER_HAS_CELERY:
+                tasks.post_donation_to_postbacks.delay(donation.id)
+            else:
+                tasks.post_donation_to_postbacks(donation.id)
             _track_donation_completed(donation)
 
         elif donation.transactionstate == 'CANCELLED':
@@ -288,7 +293,7 @@ def ipn(request):
         viewutil.tracker_log('paypal', str(e))
     except Exception as e:
         # just to make sure we have a record of it somewhere
-        logging.error('ERROR IN IPN RESPONSE, FIX IT')
+        logging.error(f'ERROR IN IPN RESPONSE, FIX IT - {type(e)}', exc_info=e)
         if ipnObj:
             paypalutil.log_ipn(
                 ipnObj,


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188769223

### Description of the Change

This is a combination of a couple things. Firstly, the IPN processing should be calling the celery task. Secondly, the celery task should be filtering out non-public bid information from the callback, since a change back in November this would actually trigger an error during the task to send the donation out over the websocket if the donation had at least one non-public (e.g. a new name to be approved) bid attached to it, which in turn would cause donation processors to miss the payload unless they did a hard refresh.

### Verification Process

Donated via PayPal sandbox both with and without Celery enabled, with a split bid (both an approved bid and a new suggestion) and the payload was received by the donation processing websocket *without* the pending bid information.