### PR TITLE
catch ValidationError for bad boolean query parameters

### DIFF
--- a/tests/apiv2/test_api.py
+++ b/tests/apiv2/test_api.py
@@ -37,3 +37,18 @@ class TestAPI(APITestCase):
             status_code=400,
             expected_error_codes={'runners': messages.NO_NESTED_CREATES_CODE},
         )
+
+    def test_bad_search_param(self):
+        self.get_list(
+            model_name='bid',
+            data={'target': 'foo'},
+            status_code=400,
+            expected_error_codes=[messages.MALFORMED_SEARCH_PARAMETER_CODE],
+        )
+
+        self.get_list(
+            model_name='bid',
+            data={'level': 'bar'},
+            status_code=400,
+            expected_error_codes=[messages.MALFORMED_SEARCH_PARAMETER_CODE],
+        )

--- a/tracker/api/filters.py
+++ b/tracker/api/filters.py
@@ -5,6 +5,7 @@ import operator
 import re
 from functools import reduce
 
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
@@ -127,7 +128,7 @@ class TrackerFilter(filters.BaseFilterBackend):
                     filter_args.append(p)
         try:
             queryset = queryset.filter(*filter_args, **filter_kwargs)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, ValidationError):
             raise ParseError(
                 detail=messages.MALFORMED_SEARCH_PARAMETER,
                 code=messages.MALFORMED_SEARCH_PARAMETER_CODE,


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Closes #831.

For some reason Django's BooleanField raises a ValidationError when given a string value that can't be parsed. Simple enough to catch it in the API filter code and turn it into a 400 instead of letting it escape.

### Verification Process

`/tracker/api/v2/bids/?target=foo` returns a 400 with a malformed parameter warning instead of triggering a server exception.