### PR TITLE
fix various display bugs

### DIFF
--- a/bundles/processing/modules/processing/ProcessingDonationRow.tsx
+++ b/bundles/processing/modules/processing/ProcessingDonationRow.tsx
@@ -75,6 +75,7 @@ function ProcessingActions(props: ProcessingActionsProps) {
         variant="success"
         label={actionLabel}
         data-testid="action-send"
+        disabled={loading}
       />
       <MutationButton
         mutation={approve[0]}

--- a/bundles/processing/pages/ProcessDonations.tsx
+++ b/bundles/processing/pages/ProcessDonations.tsx
@@ -90,10 +90,10 @@ function Sidebar(props: SidebarProps) {
 
   // TODO: pull this logic out into a helper
   React.useEffect(() => {
-    if (event?.screening_mode !== 'two_pass') {
-      setProcessingMode('onestep');
-    } else if (event) {
-      if (
+    if (event) {
+      if (event.screening_mode !== 'two_pass') {
+        setProcessingMode('onestep');
+      } else if (
         (event.screening_mode === 'two_pass' && processingMode === 'onestep') ||
         (processingMode === 'confirm' && !canSelectModes)
       ) {

--- a/tracker/api/views/run.py
+++ b/tracker/api/views/run.py
@@ -157,7 +157,9 @@ class SpeedRunViewSet(
         try:
             with transaction.atomic():
                 # pessimistic, but this endpoint should not get hit very often, so it's probably ok
-                queryset.select_for_update()
+                # need to actually evaluate it, or it won't lock the rows
+                if not queryset.select_for_update().count():
+                    raise ValidationError('nonsense')
 
                 # - every run within the range will have its order field changed
                 # - if we cross an anchor boundary, every run between the new position and the next anchor

--- a/tracker/models/bid.py
+++ b/tracker/models/bid.py
@@ -609,16 +609,6 @@ class Bid(mptt.models.MPTTModel):
             self.total = options['total']
             self.count = options['count']
 
-    def full_label(self, addMoney=True):
-        result = [self.full_name]
-        if self.speedrun:
-            result = [self.speedrun.name_with_category, ' : '] + result
-        if addMoney:
-            result += [' $', '%0.2f' % self.total]
-            if self.goal:
-                result += [' / ', '%0.2f' % self.goal]
-        return ''.join(result)
-
     def __str__(self):
         parts = [f'{self.event} (Event)']
         if self.speedrun:

--- a/tracker/templates/admin/tracker/extra_actions.html
+++ b/tracker/templates/admin/tracker/extra_actions.html
@@ -17,11 +17,13 @@
           </tr>
         {% endif %}
         <tr>
-          <td><a href="{% url 'admin:tracker_automail_prize_accept_notifications' %}">Mail Prize Winner Accept Notifications</a></td>
+          <td><a href="{% url 'admin:tracker_automail_prize_accept_notifications' %}">Mail Prize Winner Accept
+            Notifications</a></td>
         </tr>
         {% if perms.tracker.view_donor %}
           <tr>
-            <td><a href="{% url 'admin:tracker_automail_prize_shipping_notifications' %}">Mail Prize Winner Shipping Notifications</a></td>
+            <td><a href="{% url 'admin:tracker_automail_prize_shipping_notifications' %}">Mail Prize Winner Shipping
+              Notifications</a></td>
           </tr>
         {% endif %}
       {% endif %}
@@ -38,7 +40,11 @@
       <td><a href="{% url 'admin:tracker_ui' extra='total_watch/' %}">Total Watch (EXPERIMENTAL)</a></td>
     </tr>
     <tr>
-      <td><a href="{% url 'admin:tracker_ui' extra='schedule_editor/' %}">View Schedule</a></td>
+      <td>
+        <a href="{% url 'admin:tracker_ui' extra='schedule_editor/' %}">
+          {% if perms.tracker.change_speedrun %}Schedule Editor{% else %}View Schedule{% endif %}
+        </a>
+      </td>
     </tr>
     {% if perms.tracker.view_bid %}
       <tr>

--- a/tracker/templates/tracker/donation.html
+++ b/tracker/templates/tracker/donation.html
@@ -59,10 +59,16 @@
                     <td>
                         {% if donation_bid.speedrun_id %}
                             <a href="{% url 'tracker:run' pk=donation_bid.speedrun_id %}">{{ donation_bid.speedrun.name_with_category }}</a>
+                        {% else %}
+                            &mdash;
                         {% endif %}
                     </td>
                     <td>
-                        <a href="{% url 'tracker:bid' pk=donation_bid.bid_id %}">{{ donation_bid.fullname }}</a>
+                        <!-- FIXME: recursive DB fetches -->
+                        <a href="{% url 'tracker:bid' pk=donation_bid.bid_id %}">
+                          {% if donation_bid.bid.parent %}{{ donation_bid.bid.parent.name }} &mdash;{% endif %}
+                          {{ donation_bid.bid.name }}
+                        </a>
                     </td>
                     <td>
                         {% money event donation_bid.amount %}


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [X] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Address a few mostly cosmetic issues:

- processing row doesn't dim buttons when action is taken
- processing doesn't remember regular/confirm mode
- schedule viewer/editor checks for permissions before displaying link
- donation shows its bid list correctly

### Verification Process

Visited the pages in question to validate that it was showing stuff correctly.

Processed some test donations on a simulated slow connection to verify that the buttons would disable properly after being clicked.