### PR TITLE
lots of v2 tweaks [#188791658]

### DIFF
--- a/tests/apiv2/test_ads.py
+++ b/tests/apiv2/test_ads.py
@@ -19,10 +19,10 @@ class TestAd(InterstitialTestCase):
 
     def test_fetch(self):
         with self.subTest('happy path'), self.saveSnapshot():
-            data = self.get_list(user=self.view_user)['results']
+            data = self.get_list(user=self.view_user)
             self.assertV2ModelPresent(self.ad, data)
 
-            data = self.get_list(kwargs={'event_pk': self.event.pk})['results']
+            data = self.get_list(kwargs={'event_pk': self.event.pk})
             self.assertV2ModelPresent(self.ad, data)
 
             data = self.get_detail(self.ad)
@@ -39,7 +39,7 @@ class TestAd(InterstitialTestCase):
     def test_create(self):
         with self.subTest(
             'happy path with ids'
-        ), self.saveSnapshot(), self.assertLogsChanges(2):
+        ), self.saveSnapshot(), self.assertLogsChanges(3):
             data = self.post_new(
                 data={
                     'event': self.event.pk,
@@ -49,6 +49,7 @@ class TestAd(InterstitialTestCase):
                     'ad_name': 'Contoso University',
                     'ad_type': 'IMAGE',
                     'filename': 'foobar.jpg',
+                    'length': '30',
                 },
                 user=self.add_user,
             )
@@ -64,10 +65,28 @@ class TestAd(InterstitialTestCase):
                     'ad_type': 'IMAGE',
                     'filename': 'foobar_2.jpg',
                     'tags': ['test'],
+                    'length': '30',
                 }
             )
             result = models.Ad.objects.get(id=data['id'])
             self.assertV2ModelPresent(result, data)
+
+            data = self.post_new(
+                data={
+                    'event': self.event.pk,
+                    'order': 50,
+                    'suborder': 'last',
+                    'sponsor_name': 'Outer Space',
+                    'ad_name': 'Orion',
+                    'ad_type': 'IMAGE',
+                    'filename': 'foobar_3.jpg',
+                    'tags': [],
+                    'length': '30',
+                }
+            )
+            result = models.Ad.objects.get(id=data['id'])
+            self.assertV2ModelPresent(result, data)
+            self.assertEqual(result.suborder, 1)
 
         with self.subTest(
             'happy path with natural keys'
@@ -81,6 +100,7 @@ class TestAd(InterstitialTestCase):
                     'ad_name': 'Contoso University Natural',
                     'ad_type': 'IMAGE',
                     'filename': 'foobar.jpg',
+                    'length': '30',
                 },
                 user=self.add_user,
             )
@@ -96,6 +116,7 @@ class TestAd(InterstitialTestCase):
                     'ad_type': 'IMAGE',
                     'filename': 'foobar_2.jpg',
                     'tags': ['test'],
+                    'length': '30',
                 }
             )
             result = models.Ad.objects.get(id=data['id'])
@@ -111,6 +132,7 @@ class TestAd(InterstitialTestCase):
                     'ad_name': 'Contoso Universtity',
                     'ad_type': 'IMAGE',
                     'filename': 'foobar_3.jpg',
+                    'length': '30',
                 },
                 user=self.locked_user,
             )

--- a/tests/apiv2/test_api.py
+++ b/tests/apiv2/test_api.py
@@ -21,17 +21,19 @@ class TestAPI(APITestCase):
         )
 
     def test_bad_nesting(self):
-        self.post_new(
-            model_name='interview',
-            data={'anchor': {'no': 'nesting'}},
-            user=self.super_user,
-            status_code=400,
-            expected_error_codes={'anchor': messages.NO_NESTED_CREATES_CODE},
-        )
+        # TODO: re-add a case where this would be true
+        # self.post_new(
+        #     model_name='interview',
+        #     data={'anchor': {'no': 'nesting'}},
+        #     user=self.super_user,
+        #     status_code=400,
+        #     expected_error_codes={'anchor': messages.NO_NESTED_CREATES_CODE},
+        # )
 
         self.post_new(
             model_name='speedrun',
             data={'runners': [{'also': 'nesting'}]},
+            user=self.super_user,
             status_code=400,
             expected_error_codes={'runners': messages.NO_NESTED_CREATES_CODE},
         )

