### PR TITLE
resend events when a new DonationBid is saved to a local Donation [#188947668]

### DIFF
--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -692,6 +692,14 @@ class DonationBid(models.Model):
                 },
             )
 
+            if self.donation.domain == 'LOCAL':
+                from .. import settings, tasks
+
+                if settings.TRACKER_HAS_CELERY:
+                    tasks.post_donation_to_postbacks.delay(self.donation_id)
+                else:
+                    tasks.post_donation_to_postbacks(self.donation_id)
+
     @property
     def speedrun(self):
         return self.bid.speedrun


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Follow-on to #782, turns out that the DonationBid entries aren't necessarily saved by the time those events get fired. Either because Celery is disabled, or because of a race condition. This mostly matters for pages that are trying to show up to date information on Bids, since the correct total won't be reflected until another event that includes that information is received.

Bit of a sledgehammer approach maybe, but resending the Donation payloads when a new DonationBid is saved to a `LOCAL` donation should be sufficient. All pages I'm aware of are robust enough to deal with the mostly-repeated Donation event.

### Verification Process

Saved a new Donation in the admin page with an attached Bid while having the Process Donations page open in another tab, and saw two events in the Websocket, the latter of which included the DonationBid information, and the attachment was displayed in the Donation row.

Then saved it again, and did -not- see another event.