### PR TITLE
add fields to Event API v2 [#188848696]

### DIFF
--- a/bundles/public/apiv2/Models.ts
+++ b/bundles/public/apiv2/Models.ts
@@ -30,6 +30,8 @@ export interface Event extends ModelBase {
   receiver_short: string;
   paypalcurrency: string;
   use_one_step_screening: boolean;
+  allow_donations: boolean;
+  locked: boolean;
 }
 
 export type DonationTransactionState = 'COMPLETED' | 'PENDING' | 'CANCELLED' | 'FLAGGED';

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -717,6 +717,8 @@ class EventSerializer(PrimaryOrNaturalKeyLookup, TrackerModelSerializer):
             'receivername',
             'receiver_short',
             'use_one_step_screening',
+            'locked',
+            'allow_donations',
             # 'allowed_prize_countries',
             # 'disallowed_prize_regions',
         )


### PR DESCRIPTION
- allow_donations
- locked

# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188848696

### Description of the Change

Just adding a couple more fields to the Event API. While trying to move things off v1, realized that there were parts of the interface that read these.

### Verification Process

API returns the fields now. Typescript checks still pass after rechecking the snapshots.