### PR TITLE
add `view_bid` permission to Bid Tracker group [#188941913]

### DIFF
--- a/bundles/processing/App.tsx
+++ b/bundles/processing/App.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Route, Routes } from 'react-router';
+import { Text } from '@faulty/gdq-design';
 
 import { useConstants } from '@common/Constants';
 import APIClient from '@public/apiv2/APIClient';
@@ -60,6 +61,7 @@ export default function App() {
             <Route path="/v2/:eventId/processing/read" element={<ReadDonations />} />
           </>
         )}
+        <Route path="*" element={<Text>That page either does not exist or you do not have access to it.</Text>} />
       </Routes>
     </AppContainer>
   );

--- a/spec/fixtures/donation.ts
+++ b/spec/fixtures/donation.ts
@@ -1,4 +1,4 @@
-import { Donation } from '../../bundles/public/apiv2/APITypes';
+import { APIDonation as Donation } from '@public/apiv2/APITypes';
 
 export function getDonation(overrides?: Partial<Donation>): Donation {
   return {

--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -211,6 +211,7 @@ class EventAdmin(RelatedUserMixin, CustomModelAdmin):
                 tracker_group = auth.Group.objects.get_or_create(name='Bid Tracker')[0]
                 tracker_codenames = [
                     'change_donation',
+                    'view_bid',
                     'view_donation',
                     'view_comments',
                     # bid assignment


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

After adjusting the required permissions for the processing page, a user had issues accessing them, and I forgot to adjust the stock permissions for the `Bid Tracker` group. This addresses that.

While in there, I also made it more explicit why the page wasn't working, because the failure mode for lacking the permissions was a completely blank page.

### Verification Process

Tried to view the page as a user without the permissions and got the expected error message. Added the correct permissions, and everything works again.