### PR TITLE
point Azure at main, not master

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ very helpful.
 This app shouldn't require any special treatment to deploy, though depending on which feature set you are using, extra
 steps will be required. You should be able to install it with pip, either from GitHub, or locally. e.g.
 
-`pip install git+https://github.com/GamesDoneQuick/donation-tracker.git@master`
+`pip install git+https://github.com/GamesDoneQuick/donation-tracker.git@main`
 
 Or after downloading or checking out locally:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 trigger:
-  - master
-  - gh-readonly-queue/master/*
+  - main
+  - gh-readonly-queue/main/*
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -100,7 +100,7 @@ jobs:
     condition: >
       not(
         or(
-          eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/main'),
           startsWith(variables['Build.SourceBranchName'], 'spike'),
           eq(variables['System.PullRequest.IsFork'], 'True')
         )


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Description of the Change

Recently moved the primary branch from `master` to `main` and forgot that Azure was still pointing at `master`. This fixes that, and one documentation reference to `master`.

### Verification Process

No code changes, just pipeline configuration.