### PR TITLE
fix view_full_schedule redirect when no event is provided

### DIFF
--- a/tracker/admin/interstitial.py
+++ b/tracker/admin/interstitial.py
@@ -80,6 +80,6 @@ def view_full_schedule(request, event=None):
     return HttpResponsePermanentRedirect(
         reverse(
             'admin:tracker_ui',
-            kwargs={'extra': 'schedule_editor' + f'/{event.id}' if event.id else ''},
+            kwargs={'extra': 'schedule_editor' + (f'/{event.id}' if event.id else '')},
         )
     )


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

The old `view_full_schedule` link, if anybody still has it bookmarked, should redirect towards the schedule editor. However, if you leave out the event id, you get a server error instead. This fixes that.

I didn't bother writing tests for it since it's a legacy URL that is not linked anywhere, it's just for people who still have the old one bookmarked.

### Verification Process

The old link without an event id actually works now.