--- a/tests/apiv2/test_bids.py
+++ b/tests/apiv2/test_bids.py
@@ -117,8 +117,8 @@ class TestBidViewSet(TestBidBase, APITestCase):
                             kwargs={'event_pk': self.event.pk, 'feed': 'current'},
                             data={'now': self.run.starttime},
                         )
-                        self.assertV2ModelPresent(opened_bid.data, data['results'])
-                        self.assertV2ModelPresent(challenge.data, data['results'])
+                        self.assertV2ModelPresent(opened_bid.data, data)
+                        self.assertV2ModelPresent(challenge.data, data)
                     with self.suppressSnapshot():
                         with self.subTest('end of run'):
                             data = self.get_list(
@@ -128,10 +128,8 @@ class TestBidViewSet(TestBidBase, APITestCase):
                                     + datetime.timedelta(seconds=1)
                                 },
                             )
-                            self.assertV2ModelNotPresent(
-                                opened_bid.data, data['results']
-                            )
-                            self.assertV2ModelPresent(challenge.data, data['results'])
+                            self.assertV2ModelNotPresent(opened_bid.data, data)
+                            self.assertV2ModelPresent(challenge.data, data)
                         # need `min_runs` or we'll just get the run anyway
                         with self.subTest('an hour ago'):
                             data = self.get_list(
@@ -143,18 +141,16 @@ class TestBidViewSet(TestBidBase, APITestCase):
                                     'delta': 30,
                                 },
                             )
-                            self.assertV2ModelNotPresent(
-                                opened_bid.data, data['results']
-                            )
-                            self.assertV2ModelPresent(challenge.data, data['results'])
+                            self.assertV2ModelNotPresent(opened_bid.data, data)
+                            self.assertV2ModelPresent(challenge.data, data)
 
                         # pathological, but it tests max_runs
                         data = self.get_list(
                             kwargs={'event_pk': self.event.pk, 'feed': 'current'},
                             data={'max_runs': 0, 'now': self.run.starttime},
                         )
-                        self.assertV2ModelNotPresent(opened_bid.data, data['results'])
-                        self.assertV2ModelPresent(challenge.data, data['results'])
+                        self.assertV2ModelNotPresent(opened_bid.data, data)
+                        self.assertV2ModelPresent(challenge.data, data)
 
                 # hidden feeds
                 for feed in ['pending', 'all']:

--- a/tests/apiv2/test_countries.py
+++ b/tests/apiv2/test_countries.py
@@ -18,7 +18,7 @@ class TestCountry(APITestCase):
                 models.Country.objects.count(),
                 msg='Country count did not match',
             )
-            self.assertV2ModelPresent(country, data['results'])
+            self.assertV2ModelPresent(country, data)
 
             with self.subTest('via numeric code'):
                 data = self.get_detail(
@@ -64,7 +64,7 @@ class TestCountryRegions(APITestCase):
                 models.CountryRegion.objects.count(),
                 msg='Region count did not match',
             )
-            self.assertV2ModelPresent(region, data['results'])
+            self.assertV2ModelPresent(region, data)
 
             data = self.get_detail(region, model_name='region')
             self.assertV2ModelPresent(region, data)
@@ -77,4 +77,4 @@ class TestCountryRegions(APITestCase):
                     model_name='country',
                     kwargs={'numeric_or_alpha': region.country.alpha3},
                 )
-                self.assertV2ModelPresent(region, data['results'])
+                self.assertV2ModelPresent(region, data)

--- a/tests/apiv2/test_donation_bids.py
+++ b/tests/apiv2/test_donation_bids.py
@@ -107,7 +107,7 @@ class TestDonationBids(APITestCase):
                 data = self.get_noun(
                     'bids', self.donation, model_name='donations', user=self.view_user
                 )
