### PR TITLE
duplicate ipns are fine

### DIFF
--- a/tests/test_paypalutil.py
+++ b/tests/test_paypalutil.py
@@ -163,6 +163,23 @@ class TestIPNProcessing(APITestCase):
                 task, 'doe@example.com', dict(flag=True), transactionstate='FLAGGED'
             )
 
+    def test_flagged_duplicate(self, task):
+        donor = models.Donor.objects.create(
+            email='doe@example.com', paypalemail='doe@example.com'
+        )
+
+        self.assertDonation(
+            task, donor.paypalemail, {}, transactionstate='COMPLETED', donor=donor
+        )
+
+        with self.assertTrackerLogs(0):
+            self.assertDonation(
+                task,
+                'doe@example.com',
+                dict(flag=True, flag_info='Duplicate txn_id.'),
+                transactionstate='COMPLETED',
+            )
+
     def test_invalid_signature(self, task):
         custom = self.donation.paypal_signature.split(':', maxsplit=2)
         custom[2] = util.transpose(custom[2])

--- a/tracker/paypalutil.py
+++ b/tracker/paypalutil.py
@@ -370,6 +370,11 @@ def initialize_paypal_donation(sender, **kwargs):
 @receiver(invalid_ipn_received)
 def handle_ipn_error(*, sender, **kwargs):
     ipn = sender
+
+    # this is harmless
+    if 'Duplicate txn_id.' in ipn.flag_info:
+        return
+
     donation = get_ipn_donation(ipn)
 
     if donation is None:


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

PayPal has some built in retry logic with IPNs, if it thinks it was not received successfully for some reason. During SGDQ during periods of heavy load, PayPal would sometimes think that IPNs were not being received and would send them again, but unfortunately the existing IPN processing would then remove donations from the completed pool. After digging around a bit I've decided that a duplicate IPN can be safely ignored, though they are still logged and stored.

### Verification Process

Happened lots during SGDQ. Once I put this change on the server, donations no longer "disappeared".