### PR TITLE
add generic validate endpoint to most API endpoints

### DIFF
--- a/tests/apiv2/test_api.py
+++ b/tests/apiv2/test_api.py
@@ -1,4 +1,7 @@
+from django.urls import reverse
+
 from tests.util import APITestCase
+from tracker import models
 from tracker.api import messages
 
 
@@ -52,3 +55,93 @@ class TestAPI(APITestCase):
             status_code=400,
             expected_error_codes=[messages.MALFORMED_SEARCH_PARAMETER_CODE],
         )
+
+    def test_validate(self):
+        models.Talent.objects.create(name='Bar')
+        with self.subTest('creates'), self.assertLogsChanges(0):
+            self.post_noun(
+                'validate',
+                model_name='interview',
+                status_code=202,
+                view_name='validate-create',
+                data={
+                    'event': self.event.pk,
+                    'order': 1,
+                    'suborder': 1,
+                    'topic': 'Foo',
+                    'interviewers': ['Bar'],
+                    'length': '5:00',
+                },
+                user=self.super_user,
+            )
+            data = self.post_noun(
+                'validate',
+                model_name='interview',
+                status_code=400,
+                view_name='validate-create',
+                data=[
+                    {
+                        'event': self.event.pk,
+                        'order': 1,
+                        'suborder': 1,
+                        'topic': 'Foo',
+                        'interviewers': ['Bar'],
+                        'length': '5:00',
+                    },
+                    {},
+                ],
+            )
+            self.assertIsNone(data['valid'][1])
+            self.assertIsNone(data['invalid'][0])
+            self.assertIsInstance(data['valid'][0], dict)
+            self.assertIsInstance(data['invalid'][1], dict)
+
+        with self.subTest('updates'), self.assertLogsChanges(0):
+            interview = models.Interview.objects.create(
+                event=self.event, order=1, suborder=1, topic='Bar'
+            )
+            self.patch_noun(
+                interview,
+                'validate',
+                model_name='interview',
+                view_name='validate-update',
+                data={'topic': 'Changed Topic'},
+                status_code=202,
+            )
+            self.patch_noun(
+                interview,
+                'validate',
+                model_name='interview',
+                view_name='validate-update',
+                data={},
+                status_code=202,
+            )
+
+            self.patch_noun(
+                interview,
+                'validate',
+                model_name='interview',
+                view_name='validate-update',
+                data={'interviewers': ['Nonsense']},
+                status_code=400,
+                expected_error_codes={
+                    'interviewers': messages.INVALID_NATURAL_KEY_CODE
+                },
+            )
+
+            self.patch_noun(
+                interview,
+                'validate',
+                model_name='interview',
+                view_name='validate-update',
+                data={'topic': ''},
+                status_code=400,
+                expected_error_codes={'topic': 'blank'},
+            )
+
+            resp = self.client.patch(
+                reverse('tracker:api_v2:interview-validate-update', args=(123456,)),
+                data={},
+                format='json',
+            )
+            self.assertEqual(resp.status_code, 404)

--- a/tests/apiv2/test_bids.py
+++ b/tests/apiv2/test_bids.py
@@ -437,14 +437,14 @@ class TestBidViewSet(TestBidBase, APITestCase):
         with self.assertLogsChanges(2), self.subTest('bid approval'):
             self.pending_bid.state = 'PENDING'
             self.pending_bid.save()
-            data = self.patch_noun(self.pending_bid, noun='approve')
+            data = self.patch_noun(self.pending_bid, 'approve')
             self.assertV2ModelPresent(
                 self.pending_bid,
                 data,
             )
             self.pending_bid.state = 'PENDING'
             self.pending_bid.save()