-                self.assertExactV2Models([self.opened_child_bid], data['results'])
+                self.assertExactV2Models([self.opened_child_bid], data)
 
                 data = self.get_noun(
                     'bids',
@@ -117,7 +117,7 @@ class TestDonationBids(APITestCase):
                     user=self.view_user,
                 )
                 self.assertExactV2Models(
-                    [self.opened_child_bid, self.denied_child_bid], data['results']
+                    [self.opened_child_bid, self.denied_child_bid], data
                 )
 
                 data = self.get_noun(
@@ -133,7 +133,7 @@ class TestDonationBids(APITestCase):
                         self.hidden_child_bid,
                         self.hidden_denied_child_bid,
                     ],
-                    data['results'],
+                    data,
                 )
 
             with self.subTest('via parent bid'):
@@ -144,7 +144,7 @@ class TestDonationBids(APITestCase):
                     user=self.view_user,
                 )
                 self.assertExactV2Models(
-                    [self.opened_child_bid, self.other_child_bid], data['results']
+                    [self.opened_child_bid, self.other_child_bid], data
                 )
 
                 data = self.get_noun(
@@ -160,7 +160,7 @@ class TestDonationBids(APITestCase):
                         self.denied_child_bid,
                         self.other_child_bid,
                     ],
-                    data['results'],
+                    data,
                 )
 
                 data = self.get_noun(
@@ -171,7 +171,7 @@ class TestDonationBids(APITestCase):
                 )
                 self.assertExactV2Models(
                     [self.hidden_child_bid, self.hidden_denied_child_bid],
-                    data['results'],
+                    data,
                 )
 
             with self.subTest('via child bid'):
@@ -182,7 +182,7 @@ class TestDonationBids(APITestCase):
                     user=self.view_user,
                 )
                 self.assertExactV2Models(
-                    [self.opened_child_bid, self.other_child_bid], data['results']
+                    [self.opened_child_bid, self.other_child_bid], data
                 )
 
                 data = self.get_noun(
@@ -191,7 +191,7 @@ class TestDonationBids(APITestCase):
                     model_name='bid',
                     user=self.view_user,
                 )
-                self.assertExactV2Models([self.denied_child_bid], data['results'])
+                self.assertExactV2Models([self.denied_child_bid], data)
 
                 data = self.get_noun(
                     'donations',
@@ -199,7 +199,7 @@ class TestDonationBids(APITestCase):
                     model_name='bid',
                     user=self.view_user,
                 )
-                self.assertExactV2Models([self.hidden_child_bid], data['results'])
+                self.assertExactV2Models([self.hidden_child_bid], data)
 
         with self.subTest('error cases'):
             # strictly speaking, 403, but easier to write the permission check this way

--- a/tests/apiv2/test_donors.py
+++ b/tests/apiv2/test_donors.py
@@ -53,14 +53,12 @@ class TestDonor(APITestCase):
     def test_fetch(self):
         with self.saveSnapshot():
             data = self.get_list(user=self.view_user)
-            self.assertExactV2Models(
-                [self.visible_donor, self.anonymous_donor], data['results']
-            )
+            self.assertExactV2Models([self.visible_donor, self.anonymous_donor], data)
 
             data = self.get_list(user=self.view_user, data={'include_totals': ''})
             self.assertExactV2Models(
                 [self.visible_donor, self.anonymous_donor],
-                data['results'],
+                data,
                 serializer_kwargs={'include_totals': True},
             )
 
@@ -71,7 +69,7 @@ class TestDonor(APITestCase):
             )
             self.assertExactV2Models(
                 [self.visible_donor, self.anonymous_donor],
-                data['results'],
+                data,
                 serializer_kwargs={'include_totals': True, 'event_pk': self.event.id},
             )
 

--- a/tests/apiv2/test_interstitials.py
+++ b/tests/apiv2/test_interstitials.py
@@ -10,6 +10,8 @@ class InterstitialTestCase(APITestCase):
         super().setUp()
         self.run = randgen.generate_run(self.rand, event=self.event, ordered=True)
         self.run.save()
+        self.other_run = randgen.generate_run(self.rand, event=self.event, ordered=True)
+        self.other_run.save()
 
     def test_interstitial_common(self):
         if getattr(self, 'model_name', None) is None:

