### PR TITLE
enable no-unused-vars for Typescript files [#188848715]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -90,7 +90,17 @@
     {
       "files": ["**/*.ts", "**/*.tsx"],
       "parser": "@typescript-eslint/parser",
-      "plugins": ["@typescript-eslint"]
+      "plugins": ["@typescript-eslint"],
+      "rules": {
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "vars": "all",
+            "args": "none",
+            "varsIgnorePattern": "^React$|^_$"
+          }
+        ]
+      }
     },
     {
       "files": ["**/*Spec.ts", "**/*Spec.tsx", "**/*.spec.ts", "**/*.spec.tsx", "**/*Spec.js", "spec/**"],

--- a/bundles/@types/matchers-types.d.ts
+++ b/bundles/@types/matchers-types.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // It's mad about the T but it needs to match the other namespace in jasmine
 
 declare namespace jasmine {

--- a/bundles/processing/modules/processing/ProcessingModeSelector.tsx
+++ b/bundles/processing/modules/processing/ProcessingModeSelector.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Item, Select } from '@spyrothon/sparx';
 
 import { ProcessingMode } from './ProcessingStore';
 

--- a/bundles/processing/modules/reading/ReadDonationsStores.tsx
+++ b/bundles/processing/modules/reading/ReadDonationsStores.tsx
@@ -1,9 +1,0 @@
-import create from 'zustand';
-
-interface ReadDonationsStoreState {
-  navigation: Array<[string, string[]]>;
-}
-
-const useReadDonationsStore = create<ReadDonationsStoreState>()(() => ({
-  navigation: [],
-}));

--- a/bundles/public/apiv2/HTTPUtils.ts
+++ b/bundles/public/apiv2/HTTPUtils.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios from 'axios';
 
 const instance = axios.create();
 

--- a/bundles/public/apiv2/actions/models.ts
+++ b/bundles/public/apiv2/actions/models.ts
@@ -1,5 +1,3 @@
-import { add } from 'lodash';
-
 import { SafeDispatch } from '@public/api/useDispatch';
 import Endpoints from '@public/apiv2/Endpoints';
 import HTTPUtils from '@public/apiv2/HTTPUtils';

--- a/bundles/public/errorBoundary.tsx
+++ b/bundles/public/errorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import Header from '@uikit/Header';
 import Text from '@uikit/Text';


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Issue from Pivotal Tracker

https://www.pivotaltracker.com/story/show/188848715

### Description of the Change

Realized that the linter rule about unused variables wasn't being run on Typescript files. This fixes that and any associated errors. Including one entire file that was completely unused.

### Verification Process

None of this stuff was used, so as long as the tests pass, then we're good. Unless there's a bug in the linter, I suppose.