### PR TITLE
Bid admin child state improvements

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -133,6 +133,20 @@ def create_ipn(
     return ipn
 
 
+def find_admin_inline(response, InlineType):
+    inlines = getattr(response, 'context', {}).get('inline_admin_formsets', [])
+    return next((fs for fs in inlines if isinstance(fs.opts, InlineType)), None)
+
+
+# not used in tests, but useful for debugging
+def merge_response_context(response):
+    context = {}
+    for c in getattr(response, 'context', []):
+        for d in c.dicts:
+            context.update(**d)
+    return context
+
+
 noon = datetime.time(12, 0)
 today = datetime.date.today()
 today_noon = datetime.datetime.combine(today, noon).astimezone(

--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -100,6 +100,8 @@ class Bid(mptt.models.MPTTModel):
     HIDDEN_STATES = ('PENDING', 'DENIED', 'HIDDEN')
     PUBLIC_STATES = ('OPENED', 'CLOSED')
     ALL_STATES = HIDDEN_STATES + PUBLIC_STATES
+    TOP_LEVEL_STATES = ('HIDDEN', 'OPENED', 'CLOSED')
+    EXTRA_CHILD_STATES = ('PENDING', 'DENIED')  # only for allowuseroptions
 
     objects = BidManager.from_queryset(BidQuerySet)()
     event = models.ForeignKey(
@@ -536,6 +538,7 @@ class Bid(mptt.models.MPTTModel):
             self.parent.save()
 
     def check_parent(self):
+        self.parent.refresh_from_db()
         changed = False
         if self.speedrun != self.parent.speedrun:
             self.speedrun = self.parent.speedrun


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

This is a collection of various tweaks to the Bid admin to simplify the interface and remove superfluous options.

- display 'Inherit' instead of parent state in order to be less confusing when looking at the inline list
- state is read only for child bids if parent does not allow user options
- adding/changing a Bid outside of the Inline only shows the relevant states
- hide certain fields for user option inlines since they don't really make sense

Also touched up the Admin Log browser a bit. Still not really intended for casual perusal, but it's a little nicer now.

### Verification Process

Set up various kinds of bids and verified that everything could still be saved and edited as expected, and that the fields in question were either read only or completely missing when appropriate.