--- a/tests/apiv2/test_interviews.py
+++ b/tests/apiv2/test_interviews.py
@@ -26,7 +26,7 @@ class TestInterviews(InterstitialTestCase):
                 data = self.get_detail(self.public_interview)
                 self.assertV2ModelPresent(self.public_interview, data)
 
-                data = self.get_list()['results']
+                data = self.get_list()
                 self.assertV2ModelPresent(self.public_interview, data)
                 self.assertV2ModelNotPresent(self.private_interview, data)
 
@@ -34,7 +34,7 @@ class TestInterviews(InterstitialTestCase):
                 data = self.get_detail(self.private_interview, user=self.view_user)
                 self.assertV2ModelPresent(self.private_interview, data)
 
-                data = self.get_list(data={'all': ''})['results']
+                data = self.get_list(data={'all': ''})
                 self.assertV2ModelPresent(self.public_interview, data)
                 self.assertV2ModelPresent(self.private_interview, data)
 

--- a/tests/apiv2/test_milestones.py
+++ b/tests/apiv2/test_milestones.py
@@ -55,7 +55,7 @@ class TestMilestones(APITestCase):
                 serialized = MilestoneSerializer(self.public_milestone)
                 data = self.get_detail(self.public_milestone)
                 self.assertV2ModelPresent(serialized.data, data)
