### PR TITLE
Add donation group permissions to processors

### DIFF
--- a/tracker/admin/event.py
+++ b/tracker/admin/event.py
@@ -238,6 +238,9 @@ class EventAdmin(RelatedUserMixin, CustomModelAdmin):
                     'view_bid',
                     'view_donation',
                     'view_comments',
+                    # donation groups
+                    'add_donationgroup',
+                    'delete_donationgroup',
                     # bid assignment
                     'add_donationbid',
                     'change_donationbid',
@@ -273,6 +276,9 @@ class EventAdmin(RelatedUserMixin, CustomModelAdmin):
                     'view_comments',
                     'view_pending_donation',
                     'send_to_reader',
+                    # donation groups
+                    'add_donationgroup',
+                    'delete_donationgroup',
                     # donors
                     'add_donor',
                     'change_donor',


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

With the addition of donation groups being server side, new permissions are required for donation processors to access the functionality. Originally we weren't sure if we wanted all processors to have the capability to edit, so we had it as a manual add after importing, and forgot to revisit it.

The next time an import is run it will set the group permissions.

### Verification Process

Importing a test sheet sets the correct group permissions.