### PR TITLE
enhance Start Run

### DIFF
--- a/tracker/admin/forms.py
+++ b/tracker/admin/forms.py
@@ -1,17 +1,40 @@
 import datetime
+from collections import defaultdict
 
 from django import forms as djforms
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from tracker import models
 
 
+class DateTimeLocalInput(djforms.DateTimeInput):
+    input_type = 'datetime-local'
+
+
+class DateTimeLocalField(djforms.DateTimeField):
+    # Set DATETIME_INPUT_FORMATS here because, if USE_L10N
+    # is True, the locale-dictated format will be applied
+    # instead of settings.DATETIME_INPUT_FORMATS.
+    # See also:
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats
+
+    input_formats = [
+        '%Y-%m-%dT%H:%M:%S',
+        '%Y-%m-%dT%H:%M:%S.%f',
+        '%Y-%m-%dT%H:%M',
+    ]
+    widget = DateTimeLocalInput(format='%Y-%m-%dT%H:%M')
+
+
 class StartRunForm(djforms.Form):
+    class Media:
+        css = {'all': ('forms/hide_disabled_border.css',)}
+
     next_anchored_run = djforms.DateTimeField(disabled=True, required=False)
     checkpoint_available = djforms.CharField(disabled=True, required=False)
     run_time = djforms.CharField(help_text='Run time of previous run')
-    start_time = djforms.DateTimeField(help_text='Start time of current run')
+    start_time = DateTimeLocalField(help_text='Start time of current run')
     run_id = djforms.IntegerField(widget=djforms.HiddenInput())
 
     class Errors:
@@ -38,29 +61,41 @@ class StartRunForm(djforms.Form):
             self._run = None
             self._prev = None
 
+    def clean_start_time(self):
+        t = self.cleaned_data['start_time']
+        if t.second >= 30:
+            t += datetime.timedelta(minutes=1)
+        return t.replace(second=0, microsecond=0)
+
     def clean(self):
         from tracker.models import fields
 
+        errors = defaultdict(list)
+
         cleaned_data = super().clean()
         if not self._run:
-            raise ValidationError(
+            errors[NON_FIELD_ERRORS].append(
                 'Run either does not exist or is on an archived event'
             )
-        if not self._prev:
-            raise ValidationError('Run does not have a previous run')
-        rt = fields.TimestampField.coerce_value(cleaned_data['run_time'])
-        endtime = self._prev.starttime + datetime.timedelta(milliseconds=rt)
-        if cleaned_data['start_time'] < endtime:
-            raise ValidationError(self.Errors.invalid_start_time)
-        self._prev.run_time = cleaned_data['run_time']
-        if self._run.anchor_time is not None:
-            self._run.anchor_time = cleaned_data['start_time']
-        self._prev.setup_time = str(cleaned_data['start_time'] - endtime)
-        try:
-            self._run.clean()
-            self._prev.clean()
-        except ValidationError:
-            raise ValidationError(self.Errors.anchor_time_drift)
+        elif not self._prev:
+            errors[NON_FIELD_ERRORS].append('Run does not have a previous run')
+        else:
+            rt = fields.TimestampField.coerce_value(cleaned_data['run_time'])
+            endtime = self._prev.starttime + datetime.timedelta(milliseconds=rt)
+            if cleaned_data['start_time'] < endtime:
+                errors['start_time'].append(self.Errors.invalid_start_time)
+            else:
+                self._prev.run_time = cleaned_data['run_time']
+                if self._run.anchor_time is not None:
+                    self._run.anchor_time = cleaned_data['start_time']
+                self._prev.setup_time = str(cleaned_data['start_time'] - endtime)
+                try:
+                    self._run.clean()
+                    self._prev.clean()
+                except ValidationError:
+                    errors['start_time'].append(self.Errors.anchor_time_drift)
+        if errors:
+            raise ValidationError(errors)
         return cleaned_data
 
     def save(self):

--- a/tracker/static/forms/hide_disabled_border.css
+++ b/tracker/static/forms/hide_disabled_border.css
@@ -1,0 +1,5 @@
+input:disabled {
+  border-color: transparent;
+  background-color: transparent;
+  opacity: 50%;
+}

--- a/tracker/templates/admin/tracker/generic_form.html
+++ b/tracker/templates/admin/tracker/generic_form.html
@@ -19,12 +19,12 @@
     <form method="post" action="{{ request.path }}" enctype="multipart/form-data">
         <table>
             {% csrf_token %}
-            {{ form }}
             {% for name, value in extra.items %}
               <input type="hidden" name="{{ name }}" value="{{ value }}" />
             {% endfor %}
+            {{ form.as_table }}
             <tr>
-                <td>
+                <td colspan="2">
                     <input type="submit" name="Submit">
                 </td>
             </tr>


### PR DESCRIPTION

# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

The `start time` fields both in the overall list and the detail pages in the admin will now link right to the start run page, in addition to being able to use the dropdown.

Also it looks nicer and remembers whatever `changelist_filters` you had set after returning to the list page.

### Verification Process

Used the form, did the right thing, preserved the list filters.