### PR TITLE
support '@all' (All Events) for Process Pending Bids

### DIFF
--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -32,6 +32,11 @@ function EventMenu(name) {
         <Spinner spinning={isLoading}>
           {name}
           <ul style={{ display: 'block' }}>
+            {name === 'Process Pending Bids' && (
+              <li>
+                <Link to="@all">All Events</Link>
+              </li>
+            )}
             {sortedEvents &&
               sortedEvents.map(e => (
                 <li key={e.id}>
@@ -65,6 +70,11 @@ function DropdownMenu({ name, path }) {
           overflowY: 'auto',
         }}>
         <ul style={{ display: 'block' }}>
+          {name === 'Process Pending Bids' && (
+            <li>
+              <Link to={`${path}/@all`}>All Events</Link>
+            </li>
+          )}
           {sortedEvents &&
             sortedEvents.map(e => (
               <li key={e.id}>

--- a/bundles/admin/donationProcessing/processPendingBids.tsx
+++ b/bundles/admin/donationProcessing/processPendingBids.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import cn from 'classnames';
+import { skipToken } from '@reduxjs/toolkit/query';
 
 import { useConstants } from '@common/Constants';
 import APIErrorList from '@public/APIErrorList';
 import {
+  allEvents,
   useApproveBidMutation,
   useBidTreeQuery,
   useDenyBidMutation,
+  useEventAllParam,
   useEventFromQuery,
-  useEventParam,
   usePermission,
 } from '@public/apiv2/hooks';
 import { BidState } from '@public/apiv2/Models';
@@ -53,16 +55,24 @@ const stateMap: Record<LocalBidState, string> = {
 
 export default React.memo(function ProcessPendingBids() {
   const { ADMIN_ROOT } = useConstants();
-  const eventId = useEventParam();
+  const eventId = useEventAllParam();
+  const eventFilter: { eventId?: number } = {};
+  if (eventId !== allEvents) {
+    eventFilter.eventId = eventId;
+  }
   const {
     data: bids,
     error: bidError,
     refetch: refetchBids,
     isFetching: bidFetching,
   } = useBidTreeQuery({
-    urlParams: { eventId, feed: 'pending' },
+    urlParams: { ...eventFilter, feed: 'pending' },
   });
-  const { data: event, error: eventError, isLoading: eventLoading } = useEventFromQuery(eventId);
+  const {
+    data: event,
+    error: eventError,
+    isLoading: eventLoading,
+  } = useEventFromQuery(eventFilter.eventId ?? skipToken);
 
   const canApproveBids = usePermission('tracker.approve_bid');
   const canChangeBids = usePermission('tracker.change_bid');
@@ -98,7 +108,7 @@ export default React.memo(function ProcessPendingBids() {
 
   return (
     <div>
-      <h3>{event?.name}</h3>
+      <h3>{eventId === allEvents ? 'All Events' : event?.name}</h3>
       <div>
         <button onClick={refetch}>Refresh</button>
       </div>


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Process Pending Bids can have a more generic use when multiple concurrent events are happening (as is currently the case with SGDQ Ambassadors). This is an admittedly somewhat hacky solution to allow the page to support the special event id `@all` (which is not otherwise a valid short id) to show -all- pending bid names, so that screeners only have to have one version of the page open.

Both versions of the event list for Process Pending Bids (the page itself and the dropdown list) will also show `All Events` as a selection.

Added one new React hook that will support either `@all` or a numeric id, but currently the only place it is used is Process Pending Bids. Perhaps it can be expanded to other pages later if a use case makes itself known.

Known issue:

- won't work properly if there are pending bids on archived events, you'll just get a permissions error if you try and change them

### Verification Process

Tested links from the event list, and the dropdown, both worked.

Routes worked as expected.