### PR TITLE
Fix single forgotten dollar sign in incentive list

### DIFF
--- a/bundles/tracker/donation/components/DonationBidForm.tsx
+++ b/bundles/tracker/donation/components/DonationBidForm.tsx
@@ -156,7 +156,7 @@ const DonationBidForm = (props: DonationBidFormProps) => {
               look={Checkbox.Looks.DENSE}
               onChange={handleNewChoice(choice.id)}>
               <Checkbox.Header>{choice.name}</Checkbox.Header>
-              <span className={styles.choiceAmount}>${choice.amount}</span>
+              <span className={styles.choiceAmount}>{CurrencyUtils.asCurrency(choice.amount, { currency })}</span>
             </Checkbox>
           ))
         : null}


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.


### Issue from Pivotal Tracker

Link to the issue from the [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1521291) that your change addresses. (Expand the story and click the link icon to copy the link to your clipboard.)

N/A

### Description of the Change

I thought I found all the dollar signs in the tracker with the euro PR, it looks like this one slipped away from my grasp during my testing because I only tested incentives without bids.


### Verification Process

Ran the tracker locally and verified that the UI changed accordingly. Also did a search through all files again to check if a missed more than this one.

Before:
![](https://youwontbuyanotherdomain.com/3GjM8hVqTg.jpg)

After:
![](https://youwontbuyanotherdomain.com/yYB4Ohc17L.jpg)


