### PR TITLE
add new columns to Donation CSV Report

### DIFF
--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -103,7 +103,7 @@ class TestDonationConsumer(TransactionTestCase):
             'comment': self.donation.comment,
             'amount': self.donation.amount,
             'donor__visibility': self.donor.visibility,
-            'donor__visiblename': self.donor.visible_name(),
+            'donor__visiblename': self.donor.visible_name,
             'new_total': self.donation.amount,
             'domain': self.donation.domain,
             'bids': [

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -315,7 +315,7 @@ class TestDonorView(TestCase):
                 amount=5,
             )
             donor_header = (
-                f'<h2 class="text-center">{self.donor.full_visible_name()}</h2>'
+                f'<h2 class="text-center">{self.donor.full_visible_name}</h2>'
             )
             resp = self.client.get(reverse('tracker:donor', args=(self.donor.id,)))
             self.assertContains(resp, donor_header, html=True)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -547,7 +547,7 @@ minimal@example.com
             lines[1],
             ['All Anonymous Donations', str(donation1.amount + donation2.amount), '2'],
         )
-        self.assertEqual(lines[2], [donor3.visible_name(), str(donation3.amount), '1'])
+        self.assertEqual(lines[2], [donor3.visible_name, str(donation3.amount), '1'])
 
     def test_event_run_report(self):
         runs = randgen.generate_runs(self.rand, self.event, 2, ordered=True)
@@ -578,7 +578,10 @@ minimal@example.com
     def test_event_donation_report(self):
         randgen.generate_runs(self.rand, self.event, 5, ordered=True)
         randgen.generate_donors(self.rand, 5)
-        donations = randgen.generate_donations(self.rand, self.event, 10)
+        donations = randgen.generate_donations(self.rand, self.event, 5, domain='LOCAL')
+        donations += randgen.generate_donations(
+            self.rand, self.event, 5, domain='PAYPAL'
+        )
         randgen.generate_donations(
             self.rand, self.event, 10, transactionstate='PENDING', domain='PAYPAL'
         )
@@ -593,10 +596,12 @@ minimal@example.com
 
         def line_for(donation):
             return [
-                donation.donor.visible_name(),
+                donation.donor.visible_name,
+                donation.donor.full_name,
                 donation.event.short,
                 str(donation.amount),
                 donation.timereceived.astimezone(donation.event.timezone).isoformat(),
+                donation.domainId if donation.domain == 'PAYPAL' else '',
             ]
 
         expected = [

--- a/tests/test_prize.py
+++ b/tests/test_prize.py
@@ -1739,8 +1739,8 @@ class TestPrizeList(TestCase):
             k.save()
 
         response = self.client.get(reverse('tracker:prizeindex', args=(self.event.id,)))
-        self.assertContains(response, donors[0].visible_name())
-        self.assertContains(response, donors[1].visible_name())
+        self.assertContains(response, donors[0].visible_name)
+        self.assertContains(response, donors[1].visible_name)
         self.assertContains(response, '50 winner(s)')
         self.assertNotContains(response, 'Invalid Variable')
 

--- a/tracker/admin/donation.py
+++ b/tracker/admin/donation.py
@@ -56,7 +56,7 @@ class DonationAdmin(EventLockedMixin, CustomModelAdmin):
 
     def visible_donor_name(self, obj):
         if obj.donor:
-            return obj.donor.visible_name()
+            return obj.donor.visible_name
         else:
             return None
 

--- a/tracker/eventutil.py
+++ b/tracker/eventutil.py
@@ -29,7 +29,7 @@ def post_donation_to_postbacks(donation):
         'amount': float(donation.amount),
         # FIXME: only happens in tests
         'donor__visibility': donation.donor and donation.donor.visibility,
-        'donor__visiblename': donation.donor and donation.donor.visible_name(),
+        'donor__visiblename': donation.donor and donation.donor.visible_name,
         'new_total': float(total),
         'domain': donation.domain,
         'bids': [

--- a/tracker/models/donation.py
+++ b/tracker/models/donation.py
@@ -361,7 +361,7 @@ class Donation(models.Model):
                 tasks.post_donation_to_postbacks(self.id)
 
     def __str__(self):
-        donor_name = self.donor.visible_name() if self.donor else '(Unconfirmed)'
+        donor_name = self.donor.visible_name if self.donor else '(Unconfirmed)'
         return f'{donor_name} ({self.amount}) {self.timereceived}'
 
 
@@ -496,12 +496,14 @@ class Donor(models.Model):
         # avoid breaking prefetch
         return next((dc for dc in self.cache.all() if dc.event_id == event_id), None)
 
+    @property
     def visible_name(self):
+        # TODO: clean this up a bit
         if self.visibility == 'ANON':
             return Donor.ANONYMOUS
         elif self.visibility == 'ALIAS':
             if self.alias:
-                return f'{self.alias}#{self.alias_num}'
+                return self.full_alias
             else:
                 return Donor.ANONYMOUS
         last_name, first_name = self.lastname, self.firstname
@@ -512,7 +514,9 @@ class Donor(models.Model):
         alias = f' ({self.alias})' if self.alias else ''
         return f'{last_name}, {first_name}{alias}'
 
+    @property
     def full_visible_name(self):
+        # TODO: clean this up a bit
         if self.visibility == 'ANON':
             return Donor.ANONYMOUS
         elif self.visibility == 'ALIAS':
@@ -524,6 +528,16 @@ class Donor(models.Model):
             last_name = last_name[:1] + '...'
         alias = f' ({self.full_alias})' if self.alias else ''
         return f'{last_name}, {first_name}{alias}'
+
+    @property
+    def full_name(self):
+        if self.firstname:
+            if self.lastname:
+                return f'{self.lastname}, {self.firstname}'
+            else:
+                return self.firstname
+        else:
+            return '(No Name Supplied)'
 
     @property
     def full_alias(self):
@@ -539,7 +553,7 @@ class Donor(models.Model):
     #     )
 
     def __repr__(self):
-        return self.visible_name()
+        return self.visible_name
 
     def __str__(self):
         if not self.lastname and not self.firstname:
@@ -645,6 +659,10 @@ class DonorCache(models.Model):
     @property
     def full_visible_name(self):
         return self.donor.full_visible_name
+
+    @property
+    def full_name(self):
+        return self.donor.full_name
 
     @property
     def firstname(self):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

#817 

To make it easier to match up PayPal transactions with donations, provide some new information on the CSV report. Specifically does not include email so that we don't accidentally email people who opted out, since that's what the opt-in report is for.

### Verification Process

Ran the report on a local environment and the transaction column included PayPal transaction IDs where expected.