### PR TITLE
Bug registration email domain

### DIFF
--- a/tracker/auth.py
+++ b/tracker/auth.py
@@ -1,6 +1,7 @@
 import post_office.mail
 import post_office.models
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.shortcuts import get_current_site
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
@@ -174,6 +175,7 @@ def send_registration_mail(
         context={
             **extra_context,
             'user': user,
+            'domain': get_current_site(request).domain,
             'confirmation_url': confirmation_url,
             'reset_url': reset_url,
             'password_reset_url': password_reset_url,

--- a/tracker/templatetags/donation_tags.py
+++ b/tracker/templatetags/donation_tags.py
@@ -190,19 +190,22 @@ def admin_url(obj):
     return viewutil.admin_url(obj)
 
 
-@register.simple_tag
+@register.simple_tag(takes_context=True)
 def standardform(
-    form, formid='formid', submittext='Submit', action=None, showrequired=True
+    context, form, formid='formid', submittext='Submit', action=None, showrequired=True
 ):
-    return template.loader.render_to_string(
-        'standardform.html',
+    context.push(
         {
             'form': form,
             'formid': formid,
             'submittext': submittext,
             'action': action,
             'showrequired': showrequired,
-        },
+        }
+    )
+    return template.loader.render_to_string(
+        'standardform.html',
+        context.flatten(),
     )
 
 

--- a/tracker/views/auth.py
+++ b/tracker/views/auth.py
@@ -5,6 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_protect
 
 import tracker.auth
 import tracker.forms as forms
@@ -20,18 +21,18 @@ from tracker import settings
 
 
 @never_cache
+@csrf_protect
 def register(request):
-    if request.method == 'POST':
-        form = forms.RegistrationForm(data=request.POST)
-        if form.is_valid():
-            form.save(
-                email_template=tracker.auth.default_registration_template(),
-                from_email=settings.TRACKER_REGISTRATION_FROM_EMAIL,
-                request=request,
-            )
-            return views_common.tracker_response(request, 'tracker/register_done.html')
-    else:
-        form = forms.RegistrationForm()
+    form = forms.RegistrationForm(
+        data=request.POST if request.method == 'POST' else None
+    )
+    if form.is_valid():
+        form.save(
+            email_template=tracker.auth.default_registration_template(),
+            from_email=settings.TRACKER_REGISTRATION_FROM_EMAIL,
+            request=request,
+        )
+        return views_common.tracker_response(request, 'tracker/register_done.html')
 
     return views_common.tracker_response(
         request, 'tracker/register.html', {'form': form}


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

I'm not sure how long this has been missing from the default registration flow but it's way past overdue fixing it.

Also, turns out #860 broke several forms because of not passing the request context along to the `standardform` tag, so they were missing the CSRF token, oops. Mattered if you weren't logged in yet.

### Verification Process

Did the registration flow and the email includes the site domain.