### PR TITLE
tqdm_groupby actually tracks the completion progress

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,4 +20,5 @@ msgpack==1.1.1
 responses~=0.25.7
 selenium==4.33.0
 tblib==3.1.0
+tqdm==4.67.1
 unittest-xml-reporting==3.2.0

--- a/tracker/util.py
+++ b/tracker/util.py
@@ -277,10 +277,12 @@ def tqdm_groupby(iterable: Iterable, *args, key, **kwargs):
             total = len(iterable) if isinstance(iterable, Sized) else None
             with tqdm(iterable, *args, total=total, **kwargs) as t:
                 for k, g in groupby(iterable, key):
-                    yield k, g
+                    g = list(g)
+                    yield k, (i for i in g)
                     if total is not None:
-                        t.update(len(list(g)))
+                        t.update(len(g))
         except ImportError:
             pass
 
-    yield from groupby(iterable, key)
+    else:
+        yield from groupby(iterable, key)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

While applying one of the new migrations I realized that the way that `tqdm_groupby` was losing the length information so that the progress bar never actually filled.

Also it was calling the iterable twice if tqdm was enabled, which is obviously not desirable for long running operations.

This addresses that.

### Verification Process

Added a test to assert the output and the tasks only get called once.