### PR TITLE
fix a few template bugs

### DIFF
--- a/tests/test_donation.py
+++ b/tests/test_donation.py
@@ -641,12 +641,12 @@ class TestDonationViews(TestCase):
         resp = self.client.get(reverse('tracker:donationindex'))
         self.assertContains(
             resp,
-            '<small>Total (Count) (USD): $20.00 (2) &mdash; Max/Avg/Median Donation: $15.00/$10.00/$10.00</small>',
+            '<small>Donation Total (USD): $20.00 (2) &mdash; Max/Avg/Median Donation: $15.00/$10.00/$10.00</small>',
             html=True,
         )
         self.assertContains(
             resp,
-            '<small>Total (Count) (EUR): €25.00 (1) &mdash; Max/Avg/Median Donation: €25.00/€25.00/€25.00</small>',
+            '<small>Donation Total (EUR): €25.00 (1) &mdash; Max/Avg/Median Donation: €25.00/€25.00/€25.00</small>',
             html=True,
         )
         self.assertContains(resp, self.regular_donation.visible_donor_name)
@@ -659,7 +659,7 @@ class TestDonationViews(TestCase):
         resp = self.client.get(reverse('tracker:donationindex', args=(self.event.id,)))
         self.assertContains(
             resp,
-            '<small>Total (Count): $20.00 (2) &mdash; Max/Avg/Median Donation: $15.00/$10.00/$10.00</small>',
+            '<small>Donation Total: $20.00 (2) &mdash; Max/Avg/Median Donation: $15.00/$10.00/$10.00</small>',
             html=True,
         )
         self.assertContains(resp, self.regular_donation.visible_donor_name)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -245,6 +245,29 @@ class TestEventViews(TransactionTestCase):
         models.Donation.objects.create(
             event=self.eu_event, amount=10, transactionstate='COMPLETED', donor=donor
         )
+        models.SpeedRun.objects.create(
+            event=self.event,
+            order=1,
+            run_time='5:00',
+        )
+        models.Bid.objects.create(
+            event=self.event,
+            istarget=True,
+            name='Test Bid',
+            goal=50,
+        )
+        models.Milestone.objects.create(
+            event=self.event,
+            amount=1000,
+            name='Test Milestone',
+            visible=True,
+        )
+        models.Prize.objects.create(
+            event=self.event,
+            minimumbid=5,
+            name='Test Prize',
+            state='ACCEPTED',
+        )
 
     @override_settings(TRACKER_LOGO='example-logo.png')
     def test_main_index(self):
@@ -261,6 +284,41 @@ class TestEventViews(TransactionTestCase):
             'Donation Total (EUR): €35.00 (2) &mdash; Max/Avg/Median Donation: €25.00/€17.50/€17.50',
             html=True,
         )
+        self.assertContains(response, 'View Runs (1)', html=True)
+        self.assertContains(response, 'View Prizes (1)', html=True)
+        self.assertContains(response, 'View Bids (1)', html=True)
+        self.assertContains(response, 'View Milestones (1)', html=True)
+        self.assertContains(response, 'View Donations (5)', html=True)
+
+    @override_settings(TRACKER_LOGO='example-logo.png')
+    def test_event_detail(self):
+        response = self.client.get(reverse('tracker:index', args=(self.event.id,)))
+        self.assertContains(response, self.event.name)
+        self.assertContains(response, 'example-logo.png')
+        self.assertContains(
+            response,
+            'Donation Total: $75.00 (3) &mdash; Max/Avg/Median Donation: $60.00/$25.00/$10.00',
+            html=True,
+        )
+        self.assertContains(response, 'View Runs (1)', html=True)
+        self.assertContains(response, 'View Prizes (1)', html=True)
+        self.assertContains(response, 'View Bids (1)', html=True)
+        self.assertContains(response, 'View Milestones (1)', html=True)
+        self.assertContains(response, 'View Donations (3)', html=True)
+
+        response = self.client.get(reverse('tracker:index', args=(self.eu_event.id,)))
+        self.assertContains(response, self.eu_event.name)
+        self.assertContains(response, 'example-logo.png')
+        self.assertContains(
+            response,
+            'Donation Total: €35.00 (2) &mdash; Max/Avg/Median Donation: €25.00/€17.50/€17.50',
+            html=True,
+        )
+        self.assertContains(response, 'View Runs (0)', html=True)
+        self.assertContains(response, 'View Prizes (0)', html=True)
+        self.assertContains(response, 'View Bids (0)', html=True)
+        self.assertContains(response, 'View Milestones (0)', html=True)
+        self.assertContains(response, 'View Donations (2)', html=True)
 
     def test_json(self):
         response = self.client.get(reverse('tracker:index_all'), data={'json': ''})

