### PR TITLE
fix Donate form after UI Prizes v2 changes [#188967088]

### DIFF
--- a/bundles/tracker/App.tsx
+++ b/bundles/tracker/App.tsx
@@ -9,13 +9,11 @@ import { useTrackerInit } from '@public/apiv2/hooks';
 import Donate from '@tracker/donation/components/Donate';
 import PrizeDetail from '@tracker/prizes/components/PrizeDetail';
 import Prizes from '@tracker/prizes/components/Prizes';
-import { createTrackerStore } from '@tracker/Store';
+import { OldStoreContext } from '@tracker/Store';
 
 import { AnalyticsEvent, setAnalyticsURL, track } from './analytics/Analytics';
 import DonateInitializer from './donation/components/DonateInitializer';
 import NotFound from './router/components/NotFound';
-
-const oldStore = createTrackerStore();
 
 function PrizeRoute() {
   const { prizeId } = useParams();
@@ -24,11 +22,12 @@ function PrizeRoute() {
 
 function DonateRoute() {
   const { eventId } = useParams();
-  return (
+  const oldStore = React.useContext(OldStoreContext);
+  return oldStore ? (
     <Provider store={oldStore}>
       <Donate eventId={eventId!} />
     </Provider>
-  );
+  ) : null;
 }
 
 const App = (props: React.ComponentProps<typeof DonateInitializer>) => {

--- a/bundles/tracker/Store.ts
+++ b/bundles/tracker/Store.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { composeWithDevTools } from '@redux-devtools/extension';
@@ -16,6 +17,8 @@ const composeEnhancers = composeWithDevTools({
   // Uncomment to see stacktraces in the devtools for each action fired.
   // trace: true,
 });
+
+export const OldStoreContext = React.createContext<ReturnType<typeof createTrackerStore> | null>(null);
 
 export function createTrackerStore() {
   return createStore(combinedReducer, composeEnhancers(applyMiddleware(thunk)));

--- a/bundles/tracker/donation/__tests__/validateDonation.spec.ts
+++ b/bundles/tracker/donation/__tests__/validateDonation.spec.ts
@@ -3,7 +3,6 @@ import { Bid, Donation } from '../DonationTypes';
 import validateDonation, { DonationErrors } from '../validateDonation';
 
 const eventDetails = {
-  csrfToken: 'testing',
   currency: 'USD',
   receiverName: 'a beneficiary',
   receiverPrivacyPolicy: '',

--- a/bundles/tracker/donation/components/Donate.tsx
+++ b/bundles/tracker/donation/components/Donate.tsx
@@ -3,6 +3,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 
 import { useConstants } from '@common/Constants';
+import { useCSRFToken } from '@public/apiv2/helpers/auth';
 import { useCachedCallback } from '@public/hooks/useCachedCallback';
 import * as CurrencyUtils from '@public/util/currency';
 import Anchor from '@uikit/Anchor';
@@ -88,11 +89,13 @@ const Donate = (props: DonateProps) => {
     [dispatch],
   );
 
+  const csrfToken = useCSRFToken();
+
   const handleSubmit = React.useCallback(() => {
     if (donationValidity.valid) {
-      DonationActions.submitDonation(donateUrl, eventDetails.csrfToken, donation, bids);
+      DonationActions.submitDonation(donateUrl, csrfToken, donation, bids);
     }
-  }, [donateUrl, eventDetails.csrfToken, donation, bids, donationValidity]);
+  }, [csrfToken, donateUrl, donation, bids, donationValidity]);
 
   const updateName = React.useCallback((name: string) => updateDonation({ name }), [updateDonation]);
   const updateEmail = React.useCallback((email: string) => updateDonation({ email }), [updateDonation]);

--- a/bundles/tracker/donation/components/DonateInitializer.tsx
+++ b/bundles/tracker/donation/components/DonateInitializer.tsx
@@ -69,7 +69,6 @@ type DonateInitializerProps = {
   donateUrl: string;
   prizes: Prize[];
   prizesUrl: string;
-  csrfToken: string;
 };
 
 const DonateInitializer = (props: DonateInitializerProps) => {
@@ -83,7 +82,6 @@ const DonateInitializer = (props: DonateInitializerProps) => {
     minimumDonation = 1,
     maximumDonation = Infinity,
     step = 0.01,
-    csrfToken,
     // Donation
     initialForm,
     initialIncentives,
@@ -122,7 +120,6 @@ const DonateInitializer = (props: DonateInitializerProps) => {
 
     dispatch(
       EventDetailsActions.loadEventDetails({
-        csrfToken,
         currency: event.paypalcurrency,
         receiverName: event.receivername,
         receiverLogo: event.receiver_logo,
@@ -137,7 +134,7 @@ const DonateInitializer = (props: DonateInitializerProps) => {
         prizes,
       }),
     );
-  }, [dispatch, event, prizesUrl, donateUrl, minimumDonation, maximumDonation, step, incentives, prizes, csrfToken]);
+  }, [dispatch, event, prizesUrl, donateUrl, minimumDonation, maximumDonation, step, incentives, prizes]);
 
   return null;
 };

--- a/bundles/tracker/event_details/EventDetailsReducer.ts
+++ b/bundles/tracker/event_details/EventDetailsReducer.ts
@@ -7,7 +7,6 @@ import { EventDetails, EventDetailsAction } from './EventDetailsTypes';
 type EventDetailsState = EventDetails;
 
 const initialState: EventDetailsState = {
-  csrfToken: '',
   currency: 'USD', // Default to USD to make tests happy
   receiverName: '',
   receiverSolicitationText: '',

--- a/bundles/tracker/event_details/EventDetailsTypes.ts
+++ b/bundles/tracker/event_details/EventDetailsTypes.ts
@@ -30,7 +30,6 @@ export type Prize = {
 };
 
 export type EventDetails = {
-  csrfToken: string;
   currency: string;
   receiverName: string;
   receiverSolicitationText: string;

--- a/bundles/tracker/index.tsx
+++ b/bundles/tracker/index.tsx
@@ -7,10 +7,14 @@ import { store } from '@public/apiv2/Store';
 import ErrorBoundary from '@public/errorBoundary';
 import ThemeProvider from '@uikit/ThemeProvider';
 
+import { createTrackerStore, OldStoreContext } from '@tracker/Store';
+
 import DonateInitializer from './donation/components/DonateInitializer';
 import AppWrapper from './App';
 
 import '@common/init';
+
+const oldStore = createTrackerStore();
 
 // TODO: Migrate all page-load props to API calls. Currently these props
 // are just being proxied through to `AppWrapper` which decides what props
@@ -26,19 +30,25 @@ window.TrackerApp = (props: any) => {
   const hasDonationInitializerProps = 'incentives' in props;
 
   root.render(
-    <Provider store={store}>
-      <ThemeProvider>
-        <ErrorBoundary>
-          <Constants.Provider value={props.CONSTANTS}>
-            <AppWrapper {...props} />
-            {/* TODO: This is simpler than passing `props` through the router
+    <OldStoreContext.Provider value={oldStore}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <ErrorBoundary>
+            <Constants.Provider value={props.CONSTANTS}>
+              <AppWrapper {...props} />
+              {/* TODO: This is simpler than passing `props` through the router
               components until we reach the /donate path, but it should be
               refactored to not be dependent on these props, or use some
               global context instead. */}
-            {hasDonationInitializerProps ? <DonateInitializer {...props} /> : null}
-          </Constants.Provider>
-        </ErrorBoundary>
-      </ThemeProvider>
-    </Provider>,
+              {hasDonationInitializerProps ? (
+                <Provider store={oldStore}>
+                  <DonateInitializer {...props} />
+                </Provider>
+              ) : null}
+            </Constants.Provider>
+          </ErrorBoundary>
+        </ThemeProvider>
+      </Provider>
+    </OldStoreContext.Provider>,
   );
 };


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

After #805 the Donate page is broken because having two Redux stores is a minefield. This is a patchwork fix around that until I can migrate it to v2.

### Verification Process

The Donate form displays proper information and actually goes to the right place on PayPal.