### PR TITLE
add slop to `current` bid feed window

### DIFF
--- a/tests/apiv2/test_bids.py
+++ b/tests/apiv2/test_bids.py
@@ -137,11 +137,23 @@ class TestBidViewSet(TestBidBase, APITestCase):
                             self.assertV2ModelNotPresent(self.closed_bid, data)
                             self.assertV2ModelPresent(self.challenge, data)
                         with self.subTest('an hour ago'):
+                            # tests the hour window
                             data = self.get_list(
                                 kwargs={'event_pk': self.event.pk, 'feed': 'current'},
                                 data={
                                     'now': self.run.starttime
-                                    - datetime.timedelta(minutes=60),
+                                    - datetime.timedelta(hours=1),
+                                },
+                            )
+                            self.assertV2ModelPresent(self.opened_bid, data)
+                            self.assertV2ModelPresent(self.closed_bid, data)
+                            self.assertV2ModelPresent(self.challenge, data)
+                        with self.subTest('an hour ago and one second ago'):
+                            data = self.get_list(
+                                kwargs={'event_pk': self.event.pk, 'feed': 'current'},
+                                data={
+                                    'now': self.run.starttime
+                                    - datetime.timedelta(minutes=60, seconds=1),
                                 },
                             )
                             self.assertV2ModelPresent(self.opened_bid, data)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Unintended effect of the change to the `current` feed was that if a bid was closed just before a run was scheduled to start, it would drop off the host dashboard etc. This ensures that bids that are coming up "soon" (an hour, for now) will still show up so that existing tools don't break.

### Verification Process

Closed a bit, used the time override with `current` to ensure that it would still show up an hour ahead of time.