### PR TITLE
make delete_selected more robust

### DIFF
--- a/tests/apiv2/test_donors.py
+++ b/tests/apiv2/test_donors.py
@@ -42,12 +42,12 @@ class TestDonor(APITestCase):
         self.visible_donor = randgen.generate_donor(self.rand, visibility='ALIAS')
         self.visible_donor.save()
         randgen.generate_donations(
-            self.rand, self.event, num_donations=5, donors=[self.visible_donor]
+            self.rand, self.event, 5, donors=[self.visible_donor]
         )
         self.anonymous_donor = randgen.generate_donor(self.rand, visibility='ANON')
         self.anonymous_donor.save()
         randgen.generate_donations(
-            self.rand, self.event, num_donations=3, donors=[self.anonymous_donor]
+            self.rand, self.event, 3, donors=[self.anonymous_donor]
         )
 
     def test_fetch(self):

--- a/tests/apiv2/test_interstitials.py
+++ b/tests/apiv2/test_interstitials.py
@@ -8,9 +8,9 @@ from tracker.api import messages
 class InterstitialTestCase(APITestCase):
     def setUp(self):
         super().setUp()
-        self.run = randgen.generate_run(self.rand, event=self.event, ordered=True)
+        self.run = randgen.generate_run(self.rand, self.event, ordered=True)
         self.run.save()
-        self.other_run = randgen.generate_run(self.rand, event=self.event, ordered=True)
+        self.other_run = randgen.generate_run(self.rand, self.event, ordered=True)
         self.other_run.save()
 
     def test_interstitial_common(self):

