### PR TITLE
Django setting for Registration email from-address

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ Default: `'https://github.com/GamesDoneQuick/donation-tracker/graphs/contributor
 If set, will display this link in the common template footer. If you want to hide the link you can set it to a blank
 string.
 
+#### TRACKER_REGISTRATION_FROM_EMAIL
+
+Type: `str` (must pass `EmailValidator`)
+
+Default: `settings.DEFAULT_FROM_EMAIL`
+
+If you want to override the email address that registration emails come from, you can do so with this setting.
+
+#### TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL
+
+Type: `str` (must pass `EmailValidator`)
+
+Default: `settings.TRACKER_REGISTRATION_FROM_EMAIL`
+
+If you want to override the default email address that volunteer import registration emails (i.e. the `Send Volunteer
+Emails` via the Event Admin action dropdown) come from, you can do so with this setting. You can still override it in
+the form itself before doing the import.
+
 ### Testing Your Deploy (WIP)
 
 - PayPal currently requires the receiver account to have IPNs turned on so that payment can be confirmed
@@ -243,6 +261,9 @@ Other variables that take string values:
 
 - `STATIC_ROOT` - defaults to `/static/gen`, i.e. `http://yourserver/static/gen`, if your static files are deployed at
   a different path you'll need to override this
+
+Same with the following, except they only matter for development:
+
 - `TRACKER_API_HOST` - if you want to send `/tracker/api` requests to a different host, you can override this, will
   prefer this over `TRACKER_HOST`
 - `TRACKER_HOST` - if you want to send most HTTP/WS requests to a different host, you can override this - check

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,7 @@ from .util import MigrationsTestCase
 AuthUser = get_user_model()
 
 
-@override_settings(EMAIL_FROM_USER='example@example.com')
+@override_settings(TRACKER_REGISTRATION_FROM_EMAIL='example@example.com')
 class TestRegistrationFlow(TestCase):
     def setUp(self):
         self.factory = RequestFactory()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -19,7 +19,7 @@ class TestMergeObjectsForm(TestCase):
         self.assertEqual(form.choices[0][1], '#%d: Justin' % d1.pk)
 
 
-@override_settings(EMAIL_FROM_USER='example@example.com')
+@override_settings(TRACKER_REGISTRATION_FROM_EMAIL='example@example.com')
 class TestRegistrationForm(TransactionTestCase):
     def setUp(self):
         self.factory = RequestFactory()

--- a/tests/test_tracker_settings.py
+++ b/tests/test_tracker_settings.py
@@ -4,7 +4,11 @@ from tracker import settings
 
 
 class TestTrackerSettings(TestCase):
-    @override_settings(TRACKER_SWEEPSTAKES_URL=None, TOTAL_NONSENSE='flibbertygibbit')
+    @override_settings(
+        TRACKER_SWEEPSTAKES_URL=None,
+        TOTAL_NONSENSE='flibbertygibbit',
+        DEFAULT_FROM_EMAIL='foo@example.com',
+    )
     def test_defaults(self):
         self.assertEqual(settings.TRACKER_PAGINATION_LIMIT, 500)
         self.assertEqual(settings.TRACKER_HAS_CELERY, False)
@@ -13,6 +17,10 @@ class TestTrackerSettings(TestCase):
         self.assertEqual(settings.TRACKER_PRIVACY_POLICY_URL, '')
         self.assertEqual(settings.TRACKER_SWEEPSTAKES_URL, '')
         self.assertEqual(settings.TOTAL_NONSENSE, 'flibbertygibbit')