--- a/tracker/templates/tracker/donationindex.html
+++ b/tracker/templates/tracker/donationindex.html
@@ -17,15 +17,7 @@
         {% trans "Donation Index" %} &mdash; {{ event.name }}
     </h2>
     <h3 class="text-center">
-        {% for cache in caches %}
-          {% if not forloop.first %}<br />{% endif %}
-          <small>
-              {% trans "Total" %} ({% trans "Count" %}){% if cache.currency %} ({{ cache.currency }}){% endif %}:
-              {% money cache cache.donation_total %} ({{ cache.donation_count }}) &mdash;
-              {% trans "Max/Avg/Median Donation" %}:
-              {% money cache cache.donation_max %}/{% money cache cache.donation_avg %}/{% money cache cache.donation_med %}
-          </small>
-        {% endfor %}
+        {% include "tracker/partials/totals.html" with caches=caches only %}
     </h3>
     <table class="table table-condensed table-striped small">
         <thead>

--- a/tracker/templates/tracker/index.html
+++ b/tracker/templates/tracker/index.html
@@ -15,15 +15,7 @@
     <h2 class="text-center">
         {{ event.name }}
         {% if not event.draft %}
-          {% for cache in caches %}
-            <br/>
-            <small>
-              {% trans "Donation Total" %}{% if cache.currency %} ({{ cache.currency }}){% endif %}:
-              {% money cache.currency cache.donation_total %} ({{ cache.donation_count }}) &mdash;
-              {% trans "Max/Avg/Median Donation" %}:
-              {% money cache.currency cache.donation_max %}/{% money cache.currency cache.donation_avg %}/{% money cache.currency cache.donation_med %}
-            </small>
-          {% endfor %}
+          {% include "tracker/partials/totals.html" with caches=caches only %}
         {% endif %}
     </h2>
     <div class="col-xs-4 col-xs-offset-4">

--- a/tracker/templates/tracker/partials/totals.html
+++ b/tracker/templates/tracker/partials/totals.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load donation_tags %}
+
+{% for cache in caches %}
+  <br />
+  <small>
+    {% trans "Donation Total" %}{% if cache.currency %} ({{ cache.currency }}){% endif %}:
+    {% money cache cache.donation_total %} ({{ cache.donation_count }}) &mdash;
+    {% trans "Max/Avg/Median Donation" %}:
+    {% money cache cache.donation_max %}/{% money cache cache.donation_avg %}/{% money cache cache.donation_med %}
+  </small>
+{% endfor %}

--- a/tracker/views/public.py
+++ b/tracker/views/public.py
@@ -61,10 +61,11 @@ def eventlist(request):
 
 def index(request, event=None):
     event = viewutil.get_event(event)
-    eventParams = {}
+    filter_params = {}
 
     if event.id:
         caches = DonorCache.objects.filter(donor=None, event=event)
+        filter_params['event'] = event
     else:
         caches = DonorCache.objects.filter(donor=None, event=None)
 
@@ -72,10 +73,12 @@ def index(request, event=None):
     if not event.draft:
         count.update(
             {
-                'runs': SpeedRun.objects.public().filter(**eventParams).count(),
-                'prizes': Prize.objects.public().filter(**eventParams).count(),
-                'bids': Bid.objects.public().filter(level=0, **eventParams).count(),
-                'milestones': Milestone.objects.public().filter(**eventParams).count(),
+                'runs': SpeedRun.objects.public().filter(**filter_params).count(),
+                'prizes': Prize.objects.public().filter(**filter_params).count(),
+                'bids': Bid.objects.public().filter(level=0, **filter_params).count(),
+                'milestones': Milestone.objects.public()
+                .filter(**filter_params)
+                .count(),
                 'donations': caches.aggregate(count=Coalesce(Sum('donation_count'), 0))[
                     'count'
                 ],


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

One of the header templates was using the wrong version of the cache/total display logic. This would cause the Event header to show incorrect currency headers in some cases. Since they're basically the same for both event header and donation list header, I just stuck them in a partial to ensure they stay in sync.

Also, due to the last change to Donor totals changing the filtering logic, the event resource counts were wrong if you were looking at anything other than the overall index. This has been addressed as well.

### Verification Process

Loaded an event page, verified the correct currency symbol, both on the overall event page and on the donation list.

Also verified that the resource counts were correct per event.