--- a/tests/apiv2/test_prizes.py
+++ b/tests/apiv2/test_prizes.py
@@ -13,9 +13,7 @@ class TestPrizes(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.runs = randgen.generate_runs(
-            self.rand, num_runs=3, event=self.event, ordered=True
-        )
+        self.runs = randgen.generate_runs(self.rand, self.event, 3, ordered=True)
         self.accepted_prize = randgen.generate_prize(
             self.rand, start_run=self.runs[0], end_run=self.runs[1]
         )

--- a/tests/apiv2/test_talent.py
+++ b/tests/apiv2/test_talent.py
@@ -29,16 +29,14 @@ class TestTalent(APITestCase):
         self.subject = randgen.generate_subject(self.rand)
         self.subject.save()
         self.other_talent = randgen.generate_talent(
-            self.rand, 'not attached to anything'
+            self.rand, name='not attached to anything'
         )
         self.other_talent.save()
         self.spread_talent = randgen.generate_talent(self.rand)
         self.spread_talent.save()
         self.spread_draft_talent = randgen.generate_talent(self.rand)
         self.spread_draft_talent.save()
-        self.runs = randgen.generate_runs(
-            self.rand, num_runs=2, event=self.event, ordered=True
-        )
+        self.runs = randgen.generate_runs(self.rand, self.event, 2, ordered=True)
         self.runner.runs.add(*self.runs)
         self.host.hosting.add(*self.runs)
         self.commentator.commentating.add(*self.runs)
@@ -46,11 +44,9 @@ class TestTalent(APITestCase):
         self.interview.save()
         self.interview.interviewers.add(self.interviewer)
         self.interview.subjects.add(self.subject)
-        self.spread_runs = randgen.generate_runs(
-            self.rand, num_runs=3, event=self.event, ordered=True
-        )
+        self.spread_runs = randgen.generate_runs(self.rand, self.event, 3, ordered=True)
         self.spread_draft_runs = randgen.generate_runs(
-            self.rand, num_runs=3, event=self.draft_event, ordered=True
+            self.rand, self.draft_event, 3, ordered=True
         )
         self.spread_interviews = []
         self.spread_draft_interviews = []
@@ -72,7 +68,7 @@ class TestTalent(APITestCase):
         self.spread_draft_talent.interviewer_for.add(self.spread_draft_interviews[0])
         self.spread_draft_talent.subject_for.add(self.spread_draft_interviews[1])
         self.other_runs = randgen.generate_runs(
-            self.rand, num_runs=1, event=self.other_event, ordered=True
+            self.rand, self.other_event, 1, ordered=True
         )
         self.other_runner.runs.add(*self.other_runs)
 

--- a/tests/apiv2/test_videolinks.py
+++ b/tests/apiv2/test_videolinks.py
@@ -11,7 +11,7 @@ class TestVideoLinkSerializer(APITestCase):
         super().setUp()
         self.event = randgen.generate_event(self.rand)
         self.event.save()
-        self.run = randgen.generate_run(self.rand, event=self.event)
+        self.run = randgen.generate_run(self.rand, self.event)
         self.run.save()
         self.link_type = models.VideoLinkType.objects.create(name='youtube')
         self.link1 = models.VideoLink.objects.create(

--- a/tests/test_prizemail.py
+++ b/tests/test_prizemail.py
@@ -241,7 +241,7 @@ class TestAutomailPrizesShipped(TransactionTestCase):
         ):
             prize.key_code = True
             prize.save()
-            randgen.generate_prize_key(self.rand, prize=prize).save()
+            randgen.generate_prize_key(self.rand, prize).save()
         self.templateEmail = post_office.models.EmailTemplate.objects.create(
             name='testing_prize_shipping_notification',
             description='',

--- a/tests/util.py
+++ b/tests/util.py
@@ -294,6 +294,11 @@ class TestErrorCheckMigration(MigrationsTestCase):
 
 
 class AssertionHelpers:
+    def assertMessages(self, response, messages):
+        self.assertSetEqual(
+            {str(m) for m in response.wsgi_request._messages}, set(messages)
+        )
+
     def assertDictContainsSubset(self, subset, dictionary, msg=None):
         if sys.version_info < (3, 12):
             super().assertDictContainsSubset(subset, dictionary, msg)

--- a/tracker/admin/bid.py
+++ b/tracker/admin/bid.py
@@ -326,6 +326,9 @@ class DonationBidAdmin(EventArchivedMixin, DonationStatusMixin, CustomModelAdmin
         )
         return queryset
 
+    def get_event_filter_key(self):
+        return 'bid__event'
+
     @display
     def transactionstate(self, obj):
         return obj.donation.transactionstate

--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -1197,3 +1197,6 @@ class SpeedRunAdmin(EventArchivedMixin, CustomModelAdmin):
 class VideoLinkAdmin(EventArchivedMixin, CustomModelAdmin):
     autocomplete_fields = ('run',)
     event_child_fields = ('run',)
+
+    def get_event_filter_key(self):
+        return 'run__event'

--- a/tracker/admin/prize.py
+++ b/tracker/admin/prize.py
@@ -64,6 +64,9 @@ class PrizeWinnerAdmin(EventArchivedMixin, CustomModelAdmin):
     def winner_email(self, obj):
         return obj.winner.email
 
+    def get_event_filter_key(self):
+        return 'prize__event'
+
 
 @admin.register(models.DonorPrizeEntry)
 class DonorPrizeEntryAdmin(EventArchivedMixin, CustomModelAdmin):

--- a/tracker/templates/admin/tracker/change_form.html
+++ b/tracker/templates/admin/tracker/change_form.html
@@ -6,7 +6,10 @@
   'use strict';
   // can be removed when Django 4.2 is no longer supported
   django.jQuery(document).on('select2:open', () => {
-    document.querySelector('.select2-search--dropdown .select2-search__field').focus();
+    const element = document.querySelector('.select2-search--dropdown .select2-search__field');
+    if (element) {
+      element.focus();
+    }
   });
 })();
 </script>


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

There are some lingering issues with the `delete_selected` action under certain circumstances and this addresses them.

- On Django 4.2 it's currently entirely disabled due to a 'delete after distinct' bug (if you need this, you can still delete models individually)
- Attempting to delete a model belonging to an archived event will produce a better error message

Closes #585.

Also cleaned up randgen a bit to make the parameters more strict.

### Verification Process

Tried different versions of Django, on 4.2 the action is disabled, on 5.1 and 5.2 it worked find to delete a bid or run (the problematic models I knew about).

I also made sure it worked on Donation Bids, Prize Winners, and Video Links, as these do not directly belong to an event but need to check for the archived flag regardless.