### PR TITLE
Fix creation of milestones

### DIFF
--- a/tracker/admin/util.py
+++ b/tracker/admin/util.py
@@ -197,7 +197,8 @@ class EventReadOnlyForm(ModelForm):
     def _get_validation_exclusions(self):
         # TODO: better way of making sure this doesn't get excluded?
         exclusions = super()._get_validation_exclusions()
-        exclusions.remove('event')
+        if 'event' in exclusions:
+            exclusions.remove('event')
         return exclusions
 
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

First of all, thank you for taking the time to contribute!

Please fill out the template below and check the following boxes:

- [ ] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

When removing an item from a set that does not exist python will throw a KeyError crashing the tracker. I found this out while trying to create a milestone. 
The event key is only present in the exclusions when updating a milestone.

### Verification Process

I verified this change by creating and updating a milestone. I also testing updating a milestone that was created before this change. The text "server done blown up" does not appear anymore when creating a milestone and the milestone is created properly.
