### PR TITLE
packaging updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,6 +114,7 @@ jobs:
           python setup.py package
         displayName: 'Build Package'
         env:
+          BUILD_NUMBER: $(Build.BuildNumber)
           PACKAGE_NAME_SUFFIX: $(Build.SourceVersion)
 
       - task: TwineAuthenticate@1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donation_tracker",
-  "version": "3.3.0",
+  "version": "3.3.1.dev0",
   "description": "GDQ Donation Tracker",
   "scripts": {
     "build": "webpack",
@@ -28,6 +28,7 @@
     "@fortawesome/react-fontawesome": "^0.1.7",
     "@redux-devtools/extension": "^3.2.5",
     "@reduxjs/toolkit": "^2.7.0",
+    "@swc/core": "^1.3.46",
     "axios": "^1.8.2",
     "classnames": "^2.3.2",
     "css-loader": "^6.7.3",
@@ -60,15 +61,16 @@
     "redux-thunk": "^2.4.2",
     "reselect": "^5.0.0",
     "sturdy-websocket": "^0.2.1",
+    "swc-loader": "^0.2.3",
     "validator": "^13.9.0",
     "webpack": "^5.94.0",
+    "webpack-cli": "^4.10.0",
     "zustand": "^4.0.0-rc.1"
   },
   "devDependencies": {
     "@gamesdonequick/prettier-config": "^2.2.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.46",
     "@testing-library/dom": "^9.2.0",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^7.1.2",
@@ -114,11 +116,9 @@
     "redux-logger": "^3.0.6",
     "stream-browserify": "^3.0.0",
     "string_decoder": "^1.3.0",
-    "swc-loader": "^0.2.3",
     "typescript": "^5.8.3",
     "util": "^0.12.5",
     "webpack-bundle-analyzer": "^4.8.0",
-    "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.13.2"
   },
   "resolutions": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,54 @@
 [tool.black]
-target-version = ['py39']
-exclude = 'migrations/'
+extend-exclude = 'migrations/'
 skip-string-normalization = 'True'
 [tool.isort]
 profile = 'black'
+[tool.setuptools.dynamic]
+version = { attr = "tracker.__version__"}
+[project]
+authors = [
+  { name = 'Games Done Quick, LLC', email = 'tracker@gamesdonequick.com' },
+]
+classifiers = [
+  'Development Status :: 5 - Production/Stable',
+  'Environment :: Web Environment',
+  'Framework :: Django',
+  'Intended Audience :: Other Audience',
+  'Operating System :: OS Independent',
+  'Programming Language :: Python',
+  'Programming Language :: Python :: 3',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
+  'Topic :: Internet :: WWW/HTTP',
+  'Topic :: Software Development :: Libraries :: Python Modules',
+]
+dependencies = [
+  'babel~=2.17.0',
+  'celery~=5.0',
+  'channels>=4.0',
+  'Django>=4.2,<6.0',
+  'django-ical~=1.7',
+  'django-mptt~=0.10',
+  'django-paypal~=1.1',
+  'django-post-office~=3.2',
+  'django-timezone-field>=7.0,<8.0',
+  'djangorestframework~=3.9',
+  'python-dateutil~=2.8.1;python_version<"3.11"',
+  'requests>=2.27.1,<2.33.0',
+]
+description = 'A Django app to assist in tracking donations for live broadcast events.'
+dynamic = ['version']
+license-files = ['LICENSE', 'tracker/static/gen/**/*.LICENSE.txt']
+name = 'django-donation-tracker'
+readme = 'README.md'
+requires-python = '>= 3.9'
+[project.optional-dependencies]
+development = [
+  'daphne~=4.0',
+]
+tqdm = [
+  'tqdm~=4.67.1',
+]

--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -1,5 +1,25 @@
-from .settings import TrackerSettings
+import json
+import os
 
-settings = TrackerSettings()
+try:
+    from .settings import TrackerSettings
 
-default_app_config = 'tracker.apps.TrackerAppConfig'
+    settings = TrackerSettings()
+
+    default_app_config = 'tracker.apps.TrackerAppConfig'
+except ImportError:
+    # happens when setuptools is trying to evaluate the version
+    pass
+
+__bare_version__ = '3.3.1.dev0'
+
+if __tag__ := os.environ.get('BUILD_NUMBER', ''):
+    __version__ = __bare_version__.replace('dev0', __tag__)
+else:
+    __version__ = __bare_version__
+
+try:
+    with open(os.path.join(os.path.dirname(__file__), '../package.json')) as pkg:
+        assert json.load(pkg)['version'] == __bare_version__
+except IOError:
+    pass

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,16 @@
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
-const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+let ReactRefreshWebpackPlugin;
+let BundleAnalyzerPlugin;
+
+try {
+  ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+  BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+} catch {}
+
 const path = require('path');
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const compact = require('lodash/compact');
 
 const PROD = !(process.env.WEBPACK_SERVE === 'true' || process.env.WEBPACK_DEV_SERVER);


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Description of the Change

While trying to update the Docker instructions, I realized that the packaging setup for the Tracker needed a couple fixes:

- verify that the webpack bundles can actually be built just from `dependencies`
- move more settings into `pyproject.toml`
- tag the wheel with the Azure build number instead of the hash
- get version from the package itself

### Verification Process

This is mostly a packaging fix, so I verified package contents after running the command and they appeared to be correct.