### PR TITLE
post local donations to socket when saved for the first time [#188844963]

### DIFF
--- a/tracker/eventutil.py
+++ b/tracker/eventutil.py
@@ -27,8 +27,9 @@ def post_donation_to_postbacks(donation):
         'timereceived': str(donation.timereceived),
         'comment': donation.comment,
         'amount': float(donation.amount),
-        'donor__visibility': donation.donor.visibility,
-        'donor__visiblename': donation.donor.visible_name(),
+        # FIXME: only happens in tests
+        'donor__visibility': donation.donor and donation.donor.visibility,
+        'donor__visiblename': donation.donor and donation.donor.visible_name(),
         'new_total': float(total),
         'domain': donation.domain,
         'bids': [

--- a/tracker/models/donation.py
+++ b/tracker/models/donation.py
@@ -345,9 +345,17 @@ class Donation(models.Model):
         # TODO: language detection again?
         self.commentlanguage = 'un'
 
-        # TODO: send websocket payload when Donation is local and new
+        post = self.id is None and self.domain == 'LOCAL'
 
         super(Donation, self).save(*args, **kwargs)
+
+        if post:
+            from .. import settings, tasks
+
+            if settings.TRACKER_HAS_CELERY:
+                tasks.post_donation_to_postbacks.delay(self.id)
+            else:
+                tasks.post_donation_to_postbacks(self.id)
 
     def __str__(self):
         donor_name = self.donor.visible_name() if self.donor else '(Unconfirmed)'


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188844963

### Description of the Change

When saving a locally entered donation (from a sponsor that didn't use PayPal for example), it wouldn't show up on the live feed until somebody manually sent it. Now when a new local donation is saved, it will be sent to the websockets/postbacks.

### Verification Process

Saved a new local donation and saw it come over the websocket without any additional steps. Then saved it again to make sure it didn't repeat itself.