+        self.assertEqual(settings.TRACKER_REGISTRATION_FROM_EMAIL, 'foo@example.com')
+        self.assertEqual(
+            settings.TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL, 'foo@example.com'
+        )
 
     @override_settings(
         HAS_CELERY=True,

--- a/tracker/auth.py
+++ b/tracker/auth.py
@@ -7,7 +7,7 @@ from django.utils.http import urlsafe_base64_encode
 
 from tracker import settings
 
-from . import mailutil, viewutil
+from . import mailutil
 
 
 def default_registration_template_name():
@@ -149,7 +149,7 @@ def send_registration_mail(
     template = template or mailutil.get_email_template(
         default_registration_template_name(), default_registration_template()
     )
-    sender = sender or viewutil.get_default_email_from_user()
+    sender = sender or settings.DEFAULT_FROM_EMAIL
     extra_context = extra_context or {}
     confirmation_url = request.build_absolute_uri(
         reverse(

--- a/tracker/forms.py
+++ b/tracker/forms.py
@@ -23,7 +23,7 @@ import tracker.prizemail as prizemail
 import tracker.util
 import tracker.viewutil as viewutil
 import tracker.widgets
-from tracker import models
+from tracker import models, settings
 from tracker.validators import nonzero, positive
 
 __all__ = [
@@ -329,7 +329,9 @@ class SendVolunteerEmailsForm(forms.Form):
     template = forms.ModelChoiceField(
         post_office.models.EmailTemplate.objects.all(), empty_label=None
     )
-    sender = forms.EmailField()
+    sender = forms.EmailField(
+        initial=lambda: settings.TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL
+    )
     volunteers = forms.FileField()
 
 
@@ -812,9 +814,7 @@ class RegistrationForm(forms.Form):
         userSet = AuthUser.objects.filter(email__iexact=email)
         if userSet.count() > 1:
             raise forms.ValidationError(
-                'More than one user has the e-mail {0}. Ideally this would be a db constraint, but django is stupid. Contact SMK to get this sorted out.'.format(
-                    email
-                )
+                f'More than one user has the e-mail {email}. Please contact a server administrator.'
             )
         if userSet.exists():
             return userSet[0]

--- a/tracker/prizemail.py
+++ b/tracker/prizemail.py
@@ -25,7 +25,7 @@ def get_event_default_sender_email(event):
     if event and event.prizecoordinator:
         return event.prizecoordinator.email
     else:
-        return viewutil.get_default_email_from_user()
+        return settings.DEFAULT_FROM_EMAIL
 
 
 def event_sender_replyto_defaults(event, sender=None, reply_to=None):

--- a/tracker/settings.py
+++ b/tracker/settings.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 from django.core.checks import Error, Warning, register
+from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
 
 
 # noinspection PyPep8Naming
@@ -53,6 +55,20 @@ class TrackerSettings(object):
             settings,
             'TRACKER_CONTRIBUTORS_URL',
             'https://github.com/GamesDoneQuick/donation-tracker/graphs/contributors',
+        )
+
+    @property
+    def TRACKER_REGISTRATION_FROM_EMAIL(self):
+        return getattr(
+            settings, 'TRACKER_REGISTRATION_FROM_EMAIL', settings.DEFAULT_FROM_EMAIL
+        )
+
+    @property
+    def TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL(self):
+        return getattr(
+            settings,
+            'TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL',
+            self.TRACKER_REGISTRATION_FROM_EMAIL,
         )
 
     # pass everything else through for convenience
@@ -129,4 +145,39 @@ def tracker_settings_checks(app_configs, **kwargs):
         errors.append(
             Error('TRACKER_CONTRIBUTORS_URL should be a string', id='tracker.E109')
         )
+    if not isinstance(TrackerSettings().TRACKER_REGISTRATION_FROM_EMAIL, str):
+        errors.append(
+            Error(
+                'TRACKER_REGISTRATION_FROM_EMAIL should be a string', id='tracker.E114'
+            )
+        )
+    else:
+        try:
+            EmailValidator()(TrackerSettings().TRACKER_REGISTRATION_FROM_EMAIL)
+        except ValidationError:
+            errors.append(
+                Error(
+                    'TRACKER_REGISTRATION_FROM_EMAIL is not a valid email address',
+                    id='tracker.E115',
+                )
+            )
+    if not isinstance(TrackerSettings().TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL, str):
+        errors.append(
+            Error(
+                'TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL should be a string',
+                id='tracker.E116',
+            )
+        )
+    else:
+        try:
+            EmailValidator()(
+                TrackerSettings().TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL
+            )
+        except ValidationError:
+            errors.append(
+                Error(
+                    'TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL is not a valid email address',
+                    id='tracker.E117',
+                )
+            )
     return errors

--- a/tracker/views/auth.py
+++ b/tracker/views/auth.py
@@ -16,6 +16,8 @@ __all__ = [
     'confirm_registration',
 ]
 
+from tracker import settings
+
 
 @never_cache
 def register(request):
@@ -24,6 +26,7 @@ def register(request):
         if form.is_valid():
             form.save(
                 email_template=tracker.auth.default_registration_template(),
+                from_email=settings.TRACKER_REGISTRATION_FROM_EMAIL,
                 request=request,
             )
             return views_common.tracker_response(request, 'tracker/register_done.html')

--- a/tracker/viewutil.py
+++ b/tracker/viewutil.py
@@ -8,16 +8,8 @@ from django.db.models import Q
 from django.http import Http404
 from django.urls import reverse
 
-from tracker import search_filters, settings
+from tracker import search_filters
 from tracker.models import Donor, Event, Log
-
-
-def get_default_email_host_user():
-    return getattr(settings, 'EMAIL_HOST_USER', '')
-
-
-def get_default_email_from_user():
-    return getattr(settings, 'EMAIL_FROM_USER', get_default_email_host_user())
 
 
 def admin_url(obj):


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

While setting up a test server I realized that the registration flow is broken for certain otherwise sensible configurations.

Notably, `EMAIL_HOST_USER` is not a suitable fallback for a source email, and it makes more sense to use `DEFAULT_FROM_EMAIL` from the standard Django settings. However, this does add an optional override specific to registration emails (either self or through the volunteer import form) by specifying `TRACKER_REGISTRATION_FROM_EMAIL`. Further, a setting specific to volunteer importing can override the default sender email via `TRACKER_VOLUNTEER_REGISTRATION_FROM_EMAIL`. This can still be edited via the form before sending, but allows tuning the default.

### Verification Process

Sent a local registration email and it came from the expected setting, with and without `TRACKER_REGISTRATION_FROM_EMAIL` present.

Opening the volunteer import form populated the field with the expected setting.

