### PR TITLE
Add donation currency to postback

### DIFF
--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -107,6 +107,7 @@ class TestDonationConsumer(TransactionTestCase):
             ).isoformat(),
             'comment': self.donation.comment,
             'amount': self.donation.amount,
+            'currency': self.donation.currency,
             'donor__visibility': self.donor.visibility,
             'donor__visiblename': self.donor.visible_name,
             'new_total': self.donation.amount,

--- a/tests/test_eventutil.py
+++ b/tests/test_eventutil.py
@@ -36,6 +36,7 @@ class TestPostDonation(TransactionTestCase):
             domain='PAYPAL',
             donor=self.donor,
             event=self.event,
+            currency='USD',
             transactionstate='COMPLETED',
         )
 
@@ -51,6 +52,7 @@ class TestPostDonation(TransactionTestCase):
                 self.event.timezone
             ).isoformat(),
             'comment': '',
+            'currency': 'USD',
             'amount': 1.5,
             'donor__visibility': 'FIRST',
             'donor__visiblename': '(No Name)',

--- a/tracker/eventutil.py
+++ b/tracker/eventutil.py
@@ -29,6 +29,7 @@ def post_donation_to_postbacks(donation):
         ).isoformat(),
         'comment': donation.comment,
         'amount': float(donation.amount),
+        'currency': donation.currency,
         # FIXME: donor being None only happens in tests
         'donor__visibility': donation.donor and donation.donor.visibility,
         'donor__visiblename': donation.donor and donation.donor.visible_name,


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [x] I've added tests or modified existing tests for the change.
- [x] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Donation postbacks did not include the donation currency previously, this PR adds the currency when the postback is sent.

### Verification Process

I've sent out a postback from the admin panel and it showed the currency as expected:
```json
{"id": 13, "event": 1, "timereceived": "2024-10-20T13:13:34+02:00", "comment": "", "amount": 10.0, "currency": "EUR", "donor__visibility": "FIRST", "donor__visiblename": "S..., Duncan (duncte123)", "new_total": 450.0, "domain": "LOCAL", "bids": [{"id": 8, "total": 40.0, "parent": 5, "name": "James", "goal": null, "state": "OPENED", "speedrun": 1}]}
```
