### PR TITLE
fix some bugs with the schedule editor

### DIFF
--- a/bundles/admin/scheduleEditor/index.tsx
+++ b/bundles/admin/scheduleEditor/index.tsx
@@ -28,7 +28,7 @@ function Header({ timezone, title }: { timezone?: string; title?: string }) {
     [timezone],
   );
   const canViewRuns = usePermission('tracker.view_speedrun');
-  const colSpan = canViewRuns ? 8 : 7;
+  const colSpan = canViewRuns ? 9 : 8;
   return (
     <thead>
       {!sameTimezone && (
@@ -148,23 +148,31 @@ export default function ScheduleEditor() {
     }
     refetchPrizes();
   }, [canViewAds, refetchAds, refetchEvent, refetchInterviews, refetchPrizes, refetchRuns]);
+  const refreshInterstitials = React.useCallback(() => {
+    refetchInterviews();
+    if (canViewAds) {
+      refetchAds();
+    }
+  }, [canViewAds, refetchAds, refetchInterviews]);
 
   return (
-    <>
-      <div>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'calc(100vh - 190px)', // FIXME: hard coded because of the rest of the layout
+        overflow: 'hidden',
+      }}>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
         <button disabled={isFetching} onClick={refetch}>
           Refresh
         </button>
-      </div>
-      {canViewAds && (
-        <div>
+        {canViewAds && (
           <label>
             <input type="checkbox" checked={showAds} onChange={e => setShowAds(e.target.checked)} />
             Show Ads
           </label>
-        </div>
-      )}
-      <div>
+        )}
         <label>
           <input type="checkbox" checked={showInterviews} onChange={e => setShowInterviews(e.target.checked)} />
           Show Interviews
@@ -172,41 +180,48 @@ export default function ScheduleEditor() {
       </div>
       <APIErrorList errors={[runsError, eventError, interviewsError, adsError, prizesError]}>
         <Spinner spinning={isFetching} showPartial={(event && runs) != null}>
-          <table className="table table-striped table-condensed small">
-            <Header timezone={event?.timezone} title={event?.name} />
-            <tbody>
-              {orderedRuns.map((r, i, runs) => (
-                <React.Fragment key={r.id}>
-                  <RunRow run={r} prizeCount={prizeCount?.[r.id]} />
-                  {interstitials[r.id].map(i =>
-                    i.type === 'interview'
-                      ? showInterviews && <InterviewRow key={i.id} interview={i} />
-                      : showAds && <AdRow key={i.id} ad={i} />,
-                  )}
-                </React.Fragment>
-              ))}
-              {runs?.length ? (
-                canChangeRuns && (
-                  <LastSlotDropTarget elementType="tr" displayError={lastTargetError}>
-                    <td colSpan={colSpan} style={{ textAlign: 'center' }}>
-                      --The End--
+          <div style={{ overflow: 'scroll' }}>
+            <table className="table table-striped table-condensed small">
+              <Header timezone={event?.timezone} title={event?.name} />
+              <tbody>
+                {orderedRuns.map((r, i, runs) => (
+                  <React.Fragment key={r.id}>
+                    <RunRow
+                      run={r}
+                      interstitials={interstitials[r.id].some(i => i.anchor)}
+                      prizeCount={prizeCount?.[r.id]}
+                      refreshInterstitials={refreshInterstitials}
+                    />
+                    {interstitials[r.id].map(i =>
+                      i.type === 'interview'
+                        ? showInterviews && <InterviewRow key={i.id} interview={i} />
+                        : showAds && <AdRow key={i.id} ad={i} />,
+                    )}
+                  </React.Fragment>
+                ))}
+                {runs?.length ? (
+                  canChangeRuns && (
+                    <LastSlotDropTarget elementType="tr" displayError={lastTargetError}>
+                      <td colSpan={colSpan} style={{ textAlign: 'center' }}>
+                        --The End--
+                      </td>
+                    </LastSlotDropTarget>
+                  )
+                ) : (
+                  <tr>
+                    <td colSpan={colSpan} data-testid="empty-event">
+                      This event doesn&apos;t have any runs yet. {canChangeRuns && 'Add some!'}
                     </td>
-                  </LastSlotDropTarget>
-                )
-              ) : (
-                <tr>
-                  <td colSpan={colSpan} data-testid="empty-event">
-                    This event doesn&apos;t have any runs yet. {canChangeRuns && 'Add some!'}
-                  </td>
-                </tr>
-              )}
-              {unorderedRuns.map(r => (
-                <RunRow key={r.id} run={r} />
-              ))}
-            </tbody>
-          </table>
+                  </tr>
+                )}
+                {unorderedRuns.map(r => (
+                  <RunRow key={r.id} run={r} refreshInterstitials={refreshInterstitials} />
+                ))}
+              </tbody>
+            </table>
+          </div>
         </Spinner>
       </APIErrorList>
-    </>
+    </div>
   );
 }

