### PR TITLE
Drop Django 5.0 from supported versions, add 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.9 to 3.13
-- Django 4.2, 5.0, or 5.1
+- Django 4.2, 5.1, or 5.2
 
 Additionally, if you are planning on developing, and/or building the JS bundles yourself:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,21 +17,21 @@ jobs:
         Django42:
           PYTHON_VERSION: '3.12'
           DJANGO_VERSION: '4.2'
-        Django50:
+        Django51:
           PYTHON_VERSION: '3.13'
-          DJANGO_VERSION: '5.0'
+          DJANGO_VERSION: '5.1'
         Python3A:
           PYTHON_VERSION: '3.10'
-          DJANGO_VERSION: '5.1'
+          DJANGO_VERSION: '5.2'
         Python3B:
           PYTHON_VERSION: '3.11'
-          DJANGO_VERSION: '5.1'
+          DJANGO_VERSION: '5.2'
         Python3C:
           PYTHON_VERSION: '3.12'
-          DJANGO_VERSION: '5.1'
+          DJANGO_VERSION: '5.2'
         Latest:
           PYTHON_VERSION: '3.13'
-          DJANGO_VERSION: '5.1'
+          DJANGO_VERSION: '5.2'
 
     steps:
       - task: UsePythonVersion@0

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     install_requires=[
         'celery~=5.0',
         'channels>=4.0',
-        'Django>=4.2,<5.2',
+        'Django>=4.2,<6.0',
         'django-ical~=1.7',
         'django-mptt~=0.10',
         'django-paypal~=1.1',


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

#826 

Django 5.0 is EOL. 5.2 is out. Update the test matrix.

### Verification Process

Server runs locally and tests pass.