-                data = self.get_list()['results']
+                data = self.get_list()
                 self.assertV2ModelPresent(self.public_milestone, data)
                 self.assertV2ModelNotPresent(self.hidden_milestone, data)
                 event_data = self.get_list(kwargs={'event_pk': self.event.pk})[
@@ -72,7 +72,7 @@ class TestMilestones(APITestCase):
                 serialized = MilestoneSerializer(self.hidden_milestone)
                 data = self.get_detail(self.hidden_milestone, user=self.view_user)
                 self.assertV2ModelPresent(serialized.data, data)
-                data = self.get_list(data={'all': ''})['results']
+                data = self.get_list(data={'all': ''})
                 self.assertV2ModelPresent(self.public_milestone, data)
                 self.assertV2ModelPresent(self.hidden_milestone, data)
 

--- a/tests/apiv2/test_runs.py
+++ b/tests/apiv2/test_runs.py
@@ -357,6 +357,7 @@ class TestRunSerializer(TestSpeedRunBase, APITestCase):
             'category': run.category,
             'coop': run.coop,
             'onsite': run.onsite,
+            'layout': run.layout,
             'runners': TalentSerializer(run.runners, many=True).data,
             'description': run.description,
             'console': run.console,

--- a/tests/apiv2/test_talent.py
+++ b/tests/apiv2/test_talent.py
@@ -48,7 +48,7 @@ class TestTalent(APITestCase):
             with self.subTest('generic lists'):
                 # participants of any kind
 
-                data = self.get_list()['results']
+                data = self.get_list()
                 self.assertExactV2Models(
                     {
                         self.runner,
@@ -61,13 +61,17 @@ class TestTalent(APITestCase):
                     data,
                 )
 
-                data = self.get_list(kwargs={'event_pk': self.event.pk})['results']
+                data = self.get_list(kwargs={'event_pk': self.event.pk})
                 self.assertExactV2Models(
                     {self.runner, self.host, self.commentator, self.spread_talent}, data
                 )
 
+            with self.subTest('search'):
+                data = self.get_list(data={'name': self.runner.name})
+                self.assertExactV2Models([self.runner], data)
+
             with self.subTest('filtered lists'):
-                data = self.get_noun('runners')['results']
+                data = self.get_noun('runners')
                 self.assertExactV2Models(
                     {self.runner, self.other_runner, self.spread_talent}, data
                 )
@@ -79,10 +83,10 @@ class TestTalent(APITestCase):
 
                 data = self.get_noun(
                     'runners', kwargs={'event_pk': self.other_event.pk}
-                )['results']
+                )
                 self.assertExactV2Models({self.other_runner}, data)
 
-                data = self.get_noun('hosts')['results']
+                data = self.get_noun('hosts')
                 self.assertExactV2Models({self.host, self.spread_talent}, data)
 
                 data = self.get_noun('hosts', kwargs={'event_pk': self.other_event.pk})[
@@ -90,7 +94,7 @@ class TestTalent(APITestCase):
                 ]
                 self.assertEqual(len(data), 0)
 
-                data = self.get_noun('commentators')['results']
+                data = self.get_noun('commentators')
                 self.assertExactV2Models({self.commentator, self.spread_talent}, data)
 
                 data = self.get_noun(

--- a/tests/util.py
+++ b/tests/util.py
@@ -709,6 +709,8 @@ class APITestCase(TransactionTestCase, AssertionHelpers):
         if missing_ok has any values, then those explicit keys are allowed to be missing, but not unequal (useful for
          nested models)
         """
+        if isinstance(data, dict) and 'results' in data:
+            data = data['results']
         if not isinstance(data, list):
             data = [data]
         missing_ok = []
@@ -758,6 +760,10 @@ class APITestCase(TransactionTestCase, AssertionHelpers):
             )
 
     def assertV2ModelNotPresent(self, unexpected_model, data):
+        if isinstance(data, dict) and 'results' in data:
+            data = data['results']
+        if not isinstance(data, list):
+            data = [data]
         if isinstance(unexpected_model, ModelSerializer):
             unexpected_model = unexpected_model.data
         elif not isinstance(unexpected_model, dict):
@@ -803,6 +809,10 @@ class APITestCase(TransactionTestCase, AssertionHelpers):
         if data is None:
             data = unexpected_models
             unexpected_models = []
+        if isinstance(data, dict) and 'results' in data:
+            data = data['results']
+        if not isinstance(data, list):
+            data = [data]
         if exact_count and len(data) != len(expected_models):
             problems.append(
                 f'Data length mismatch, expected {len(expected_models)}, got {len(data)}'

--- a/tracker/api/filters.py
+++ b/tracker/api/filters.py
@@ -199,7 +199,7 @@ class BidFilter(TrackerFilter):
                 queryset = queryset.pending()
             # no change for 'all'
         elif feed is not None:
-            if feed.upper() in Bid.ALL_FEEDS:
+            if feed.lower() in Bid.ALL_FEEDS:
                 logger.warning(f'unhandled valid bid feed `{feed}`')
             raise NotFound(
                 detail=messages.INVALID_FEED % feed, code=messages.INVALID_FEED_CODE
@@ -276,3 +276,9 @@ class PrizeFilter(TrackerFilter):
             )
 
         return super().filter_queryset(request, queryset, view)
+
+
+class TalentFilter(TrackerFilter):
+    filter_keys = {
+        'name': 'name__icontains',
+    }

--- a/tracker/api/views/ad.py
+++ b/tracker/api/views/ad.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class AdViewSet(TrackerFullViewSet, EventCreateNestedMixin):
-    queryset = Ad.objects.select_related('event')
+    queryset = Ad.objects.select_related('event').prefetch_related(
+        'tags',
+    )
     serializer_class = AdSerializer
     pagination_class = TrackerPagination
     permission_classes = [tracker_permission('tracker.view_ad')]

--- a/tracker/api/views/interview.py
+++ b/tracker/api/views/interview.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class InterviewViewSet(TrackerFullViewSet, EventCreateNestedMixin):
-    queryset = Interview.objects.select_related('event').prefetch_related('tags')
+    queryset = Interview.objects.select_related('event').prefetch_related(
+        'tags',
+    )
     serializer_class = InterviewSerializer
     pagination_class = TrackerPagination
     permission_classes = [*PrivateGenericPermissions('interview', lambda o: o.public)]

--- a/tracker/api/views/me.py
+++ b/tracker/api/views/me.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers, viewsets
 from rest_framework.response import Response
 
+from tracker.api.views import RemoveBrowsableMixin
+
 
 class MeSerializer(serializers.Serializer):
     username = serializers.CharField()
@@ -9,8 +11,8 @@ class MeSerializer(serializers.Serializer):
     permissions = serializers.ListField(child=serializers.CharField())
 
 
-class MeViewSet(viewsets.GenericViewSet):
-    def list(self, request):
+class MeViewSet(RemoveBrowsableMixin, viewsets.GenericViewSet):
+    def list(self, request, *args, **kwargs):
         """
         Return information about the user that made the request.
         """

--- a/tracker/api/views/prize.py
+++ b/tracker/api/views/prize.py
@@ -1,4 +1,5 @@
 from tracker.api.filters import PrizeFilter
+from tracker.api.pagination import TrackerPagination
 from tracker.api.permissions import PrizeFeedPermission, PrizeStatePermission
 from tracker.api.serializers import PrizeSerializer
 from tracker.api.views import (
@@ -20,6 +21,7 @@ class PrizeViewSet(
     serializer_class = PrizeSerializer
     permission_classes = [PrizeFeedPermission, PrizeStatePermission]
     filter_backends = [PrizeFilter]
+    pagination_class = TrackerPagination
 
     def get_feed(self):
         return self.kwargs.get('feed', None)

--- a/tracker/api/views/talent.py
+++ b/tracker/api/views/talent.py
@@ -1,6 +1,7 @@
 from django.db.models import Q
 from rest_framework.decorators import action
 
+from tracker.api.filters import TalentFilter
 from tracker.api.pagination import TrackerPagination
 from tracker.api.serializers import TalentSerializer
 from tracker.api.views import (
@@ -16,6 +17,7 @@ class TalentViewSet(FlatteningViewSetMixin, EventNestedMixin, TrackerFullViewSet
     queryset = Talent.objects.all()
     serializer_class = TalentSerializer
     pagination_class = TrackerPagination
+    filter_backends = [TalentFilter]
 
     def is_event_locked(self, obj=None):
         # talent never actually belongs to an event, just associated with it
@@ -34,22 +36,30 @@ class TalentViewSet(FlatteningViewSetMixin, EventNestedMixin, TrackerFullViewSet
         ).distinct()
 
     def _fetch_sublist(self, query_filter):
-        queryset = self.get_queryset().filter(query_filter)
+        # bypass the usual event filter because we're doing it already
+        queryset = super().get_queryset().filter(query_filter)
         page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
+    def _sublist_event_filter(self, key):
+        return (
+            Q(**{f'{key}__event': event})
+            if (event := self.get_event_from_request())
+            else ~Q(**{key: None})
+        )
+
     @action(detail=False)
     def runners(self, *args, **kwargs):
-        return self._fetch_sublist(~Q(runs=None))
+        return self._fetch_sublist(self._sublist_event_filter('runs'))
 
     @action(detail=False)
     def hosts(self, *args, **kwargs):
-        return self._fetch_sublist(~Q(hosting=None))
+        return self._fetch_sublist(self._sublist_event_filter('hosting'))
 
     @action(detail=False)
     def commentators(self, *args, **kwargs):
-        return self._fetch_sublist(~Q(commentating=None))
+        return self._fetch_sublist(self._sublist_event_filter('commentating'))
 
     # these are all m2m relationships, so we still include the nested key from the run, even though it can be
     #  partially redundant


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188791658

### Description of the Change

Lots of little tweaks were made either during AGDQ or shortly thereafter, and rather than make individual PRs for them they're all grouped together here:

- fix a couple bugs with the talent endpoint not returning the proper filters
- change `anchor` field to just the primary key (realized it was extremely verbose when querying lists of ads/interviews)
- include `length` on all interstitials (was on interviews, shoulda been on ads too)
- include `receivername` and `receiver_short` on events
- include `layout` on runs
- paginate prizes
- fix a bug with `last` suborder when no other interstitials exist in that order slot
- add searching for talent by name
- remove browseable API on all TrackerReadViewSet instances (this was already mostly a thing, just a refactor)
- fix `me` endpoint crashing when format is specified (e.g. `/me.json`)
- check for permissions on the root serializer if possible (relevant when trying to serialize a Donation with hidden bid instances)

### Verification Process

Most of this stuff was already live during the event, and most of them are just field tweaks, so I hit all the endpoints in question to verify that they were as expected.