### PR TITLE
disallow certain empty M2M fields on API create/update [#188940480]

### DIFF
--- a/tests/apiv2/test_interviews.py
+++ b/tests/apiv2/test_interviews.py
@@ -145,6 +145,15 @@ class TestInterviews(InterstitialTestCase):
                 },
             )
 
+        with self.subTest('blank interviewers'):
+            self.post_new(
+                data={
+                    'interviewers': [],
+                },
+                status_code=400,
+                expected_error_codes={'interviewers': {'non_field_errors': 'empty'}},
+            )
+
     def test_patch(self):
         with self.subTest('happy path'), self.saveSnapshot(), self.assertLogsChanges(2):
             data = self.patch_detail(
@@ -188,4 +197,12 @@ class TestInterviews(InterstitialTestCase):
                     'interviewers': messages.INVALID_PK_CODE,
                     'subjects': messages.INVALID_NATURAL_KEY_CODE,
                 },
+            )
+
+        with self.subTest('blank interviewers'):
+            self.patch_detail(
+                self.public_interview,
+                data={'interviewers': []},
+                status_code=400,
+                expected_error_codes={'interviewers': {'non_field_errors': 'empty'}},
             )

--- a/tests/apiv2/test_runs.py
+++ b/tests/apiv2/test_runs.py
@@ -218,6 +218,15 @@ class TestRunViewSet(TestSpeedRunBase, APITestCase):
                 },
             )
 
+        with self.subTest('blank runner list'), self.assertLogsChanges(0):
+            self.post_new(
+                data={'runners': []},
+                status_code=400,
+                expected_error_codes={
+                    'runners': {'non_field_errors': 'empty'},
+                },
+            )
+
         with self.subTest(
             'event route smoke test'
         ), self.saveSnapshot(), self.assertLogsChanges(1):
@@ -335,6 +344,16 @@ class TestRunViewSet(TestSpeedRunBase, APITestCase):
                 data={'video_links': []},
                 status_code=400,
                 expected_error_codes={'video_links': 'no_nested_updates'},
+            )
+
+        with self.subTest('blank runner list'), self.assertLogsChanges(0):
+            self.patch_detail(
+                self.run1,
+                data={'runners': []},
+                status_code=400,
+                expected_error_codes={
+                    'runners': {'non_field_errors': 'empty'},
+                },
             )
 
         with self.subTest('permissions smoke tests'):

--- a/tests/util.py
+++ b/tests/util.py
@@ -14,6 +14,7 @@ import sys
 import time
 import unittest
 import zoneinfo
+from collections import defaultdict
 from decimal import Decimal
 
 import msgpack
@@ -482,7 +483,7 @@ class APITestCase(TransactionTestCase, AssertionHelpers, AssertionModelHelpers):
         return getattr(response, 'data', None)
 
     def _check_nested_codes(self, data, codes):
-        mismatched_codes = {}
+        mismatched_codes = defaultdict(list)
         if not isinstance(data, (list, dict, ErrorDetail)):
             raise TypeError(f'Expected list, dict, or ErrorDetail, got {type(data)}')
         if isinstance(data, ErrorDetail):
@@ -511,17 +512,19 @@ class APITestCase(TransactionTestCase, AssertionHelpers, AssertionModelHelpers):
             actual_codes = {e.code for e in data}
             for code in codes:
                 if code not in actual_codes:
-                    mismatched_codes.setdefault('__any__', []).append(code)
+                    mismatched_codes['__any__'].append(code)
         elif isinstance(codes, dict):
             if isinstance(data, list):
                 for d in data:
                     mismatched_codes.update(self._check_nested_codes(d, codes))
+                else:
+                    mismatched_codes.update(self._check_nested_codes({}, codes))
             elif isinstance(data, dict):
                 for field, code in codes.items():
                     nested = self._check_nested_codes(data.get(field, []), code)
                     if nested:
                         nested.pop('__any__', [])
-                        mismatched_codes.setdefault(field, []).append(code)
+                        mismatched_codes[field].append(code)
         else:
             raise TypeError(f'Expected list, str, or dict, got {type(codes)}')
         return mismatched_codes

--- a/tracker/api/serializers.py
+++ b/tracker/api/serializers.py
@@ -852,7 +852,7 @@ class SpeedRunSerializer(
 ):
     type = ClassNameField()
     event = EventSerializer()
-    runners = TalentSerializer(many=True)
+    runners = TalentSerializer(many=True, allow_empty=False)
     hosts = TalentSerializer(many=True, required=False)
     commentators = TalentSerializer(many=True, required=False)
     video_links = VideoLinkSerializer(many=True, required=False)
@@ -1007,7 +1007,7 @@ class AdSerializer(InterstitialSerializer):
 
 
 class InterviewSerializer(InterstitialSerializer):
-    interviewers = TalentSerializer(many=True)
+    interviewers = TalentSerializer(many=True, allow_empty=False)
     subjects = TalentSerializer(many=True, required=False)
 
     class Meta:


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

While importing the interviews for Frost Fatales 2025, an error in my script accidentally sent `interviewers` as an empty list, but the API accepted it anyway.

Realized that the same happened with `runners`.

Both fields were missing `allow_blank=False` in their API serializers. This has been corrected and test cases added.

### Verification Process

Sent JSON requests trying to set the mentioned fields to blank lists, both POST and PATCH, and got the expected errors (400 with validation errors).