### PR TITLE
better Talent Event filter on API [#188843690]

### DIFF
--- a/tests/apiv2/test_donors.py
+++ b/tests/apiv2/test_donors.py
@@ -98,7 +98,7 @@ class TestDonor(APITestCase):
         data = self.get_list(
             user=self.view_user, kwargs={'event_pk': self.locked_event.id}
         )
-        self.assertEqual(len(data['results']), 0, msg='Donor list was not empty')
+        self.assertEmptyModels(data)
 
         with self.subTest('error cases'):
             with self.subTest('no donations on event'):

--- a/tests/apiv2/test_talent.py
+++ b/tests/apiv2/test_talent.py
@@ -103,9 +103,7 @@ class TestTalent(APITestCase):
                     {self.runner, self.other_runner, self.spread_talent}, data
                 )
 
-                data = self.get_noun('runners', kwargs={'event_pk': self.event.pk})[
-                    'results'
-                ]
+                data = self.get_noun('runners', kwargs={'event_pk': self.event.pk})
                 self.assertExactV2Models({self.runner, self.spread_talent}, data)
 
                 data = self.get_noun(
@@ -116,34 +114,32 @@ class TestTalent(APITestCase):
                 data = self.get_noun('hosts')
                 self.assertExactV2Models({self.host, self.spread_talent}, data)
 
-                data = self.get_noun('hosts', kwargs={'event_pk': self.other_event.pk})[
-                    'results'
-                ]
-                self.assertEqual(len(data), 0)
+                data = self.get_noun('hosts', kwargs={'event_pk': self.other_event.pk})
+                self.assertEmptyModels(data)
 
                 data = self.get_noun('commentators')
                 self.assertExactV2Models({self.commentator, self.spread_talent}, data)
 
                 data = self.get_noun(
                     'commentators', kwargs={'event_pk': self.other_event.pk}
-                )['results']
-                self.assertEqual(len(data), 0)
+                )
+                self.assertEmptyModels(data)
 
                 data = self.get_noun('interviewers')
                 self.assertExactV2Models({self.interviewer, self.spread_talent}, data)
 
                 data = self.get_noun(
                     'interviewers', kwargs={'event_pk': self.other_event.pk}
-                )['results']
-                self.assertEqual(len(data), 0)
+                )
+                self.assertEmptyModels(data)
 
                 data = self.get_noun('subjects')
                 self.assertExactV2Models({self.subject, self.spread_talent}, data)
 
                 data = self.get_noun(
                     'subjects', kwargs={'event_pk': self.other_event.pk}
-                )['results']
-                self.assertEqual(len(data), 0)
+                )
+                self.assertEmptyModels(data)
 
             with self.subTest('reverse lists'):
                 for noun in [


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188843690

### Description of the Change

This is a performance fix, not a functionality fix. The `Q|` filter approach apparently is not suitable for this sort of table layout, but in this case a `.union` and refetch on the queryset will work instead, since the number of hits for an event filter is relatively low.

### Verification Process

I had to deploy it to the real server to test it, and it went from taking several seconds to respond to being nearly instant.