### PR TITLE
[chore] Add Django 6.1 to test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
 
 jobs:
   - job: tracker_backend_tests
-    dependsOn: []
+    dependsOn: [ ]
     displayName: Tracker Backend
     strategy:
       matrix:
@@ -17,18 +17,21 @@ jobs:
         Django52:
           PYTHON_VERSION: '3.14'
           DJANGO_VERSION: '5.2'
+        Django60:
+          PYTHON_VERSION: '3.14'
+          DJANGO_VERSION: '6.0'
         Python3B:
           PYTHON_VERSION: '3.11'
           DJANGO_VERSION: '5.2'
         Python3C:
           PYTHON_VERSION: '3.12'
-          DJANGO_VERSION: '6.0'
+          DJANGO_VERSION: '6.1'
         Python3D:
           PYTHON_VERSION: '3.13'
-          DJANGO_VERSION: '6.0'
+          DJANGO_VERSION: '6.1'
         Latest:
           PYTHON_VERSION: '3.14'
-          DJANGO_VERSION: '6.0'
+          DJANGO_VERSION: '6.1'
 
     steps:
       - task: UsePythonVersion@0
@@ -164,7 +167,7 @@ jobs:
         displayName: 'Run pre-commit hooks'
 
   - job: tracker_frontend_tests
-    dependsOn: []
+    dependsOn: [ ]
     displayName: Tracker Frontend
     continueOnError: true
     variables:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ skip-string-normalization = 'True'
 [tool.isort]
 profile = 'black'
 [tool.setuptools.dynamic]
-version = { attr = "tracker.__version__"}
+version = { attr = "tracker.__version__" }
 [project]
 authors = [
   { name = 'Games Done Quick, LLC', email = 'tracker@gamesdonequick.com' },
@@ -29,7 +29,7 @@ dependencies = [
   'babel~=2.17.0',
   'celery~=5.0',
   'channels>=4.0',
-  'Django>=5.2,!=6.0,<6.1',
+  'Django>=5.2,!=6.0,<6.2',
   'django-ical~=1.7',
   'django-mptt~=0.10',
   'django-paypal~=1.1',


### PR DESCRIPTION
# Contributing to the Donation Tracker


~- [ ] I've added tests or modified existing tests for the change.~
- [X] I've humanly end-to-end tested the change by running an instance of the tracker.

### Description of the Change

Django 6.1 is out as of a week or two ago. This adds 6.1.x to the test matrix.

### Verification Process

TBD. Tests don't run because of an issue with DRF.