### PR TITLE
use django-paypal ipn handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Type: `bool`
 
 Default: `False`
 
-Controls whether or not to try and use Celery. Certain tasks will be queued up as asynchronous if this setting is
-turned on, but it requires extra setup and for smaller events the performance impact is pretty minor.
+Controls whether to try and use Celery. Certain tasks will be queued up as asynchronous if this setting is turned on,
+but it requires extra setup and for smaller events the performance impact is pretty minor.
 
 #### TRACKER_GIANTBOMB_API_KEY (deprecated alias: GIANTBOMB_API_KEY)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -113,7 +113,7 @@ def create_ipn(
         if payment_date is not None
         else donation.timereceived + datetime.timedelta(minutes=1)
     )
-    return PayPalIPN.objects.create(
+    ipn = PayPalIPN.objects.create(
         residence_country=residence_country,
         mc_currency=mc_currency,
         mc_gross=mc_gross,
@@ -125,6 +125,8 @@ def create_ipn(
         txn_id=txn_id,
         **kwargs,
     )
+    ipn.send_signals()
+    return ipn
 
 
 noon = datetime.time(12, 0)

--- a/tracker/apps.py
+++ b/tracker/apps.py
@@ -5,3 +5,6 @@ class TrackerAppConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
     name = 'tracker'
     verbose_name = 'Donation Tracker'
+
+    def ready(self):
+        from tracker import paypalutil  # noqa

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     path('donate/<slug:event>', donateviews.donate, name='donate'),
     path('paypal_return/', donateviews.paypal_return, name='paypal_return'),
     path('paypal_cancel/', donateviews.paypal_cancel, name='paypal_cancel'),
-    path('ipn/', donateviews.ipn, name='ipn'),
+    path('ipn/', include('paypal.standard.ipn.urls')),
     path('analytics/', analyticsviews.post_analytics, name='analytics'),
     path('search/', api.gone),
     path('add/', api.gone),


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Ever since the initial implementation of the PayPal flow, the Tracker has been handling IPN processing directly. `django-paypal` provides its own endpoint and model signals that can simplify the logic somewhat, so this refactors the flow to make use of that.

While working on that I decided to make the handling of suspect/corrupt payloads more pessimistic and treat them as invalid IPNs rather than try and do any special logic other than logging them.

Also added some tests to ensure the correct Celery task is called when a donation clears.

### Verification Process

PayPal flow via the sandbox continues to work. I sent a few manual IPNs with modified/corrupted payloads to ensure that they were ignored but otherwise processed correctly.