### PR TITLE
add/fix several things about Total Watch

### DIFF
--- a/bundles/public/apiv2/reducers/sockets.ts
+++ b/bundles/public/apiv2/reducers/sockets.ts
@@ -35,7 +35,7 @@ const sockets: Record<string, SocketCallbacks> = {};
 
 function newSocket(url: string) {
   const socket = new SturdyWebSocket(url, {
-    shouldReconnect: ev => !ev.wasClean,
+    shouldReconnect: ev => (ev.wasClean ? true : new Promise(resolve => setTimeout(() => resolve(true), 16000))),
   });
   socket.addEventListener('message', async ev => await Promise.allSettled(sockets[url].callbacks.map(cb => cb(ev))));
   return socket;

--- a/bundles/public/apiv2/reducers/trackerApi.ts
+++ b/bundles/public/apiv2/reducers/trackerApi.ts
@@ -713,6 +713,7 @@ const socketEvents: TrackerQueryOnCacheEntryAdded<'events'> = async (args, api) 
         const event = events.find(e => e.id === data.donation.event);
         if (event) {
           event.donation_count = data.donation_count;
+          event.donation_total = data.event_total;
           event.amount = data.event_total;
         }
       });

--- a/bundles/public/apiv2/reducers/trackerApiSpec.ts
+++ b/bundles/public/apiv2/reducers/trackerApiSpec.ts
@@ -79,13 +79,14 @@ describe('trackerApi', () => {
         const message: ProcessingEvent = {
           type: 'donation_received',
           donation: getFixtureDonation({ id: 1, amount: 25 }),
-          event_total: oldData.amount! + 25,
+          event_total: oldData.donation_total! + 25,
           donation_count: oldData.donation_count! + 1,
           posted_at: DateTime.now().toISO()!,
         };
         server.emit('message', JSON.stringify(message));
         const newData = (await nextData('events', params))[0];
         expect(newData.amount).toBe(oldData.amount! + 25);
+        expect(newData.donation_total).toBe(oldData.donation_total! + 25);
         expect(newData.donation_count).toBe(oldData.donation_count! + 1);
       });
 


### PR DESCRIPTION
# Contributing to the Donation Tracker

- [X] I've added tests or modified existing tests for the change.
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Various bugs and features that cropped up during SGDQ consolidated down to one PR.

- both fields on Event totals are updated on socket event (previously only the deprecated `amount` field was)
- milestone/challenge bars use more correct ratio/sizing
- bids are properly sorted rather than being essentially random
- show domain/allocation ratios for incoming donations
- socket reconnect is more robust (this also affects Process/Read donations, and the status component there has been tweaked to account for this)

### Verification Process

These were all hotfixes during SGDQ, but I ran through the pages locally to ensure everything worked as expected.