### PR TITLE
import from react-router-dom, not react-router

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,7 @@
       }
     ],
     "no-constant-condition": 2,
+    "no-duplicate-imports": 2,
     "no-eval": 2,
     "no-implied-eval": 2,
     "no-lonely-if": 2,

--- a/bundles/admin/app.js
+++ b/bundles/admin/app.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Outlet, Route, Routes } from 'react-router';
-import { BrowserRouter, Link } from 'react-router-dom';
+import { BrowserRouter, Link, Outlet, Route, Routes } from 'react-router-dom';
 
 import { useConstants } from '@common/Constants';
 import Loading from '@common/Loading';

--- a/bundles/admin/donationProcessing/processPendingBidsSpec.tsx
+++ b/bundles/admin/donationProcessing/processPendingBidsSpec.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { Provider } from 'react-redux';
-import { Route } from 'react-router';
-import { Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import { act, cleanup, render, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/bundles/admin/scheduleEditor/indexSpec.tsx
+++ b/bundles/admin/scheduleEditor/indexSpec.tsx
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Provider } from 'react-redux';
-import { Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 

--- a/bundles/processing/App.tsx
+++ b/bundles/processing/App.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { useConstants } from '@common/Constants';
 import { usePermission, useTrackerInit } from '@public/apiv2/hooks';

--- a/bundles/processing/pages/ProcessDonations.tsx
+++ b/bundles/processing/pages/ProcessDonations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { Button, Header, openModal, Stack } from '@faulty/gdq-design';
 
 import {

--- a/bundles/public/apiv2/hooks/index.ts
+++ b/bundles/public/apiv2/hooks/index.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { produce } from 'immer';
 import { ReactReduxContext, shallowEqual } from 'react-redux';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { useConstants } from '@common/Constants';

--- a/bundles/public/apiv2/hooks/indexSpec.tsx
+++ b/bundles/public/apiv2/hooks/indexSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { Provider } from 'react-redux';
-import { Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import { act, render } from '@testing-library/react';
 

--- a/bundles/tracker/App.tsx
+++ b/bundles/tracker/App.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useParams } from 'react-router-dom';
 
 import { useConstants } from '@common/Constants';
 import { useTrackerInit } from '@public/apiv2/hooks';

--- a/bundles/tracker/donation/__tests__/Donate.spec.tsx
+++ b/bundles/tracker/donation/__tests__/Donate.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { Provider } from 'react-redux';
-import { Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/bundles/tracker/donation/components/Donate.tsx
+++ b/bundles/tracker/donation/components/Donate.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallowEqual } from 'react-redux';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 import { useConstants } from '@common/Constants';
 import APIErrorList from '@public/APIErrorList';

--- a/bundles/tracker/prizes/components/PrizeCard.tsx
+++ b/bundles/tracker/prizes/components/PrizeCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import cn from 'classnames';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { useEventFromRoute, useRunsQuery, useSplitRuns } from '@public/apiv2/hooks';
 import { Prize } from '@public/apiv2/Models';

--- a/bundles/tracker/prizes/components/PrizeCardSpec.tsx
+++ b/bundles/tracker/prizes/components/PrizeCardSpec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import { fireEvent, render } from '@testing-library/react';
 

--- a/bundles/tracker/prizes/components/PrizeDetail.tsx
+++ b/bundles/tracker/prizes/components/PrizeDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { useConstants } from '@common/Constants';
 import APIErrorList from '@public/APIErrorList';

--- a/bundles/tracker/prizes/components/PrizeDetailSpec.tsx
+++ b/bundles/tracker/prizes/components/PrizeDetailSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { Provider } from 'react-redux';
-import { Route, Routes } from 'react-router';
+import { Route, Routes } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 

--- a/bundles/tracker/router/RouterUtils.ts
+++ b/bundles/tracker/router/RouterUtils.ts
@@ -1,5 +1,5 @@
 import queryString from 'query-string';
-import { NavigateOptions as NavOptions, useNavigate } from 'react-router';
+import { NavigateOptions as NavOptions, useNavigate } from 'react-router-dom';
 
 export const Routes = {
   EVENT_BASE: (eventId: string | number) => `/events/${eventId}`,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "react-markdown": "^8.0.6",
     "react-numeric": "^1.0.0",
     "react-redux": "^9.1.2",
-    "react-router": "^6.27.0",
     "react-router-dom": "^6.27.0",
     "react-transition-group": "^4.4.5",
     "redux": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5584,7 +5584,6 @@ __metadata:
     react-numeric: ^1.0.0
     react-redux: ^9.1.2
     react-refresh: ^0.14.0
-    react-router: ^6.27.0
     react-router-dom: ^6.27.0
     react-transition-group: ^4.4.5
     redux: ^4.2.1
@@ -10813,7 +10812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.27.0, react-router@npm:^6.27.0":
+"react-router@npm:6.27.0":
   version: 6.27.0
   resolution: "react-router@npm:6.27.0"
   dependencies:


### PR DESCRIPTION
# Contributing to the Donation Tracker

~- [ ] I've added tests or modified existing tests for the change.~
~- [ ] I've humanly end-to-end tested the change by running an instance of the tracker.~

### Description of the Change

While poking at some other stuff I noticed a note saying that we shouldn't be importing or relying directly on `react-router`, but rather just use `react-router-dom`. Effectively no code changes, since they're importing the same underlying objects.

### Verification Process

Spot checked a few pages and ran all the tests, since this -should- effectively be a no-op, just a bit cleaner arrangement.