--- a/spec/helpers/rtl.ts
+++ b/spec/helpers/rtl.ts
@@ -24,7 +24,10 @@ export async function waitForAPIErrors(
   }
 }
 
-export function getByChainedTestId(subject: ReturnType<typeof render>, ...ids: string[]) {
+export function getByChainedTestId<T extends HTMLElement = HTMLElement>(
+  subject: ReturnType<typeof render>,
+  ...ids: string[]
+): T {
   let element: ReturnType<typeof subject.getByTestId> | null = null;
   if (ids.length === 0) {
     throw new Error('must provide at least one id');
@@ -33,7 +36,7 @@ export function getByChainedTestId(subject: ReturnType<typeof render>, ...ids: s
     element = (element ? within(element) : subject).getByTestId(ids[0]);
     ids = ids.slice(1);
   }
-  return element!;
+  return element as T;
 }
 
 export function queryByChainedTestId(subject: ReturnType<typeof render>, ...ids: string[]) {

--- a/tests/apiv2/test_runs.py
+++ b/tests/apiv2/test_runs.py
@@ -457,6 +457,9 @@ class TestRunMove(TestSpeedRunBase, APITestCase):
         self.interview = models.Interview.objects.create(
             event=self.event, topic='Test Interview', anchor=self.run3, suborder=1
         )
+        self.other_interview = models.Interview.objects.create(
+            event=self.event, topic='Other Test Interview', anchor=self.run5, suborder=1
+        )
         self.ad = models.Ad.objects.create(
             event=self.event, ad_name='Test Ad', order=1, suborder=1
         )
@@ -538,6 +541,14 @@ class TestRunMove(TestSpeedRunBase, APITestCase):
                     self.assertEqual(
                         self.interview.order,
                         self.interview.anchor.order,
+                        'Interview order mismatch',
+                    )
+                self.other_interview.refresh_from_db()
+                if self.other_interview.anchor:
+                    self.other_interview.anchor.refresh_from_db()
+                    self.assertEqual(
+                        self.other_interview.order,
+                        self.other_interview.anchor.order,
                         'Interview order mismatch',
                     )
                 # TODO
@@ -649,6 +660,8 @@ class TestRunMove(TestSpeedRunBase, APITestCase):
         )
 
     def test_remove_last_run(self):
+        self.other_interview.anchor = None
+        self.other_interview.save()
         self.assertResults(self.run5, order=None, expected_change_count=1)
         self.assertRunsInOrder(
             [self.run1, self.run2, self.run3], [self.run5, self.run4]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ DATABASES = {
         'OPTIONS': {'timeout': 5},
     },
 }
-SILENCED_SYSTEM_CHECKS = ['models.W042']
+SILENCED_SYSTEM_CHECKS = ['models.W042', 'tracker.I118']
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(os.path.dirname(__file__), 'static')
 MEDIA_ROOT = os.path.join(os.path.dirname(__file__), 'media')

--- a/tracker/decorators.py
+++ b/tracker/decorators.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from django.http import HttpResponsePermanentRedirect
 
 
@@ -5,6 +7,7 @@ def strip_args(positional=0, keywords=None):
     keywords = keywords or []
 
     def _inner(view_func):
+        @wraps(view_func)
         def decorator(*args, **kwargs):
             return view_func(
                 *args[positional:],
@@ -17,6 +20,7 @@ def strip_args(positional=0, keywords=None):
 
 
 def no_querystring(view_func):
+    @wraps(view_func)
     def decorator(request, *args, **kwargs):
         if request.GET:
             return HttpResponsePermanentRedirect(request.path)


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

At SGDQ we discovered that dragging runs around didn't always work and I traced it to some issues with Interstitial state not being handled correctly during a move. This addresses that, and fixes some other issues with the schedule editor, mostly usability, but some functionality as well.

- interstitials are reloaded after a run is moved since the API does not currently return them in the payload and they may have moved
- anchored interstitials are temporarily cleared of order to so that move operations work
- changed the layout of the table so that dragging scrolls it in both directions
- runs that have prizes or anchored interstitials cannot be removed from the schedule (the API already disallowed this, so this was a display bug)

### Verification Process

Attached anchored Interstitials and Prizes to runs and verified that the schedule editor no longer allowed a drag, dragging on a tall schedule scrolls in both directions, most of this was live during SGDQ soon as we figured out the problem so it got battle tested pretty well.