### PR TITLE
use Django template static tags in webpack templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,12 +529,7 @@ The following keys are considered boolean and will activate if any non-empty val
 - `ANALYZE` - activates [Webpack Bundle Analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer)
 - `SOURCE_MAPS` - activates source maps, defaults to on when running in dev mode
 
-Other variables that take string values:
-
-- `STATIC_ROOT` - defaults to `/static/gen`, i.e. `http://yourserver/static/gen`, if your static files are deployed at
-  a different path you'll need to override this
-
-Same with the following, except they only matter for development:
+Other variables that take string values, but only matter for development:
 
 - `TRACKER_API_HOST` - if you want to send `/tracker/api` requests to a different host, you can override this, will
   prefer this over `TRACKER_HOST`

--- a/tracker/templates/ui/index.html
+++ b/tracker/templates/ui/index.html
@@ -12,7 +12,8 @@
     {{ API_PREFETCH|json_script:'API_PREFETCH' }}
     <link rel="stylesheet" type="text/css" href="{% static 'main.css' %}"/>
 
-    <%= htmlWebpackPlugin.tags.headTags %>
+    <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %><script defer src="{% static '<%- file %>' %}"></script><% }); %>
+    <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %><link href="{% static '<%- file %>' %}" rel="stylesheet"><% }); %>
 
     <script type='text/javascript'>
       <!--

--- a/tracker/templates/ui/minimal.html
+++ b/tracker/templates/ui/minimal.html
@@ -9,7 +9,8 @@
     {{ app_name|json_script:'app_name' }}
     {{ CONSTANTS|json_script:'CONSTANTS' }}
 
-    <%= htmlWebpackPlugin.tags.headTags %>
+    <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %><script defer src="{% static '<%- file %>' %}"></script><% }); %>
+    <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %><link href="{% static '<%- file %>' %}" rel="stylesheet"><% }); %>
 
     <script type='text/javascript'>
       <!--

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,13 +18,18 @@ const SOURCE_MAPS = !!process.env.SOURCE_MAPS ?? false;
 const ANALYZE = !!process.env.ANALYZE ?? false;
 const NO_MANIFEST = !!process.env.NO_MANIFEST ?? false;
 const PROJECT_ROOT = __dirname;
-const STATIC_ROOT = process.env.STATIC_ROOT ?? '/static/gen';
 
 const BUNDLE_TO_TEMPLATE_MAP = {
   admin: PROJECT_ROOT + '/tracker/templates/ui/index.html',
   tracker: PROJECT_ROOT + '/tracker/templates/ui/index.html',
   processing: PROJECT_ROOT + '/tracker/templates/ui/minimal.html',
 };
+
+if (process.env.STATIC_ROOT) {
+  console.warn(
+    "STATIC_ROOT no longer needs to be passed to the build step, as the templates now use Django's built-in static tags.",
+  );
+}
 
 function generateHTMLWebpackPlugins() {
   return Object.entries(BUNDLE_TO_TEMPLATE_MAP).map(([bundle, template]) => {
@@ -50,7 +55,7 @@ module.exports = {
     filename: PROD ? 'tracker-[name]-[contenthash].js' : 'tracker-[name].js',
     pathinfo: true,
     path: PROJECT_ROOT + '/tracker/static/gen',
-    publicPath: STATIC_ROOT,
+    publicPath: 'gen',
   },
   stats: 'minimal',
   module: {


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Realized while toying with a deploy that it's possible to embed the Django `static` tag in a template produced by `html-webpack-plugin`. The syntax is a little gnarly but it results in, e.g.:

```
    <script defer src="{% static 'gen/tracker-processing.js' %}"></script>
    <link href="{% static 'gen/tracker-processing.css' %}" rel="stylesheet">
```

This matters because otherwise you have to know the final path for the static assets at build time and that's not very robust or reusable for, say, a Docker image. This means specifying `STATIC_PATH` when you run `yarn build` doesn't do anything any more, because it doesn't need to. 

### Verification Process

Works in dev mode, works in build mode (the generated tags will have the cache-busting hash in the filenames), works on the server. Works for me!