-            data = self.patch_noun(self.pending_bid, noun='deny')
+            data = self.patch_noun(self.pending_bid, 'deny')
             self.assertV2ModelPresent(
                 self.pending_bid,
                 data,
@@ -456,10 +456,10 @@ class TestBidViewSet(TestBidBase, APITestCase):
         with self.subTest('approval only user'), self.assertLogsChanges(2):
             self.pending_bid.state = 'PENDING'
             self.pending_bid.save()
-            self.patch_noun(self.pending_bid, noun='approve', user=self.approval_user)
+            self.patch_noun(self.pending_bid, 'approve', user=self.approval_user)
             self.pending_bid.state = 'PENDING'
             self.pending_bid.save()
-            self.patch_noun(self.pending_bid, noun='deny', user=self.approval_user)
+            self.patch_noun(self.pending_bid, 'deny', user=self.approval_user)
 
         with (
             self.subTest('can edit top level bids even without creation permission'),
@@ -487,8 +487,8 @@ class TestBidViewSet(TestBidBase, APITestCase):
         with self.subTest(
             'approve deny on an archived event non-option should still 404'
         ):
-            self.patch_noun(self.archived_challenge, noun='approve', status_code=404)
-            self.patch_noun(self.archived_challenge, noun='deny', status_code=404)
+            self.patch_noun(self.archived_challenge, 'approve', status_code=404)
+            self.patch_noun(self.archived_challenge, 'deny', status_code=404)
 
         with self.subTest('should not be able to edit an archived bid'):
             self.patch_detail(
@@ -496,8 +496,8 @@ class TestBidViewSet(TestBidBase, APITestCase):
                 data={'name': 'Archived Updated Again'},
                 status_code=403,
             )
-            self.patch_noun(self.archived_pending_bid, noun='approve', status_code=403)
-            self.patch_noun(self.archived_pending_bid, noun='deny', status_code=403)
+            self.patch_noun(self.archived_pending_bid, 'approve', status_code=403)
+            self.patch_noun(self.archived_pending_bid, 'deny', status_code=403)
 
         with self.subTest('should not be able to move to an archived event'):
             self.patch_detail(
@@ -512,10 +512,10 @@ class TestBidViewSet(TestBidBase, APITestCase):
             )
 
         with self.subTest('approve and deny without user options'):
-            self.patch_noun(self.closed_parent_bid, noun='approve', status_code=404)
-            self.patch_noun(self.closed_parent_bid, noun='deny', status_code=404)
-            self.patch_noun(self.closed_bid, noun='approve', status_code=404)
-            self.patch_noun(self.closed_bid, noun='deny', status_code=404)
+            self.patch_noun(self.closed_parent_bid, 'approve', status_code=404)
+            self.patch_noun(self.closed_parent_bid, 'deny', status_code=404)
+            self.patch_noun(self.closed_bid, 'approve', status_code=404)
+            self.patch_noun(self.closed_bid, 'deny', status_code=404)
 
         with self.subTest('anonymous'):
             self.patch_detail(
@@ -524,8 +524,8 @@ class TestBidViewSet(TestBidBase, APITestCase):
                 status_code=403,
                 user=None,
             )
-            self.patch_noun(self.opened_bid, noun='approve', status_code=403, user=None)
-            self.patch_noun(self.opened_bid, noun='deny', status_code=403, user=None)
+            self.patch_noun(self.opened_bid, 'approve', status_code=403, user=None)
+            self.patch_noun(self.opened_bid, 'deny', status_code=403, user=None)
 
 
 class TestBidSerializer(TestBidBase, APITestCase):

--- a/tests/apiv2/test_donations.py
+++ b/tests/apiv2/test_donations.py
@@ -173,14 +173,10 @@ class TestDonations(APITestCase):
         with self.saveSnapshot():
             with self.subTest('unprocess'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(
-                        donation, noun='unprocess', status_code=403, user=None
-                    )
-                    self.patch_noun(
-                        donation, noun='unprocess', status_code=403, user=user
-                    )
+                    self.patch_noun(donation, 'unprocess', status_code=403, user=None)
+                    self.patch_noun(donation, 'unprocess', status_code=403, user=user)
 
-                data = self.patch_noun(donation, noun='unprocess', user=self.add_user)
+                data = self.patch_noun(donation, 'unprocess', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'PENDING')
                 self.assertEqual(donation.readstate, 'PENDING')
@@ -188,15 +184,13 @@ class TestDonations(APITestCase):
             with self.subTest('approve comment'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
                     self.patch_noun(
-                        donation, noun='approve-comment', status_code=403, user=None
+                        donation, 'approve-comment', status_code=403, user=None
                     )
                     self.patch_noun(
-                        donation, noun='approve-comment', status_code=403, user=user
+                        donation, 'approve-comment', status_code=403, user=user
                     )
 
-                data = self.patch_noun(
-                    donation, noun='approve-comment', user=self.add_user
-                )
+                data = self.patch_noun(donation, 'approve-comment', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'APPROVED')
                 self.assertEqual(donation.readstate, 'IGNORED')
@@ -204,32 +198,30 @@ class TestDonations(APITestCase):
             with self.subTest('deny comment'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
                     self.patch_noun(
-                        donation, noun='deny-comment', status_code=403, user=None
+                        donation, 'deny-comment', status_code=403, user=None
                     )
                     self.patch_noun(
-                        donation, noun='deny-comment', status_code=403, user=user
+                        donation, 'deny-comment', status_code=403, user=user
                     )
 
-                data = self.patch_noun(
-                    donation, noun='deny-comment', user=self.add_user
-                )
+                data = self.patch_noun(donation, 'deny-comment', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'DENIED')
                 self.assertEqual(donation.readstate, 'IGNORED')
 
             with self.subTest('flag comment'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(donation, noun='flag', status_code=403, user=None)
-                    self.patch_noun(donation, noun='flag', status_code=403, user=user)
+                    self.patch_noun(donation, 'flag', status_code=403, user=None)
+                    self.patch_noun(donation, 'flag', status_code=403, user=user)
                     self.event.screening_mode = 'one_pass'
                     self.event.save()
                     self.patch_noun(
-                        donation, noun='flag', status_code=400, user=self.add_user
+                        donation, 'flag', status_code=400, user=self.add_user
                     )
 
                 self.event.screening_mode = 'two_pass'
                 self.event.save()
-                data = self.patch_noun(donation, noun='flag', user=self.add_user)
+                data = self.patch_noun(donation, 'flag', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'APPROVED')
                 self.assertEqual(donation.readstate, 'FLAGGED')
@@ -237,15 +229,15 @@ class TestDonations(APITestCase):
             with self.subTest('send to reader'), self.assertLogsChanges(2):
                 with self.suppressSnapshot(), self.subTest('error cases'):
                     self.patch_noun(
-                        donation, noun='send-to-reader', status_code=403, user=None
+                        donation, 'send-to-reader', status_code=403, user=None
                     )
                     self.patch_noun(
-                        donation, noun='send-to-reader', status_code=403, user=user
+                        donation, 'send-to-reader', status_code=403, user=user
                     )
                     # check permission if two-step screening is active
                     self.patch_noun(
                         donation,
-                        noun='send-to-reader',
+                        'send-to-reader',
                         status_code=403,
                         user=self.add_user,
                     )
@@ -256,9 +248,7 @@ class TestDonations(APITestCase):
                 # no special permission for one pass screening
                 self.event.screening_mode = 'one_pass'
                 self.event.save()
-                data = self.patch_noun(
-                    donation, noun='send-to-reader', user=self.add_user
-                )
+                data = self.patch_noun(donation, 'send-to-reader', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'APPROVED')
                 self.assertEqual(donation.readstate, 'READY')
@@ -272,62 +262,56 @@ class TestDonations(APITestCase):
                     Permission.objects.get(codename='send_to_reader')
                 )
                 self.add_user = User.objects.get(pk=self.add_user.pk)  # refresh perms
-                data = self.patch_noun(
-                    donation, noun='send-to-reader', user=self.add_user
-                )
+                data = self.patch_noun(donation, 'send-to-reader', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'APPROVED')
                 self.assertEqual(donation.readstate, 'READY')
 
             with self.subTest('pin'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(donation, noun='pin', status_code=403, user=None)
-                    self.patch_noun(donation, noun='pin', status_code=403, user=user)
+                    self.patch_noun(donation, 'pin', status_code=403, user=None)
+                    self.patch_noun(donation, 'pin', status_code=403, user=user)
 
-                data = self.patch_noun(donation, noun='pin', user=self.add_user)
+                data = self.patch_noun(donation, 'pin', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertTrue(donation.pinned)
 
             with self.subTest('unpin'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(donation, noun='unpin', status_code=403, user=None)
-                    self.patch_noun(donation, noun='unpin', status_code=403, user=user)
+                    self.patch_noun(donation, 'unpin', status_code=403, user=None)
+                    self.patch_noun(donation, 'unpin', status_code=403, user=user)
 
-                data = self.patch_noun(donation, noun='unpin', user=self.add_user)
+                data = self.patch_noun(donation, 'unpin', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertFalse(donation.pinned)
 
             with self.subTest('read'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(donation, noun='read', status_code=403, user=None)
-                    self.patch_noun(donation, noun='read', status_code=403, user=user)
+                    self.patch_noun(donation, 'read', status_code=403, user=None)
+                    self.patch_noun(donation, 'read', status_code=403, user=user)
 
-                data = self.patch_noun(donation, noun='read', user=self.add_user)
+                data = self.patch_noun(donation, 'read', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'APPROVED')
                 self.assertEqual(donation.readstate, 'READ')
 
             with self.subTest('ignore'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(donation, noun='ignore', status_code=403, user=None)
-                    self.patch_noun(donation, noun='ignore', status_code=403, user=user)
+                    self.patch_noun(donation, 'ignore', status_code=403, user=None)
+                    self.patch_noun(donation, 'ignore', status_code=403, user=user)
 
-                data = self.patch_noun(donation, noun='ignore', user=self.add_user)
+                data = self.patch_noun(donation, 'ignore', user=self.add_user)
                 self.assertV2ModelPresent(donation, data)
                 self.assertEqual(donation.commentstate, 'APPROVED')
                 self.assertEqual(donation.readstate, 'IGNORED')
 
             with self.subTest('comment'), self.assertLogsChanges(1):
                 with self.suppressSnapshot(), self.subTest('error cases'):
-                    self.patch_noun(
-                        donation, noun='comment', status_code=403, user=None
-                    )
-                    self.patch_noun(
-                        donation, noun='comment', status_code=403, user=user
-                    )
+                    self.patch_noun(donation, 'comment', status_code=403, user=None)
+                    self.patch_noun(donation, 'comment', status_code=403, user=user)
                     self.patch_noun(
                         donation,
-                        noun='comment',
+                        'comment',
                         status_code=400,
                         user=self.add_user,
                         expected_error_codes={'comment': 'required'},
@@ -335,7 +319,7 @@ class TestDonations(APITestCase):
 
                 data = self.patch_noun(
                     donation,
-                    noun='comment',
+                    'comment',
                     data={'comment': 'New comment.'},
                     user=self.add_user,
                 )
@@ -347,14 +331,14 @@ class TestDonations(APITestCase):
                     # can't add a new one without permission
                     self.patch_noun(
                         donation,
-                        noun='groups',
+                        'groups',
                         kwargs={'group': 'foo'},
                         status_code=400,
                     )
 
                 self.add_permission(self.add_user, codename='add_donationgroup')
 
-                data = self.patch_noun(donation, noun='groups', kwargs={'group': 'foo'})
+                data = self.patch_noun(donation, 'groups', kwargs={'group': 'foo'})
                 self.assertEqual(data, ['foo'])
                 self.assertEqual(donation.groups.count(), 1)
                 self.assertTrue(
@@ -363,10 +347,10 @@ class TestDonations(APITestCase):
 
                 with self.suppressSnapshot(), self.assertLogsChanges(0):
                     # no-op
-                    self.patch_noun(donation, noun='groups', kwargs={'group': 'foo'})
+                    self.patch_noun(donation, 'groups', kwargs={'group': 'foo'})
 
                 data = self.delete_noun(
-                    donation, noun='groups', kwargs={'group': 'foo'}, status_code=200
+                    donation, 'groups', kwargs={'group': 'foo'}, status_code=200
                 )
                 self.assertEqual(data, [])
                 self.assertEqual(donation.groups.count(), 0)
@@ -379,7 +363,7 @@ class TestDonations(APITestCase):
                     # no-op
                     self.delete_noun(
                         donation,
-                        noun='groups',
+                        'groups',
                         kwargs={'group': 'foo'},
                         status_code=200,
                     )

--- a/tests/apiv2/test_runs.py
+++ b/tests/apiv2/test_runs.py
@@ -518,7 +518,7 @@ class TestRunMove(TestSpeedRunBase, APITestCase):
         with self.assertLogsChanges(expected_logged_changes):
             data = self.patch_noun(
                 moving,
-                noun='move',
+                'move',
                 data=data,
                 expected_error_codes=expected_error_codes,
                 status_code=expected_status_code,

--- a/tracker/api/views/__init__.py
+++ b/tracker/api/views/__init__.py
@@ -8,8 +8,9 @@ from decimal import Decimal
 
 from django.db.models import Model
 from django.http import Http404
-from rest_framework import mixins, viewsets
-from rest_framework.exceptions import NotFound
+from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from rest_framework.relations import ManyRelatedField
 from rest_framework.renderers import BrowsableAPIRenderer
@@ -222,6 +223,29 @@ class TrackerCreateMixin(mixins.CreateModelMixin):
         super().perform_create(serializer)
         logutil.addition(self.request, serializer.instance)
 
+    @action(methods=['post'], detail=False, url_path='validate')
+    def validate_create(self, request, *args, **kwargs):
+        status_code = status.HTTP_202_ACCEPTED
+        if isinstance(request.data, dict):
+            data = request.data
+            self.get_serializer(data=request.data).is_valid(raise_exception=True)
+        elif isinstance(request.data, list):
+            data = {
+                'valid': [None] * len(request.data),
+                'invalid': [None] * len(request.data),
+            }
+            for n, i in enumerate(request.data):
+                try:
+                    self.get_serializer(data=i).is_valid(raise_exception=True)
+                except ValidationError as e:
+                    data['invalid'][n] = e.detail
+                    status_code = status.HTTP_400_BAD_REQUEST
+                else:
+                    data['valid'][n] = i
+        else:
+            raise ValidationError('data must be dict or list')
+        return Response(data, status=status_code)
+
 
 class EventCreateNestedMixin(EventNestedMixin, TrackerCreateMixin):
     pass
@@ -232,6 +256,14 @@ class TrackerUpdateMixin(mixins.UpdateModelMixin):
     def allowed_methods(self):
         # partial updates only
         return [m for m in super()._allowed_methods() if m != 'PUT']
+
+    @action(methods=['patch'], detail=True, url_path='validate')
+    def validate_update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+
+        return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
 
     def perform_update(self, serializer):
         old_values = {}


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

To assist in mass imports (e.g. when the schedule is ready to import), it'll be helpful to be able to validate chunks of data before sending them to the tracker.

The create validate endpoints can take a single object, and should act identically to a normal creation except it will not actually persist the model. You can also provide a list, and it will validate them each in isolation, and return the result in two keyed lists, matching the order they were provided in. This means that it cannot detect if two or more of the incoming objects would conflict with each other, but I decided that's too complex to try and account for. Maybe later.

The update validate endpoints are much like the single creation endpoint, it will ensure that whatever patch is provided on the object will still pass validation without actually persisting the change.

Both endpoints will return 202 if the payload was valid, or 400 if any part of the payload was invalid.

### Verification Process

Created a couple of test JSON payloads, both valid and invalid, and got the expected results.